### PR TITLE
fix: exclude all directory

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -727,7 +727,7 @@ func Skip(f os.FileInfo) error {
 	}
 
 	// exclude all hidden folder
-	if f.IsDir() && len(f.Name()) > 0 && f.Name()[0] == '.' {
+	if f.IsDir() && len(f.Name()) > 1 && f.Name()[0] == '.' {
 		return filepath.SkipDir
 	}
 	return nil


### PR DESCRIPTION
**Describe the PR**
Fix skip all directory.

**Relation issue**
none

**Additional context**
`searchDir` arguments of `getAllGoFileInfo` Function is './' .
Skip following directory, because this code.

```
if f.IsDir() && len(f.Name()) > 0 && f.Name()[0] == '.' {
	return filepath.SkipDir
}
```