### PR TITLE
Fixed missing type assertion verification

### DIFF
--- a/property.go
+++ b/property.go
@@ -85,7 +85,7 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 			if astTypeArrayExpr, ok := astTypeArray.Elt.(*ast.SelectorExpr); ok {
 				return parseFieldSelectorExpr(astTypeArrayExpr, parser, newArrayProperty)
 			}
-			if astTypeArrayIdent := astTypeArray.Elt.(*ast.Ident); ok {
+			if astTypeArrayIdent, ok := astTypeArray.Elt.(*ast.Ident); ok {
 				name := astTypeArrayIdent.Name
 				return propertyName{SchemaType: "array", ArrayType: name}
 			}
@@ -96,7 +96,7 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 			return parseFieldSelectorExpr(astTypeArrayExpr, parser, newArrayProperty)
 		}
 		if astTypeArrayExpr, ok := astTypeArray.Elt.(*ast.StarExpr); ok {
-			if astTypeArrayIdent := astTypeArrayExpr.X.(*ast.Ident); ok {
+			if astTypeArrayIdent, ok := astTypeArrayExpr.X.(*ast.Ident); ok {
 				name := astTypeArrayIdent.Name
 				return propertyName{SchemaType: "array", ArrayType: name}
 			}


### PR DESCRIPTION
Missing validation of the type assertion on arrays

**Describe the PR**
Fixed property type assertion verification resulted in a false positive ok which came from the top validation.

**Relation issue**
none

**Additional context**
Before this fix I was getting this panic exit, because the assertion was wrongly positive.
```
panic: interface conversion: ast.Expr is *ast.SelectorExpr, not *ast.Ident

goroutine 1 [running]:
github.com/swaggo/swag.getPropertyName(0xc42044dc80, 0xc4204bce40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/property.go:99 +0x12be
github.com/swaggo/swag.(*Parser).parseField(0xc4204bce40, 0xc42044dc80, 0xc420983ea0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:583 +0x4d
github.com/swaggo/swag.(*Parser).parseStruct(0xc4204bce40, 0xc420382628, 0x8, 0xc42044dc80, 0xc420504660)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:450 +0x77
github.com/swaggo/swag.(*Parser).parseTypeSpec(0xc4204bce40, 0xc420382628, 0x8, 0xc4202b70e0, 0xc420326c60)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:422 +0x24d
github.com/swaggo/swag.(*Parser).ParseDefinition(0xc4204bce40, 0xc420382628, 0x8, 0xc4202b70e0, 0xc420382630, 0x7)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:384 +0x1ac
github.com/swaggo/swag.parseFieldSelectorExpr(0xc42041fa20, 0xc4204bce40, 0x14cd108, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/property.go:55 +0x231
github.com/swaggo/swag.getPropertyName(0xc42035df00, 0xc4204bce40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/property.go:68 +0x119b
github.com/swaggo/swag.(*Parser).parseField(0xc4204bce40, 0xc42035df00, 0xc4209836c0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:583 +0x4d
github.com/swaggo/swag.(*Parser).parseStruct(0xc4204bce40, 0xc420482469, 0x4, 0xc42035df00, 0xc420326090)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:450 +0x77
github.com/swaggo/swag.(*Parser).parseTypeSpec(0xc4204bce40, 0xc420482469, 0x4, 0xc42035bad0, 0xc4201abc20)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:422 +0x24d
github.com/swaggo/swag.(*Parser).ParseDefinition(0xc4204bce40, 0xc420482469, 0x4, 0xc42035bad0, 0xc420382580, 0x8)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:384 +0x1ac
github.com/swaggo/swag.(*Parser).parseStruct(0xc4204bce40, 0xc420482469, 0x4, 0xc42035dd80, 0xc4201ab380)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:478 +0xb8a
github.com/swaggo/swag.(*Parser).parseTypeSpec(0xc4204bce40, 0xc420482469, 0x4, 0xc42035ba10, 0xc42026def0)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:422 +0x24d
github.com/swaggo/swag.(*Parser).ParseDefinition(0xc4204bce40, 0xc420482469, 0x4, 0xc42035ba10, 0xc420382494, 0x4)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:384 +0x1ac
github.com/swaggo/swag.(*Parser).ParseDefinitions(0xc4204bce40)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:348 +0xbd
github.com/swaggo/swag.(*Parser).ParseAPI(0xc4204bce40, 0x14b11a9, 0x2, 0x14b2389, 0x7)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/parser.go:88 +0x247
github.com/swaggo/swag/gen.(*Gen).Build(0xc42017f988, 0x14b11a9, 0x2, 0x14b2389, 0x7, 0x14b46c5, 0xe, 0x14b2d54, 0x9, 0x0, ...)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/gen/gen.go:29 +0x2a9
main.main.func1(0xc4200e2160, 0xc420127000, 0xc4200e2160)
	/Users/ricardomalta/go/src/github.com/swaggo/swag/cmd/swag/main.go:33 +0x190
github.com/urfave/cli.HandleAction(0x14184c0, 0x14cd2e0, 0xc4200e2160, 0x0, 0xc420127080)
	/Users/ricardomalta/go/src/github.com/urfave/cli/app.go:501 +0xc8
github.com/urfave/cli.Command.Run(0x14b17b6, 0x4, 0x0, 0x0, 0xc42044e390, 0x1, 0x1, 0x14b4743, 0xe, 0x0, ...)
	/Users/ricardomalta/go/src/github.com/urfave/cli/command.go:165 +0x47d
github.com/urfave/cli.(*App).Run(0xc420058000, 0xc4200b2000, 0x2, 0x2, 0x0, 0x0)
	/Users/ricardomalta/go/src/github.com/urfave/cli/app.go:259 +0x6e8
main.main()
	/Users/ricardomalta/go/src/github.com/swaggo/swag/cmd/swag/main.go:61 +0x4e2
exit status 2
```