### PR TITLE
fix: build failed at 1.10.x version(#63)

### DIFF
--- a/example/simple/web/handler.go
+++ b/example/simple/web/handler.go
@@ -7,11 +7,17 @@ import (
 type Pet struct {
 	ID       int `json:"id" example:"1"`
 	Category struct {
-		ID   int    `json:"id" example:"1"`
-		Name string `json:"name" example:"category_name"`
+		ID            int      `json:"id" example:"1"`
+		Name          string   `json:"name" example:"category_name"`
+		PhotoUrls     []string `json:"photo_urls" example:"http://test/image/1.jpg,http://test/image/2.jpg"`
+		SmallCategory struct {
+			ID        int      `json:"id" example:"1"`
+			Name      string   `json:"name" example:"detail_category_name"`
+			PhotoUrls []string `json:"photo_urls" example:"http://test/image/1.jpg,http://test/image/2.jpg"`
+		} `json:"small_category"`
 	} `json:"category"`
 	Name      string   `json:"name" example:"poti"`
-	PhotoUrls []string `json:"photo_urls"`
+	PhotoUrls []string `json:"photo_urls" example:"http://test/image/1.jpg,http://test/image/2.jpg"`
 	Tags      []Tag    `json:"tags"`
 	Status    string   `json:"status"`
 	Price     float32  `json:"price" example:"3.25"`

--- a/parser_test.go
+++ b/parser_test.go
@@ -281,7 +281,50 @@ func TestParseSimpleApi(t *testing.T) {
             "type": "object",
             "properties": {
                 "category": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "example": 1
+                        },
+                        "name": {
+                            "type": "string",
+                            "example": "category_name"
+                        },
+                        "photo_urls": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "example": [
+                                "http://test/image/1.jpg",
+                                "http://test/image/2.jpg"
+                            ]
+                        },
+                        "small_category": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "integer",
+                                    "example": 1
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "example": "detail_category_name"
+                                },
+                                "photo_urls": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "example": [
+                                        "http://test/image/1.jpg",
+                                        "http://test/image/2.jpg"
+                                    ]
+                                }
+                            }
+                        }
+                    }
                 },
                 "id": {
                     "type": "integer",
@@ -299,7 +342,11 @@ func TestParseSimpleApi(t *testing.T) {
                     "type": "array",
                     "items": {
                         "type": "string"
-                    }
+                    },
+                    "example": [
+                        "http://test/image/1.jpg",
+                        "http://test/image/2.jpg"
+                    ]
                 },
                 "price": {
                     "type": "number",


### PR DESCRIPTION
Please merage #61 

OK
```console
2018/03/05 15:19:18 map[example/simple/api/api.go:0xc420476d00 example/simple/docs/docs.go:0xc420476e80 example/simple/main.go:0xc420477000 example/simple/web/handler.go:0xc420477280]
```

NG
```console
2018/03/05 15:19:16 map[example/simple/api/api.go:0xc420469d80 example/simple/main.go:0xc420469f00 example/simple/web/handler.go:0xc420442180]
--- FAIL: TestGetAllGoFileInfo (0.00s)
	assertions.go:238: 
			Error Trace:	parser_test.go:67
			Error:      	Not equal: 
			            	expected: 4
			            	actual  : 3
			Test:       	TestGetAllGoFileInfo
```

There was a difference of docs.go which made to ignore.
Because it fails depending on execution timing, I put static file is prepared.