### PR TITLE
minor fix to address referencing types in external, vendored pkgs #188

### DIFF
--- a/operation_test.go
+++ b/operation_test.go
@@ -597,6 +597,24 @@ func TestParseIdComment(t *testing.T) {
 	assert.Equal(t, "myOperationId", operation.ID)
 }
 
+func TestFindTypeDefCoreLib(t *testing.T) {
+	spec, err := findTypeDef("net/http", "Request")
+	assert.NoError(t, err)
+	assert.NotNil(t, spec)
+}
+
+func TestFindTypeDefExternalPkg(t *testing.T) {
+	spec, err := findTypeDef("github.com/stretchr/testify/assert", "Assertions")
+	assert.NoError(t, err)
+	assert.NotNil(t, spec)
+}
+
+func TestFindTypeDefInvalidPkg(t *testing.T) {
+	spec, err := findTypeDef("does-not-exist", "foo")
+	assert.Error(t, err)
+	assert.Nil(t, spec)
+}
+
 func TestParseSecurityComment(t *testing.T) {
 	comment := `@Security OAuth2Implicit[read, write]`
 	operation := NewOperation()


### PR DESCRIPTION
**Describe the PR**
If the pkg referenced in `importPath` is actually a package that is vendored, use the "full path" for the `program.Package(..)` call. Calling on `program.Package(originalmportPath)` will cause the return pkg to be nil, even though the `.Load(..)` succeeded.

**Relation issue**
#188 

**Additional context**
I added some extra new lines during debugging - sorry! Looking at it now, I suppose the map iteration can happen after initial `program.Package(..)` call fails.. but that may be a overkill.
