### PR TITLE
remove panic in favor of printed warning

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -445,11 +445,11 @@ func (parser *Parser) parseTypeSpec(pkgName string, typeSpec *ast.TypeSpec, prop
 		}
 
 	case *ast.ArrayType:
-		log.Panic("ParseDefinitions not supported 'Array' yet.")
+		log.Print("ParseDefinitions not supported 'Array' yet.")
 	case *ast.InterfaceType:
-		log.Panic("ParseDefinitions not supported 'Interface' yet.")
+		log.Print("ParseDefinitions not supported 'Interface' yet.")
 	case *ast.MapType:
-		log.Panic("ParseDefinitions not supported 'Map' yet.")
+		log.Print("ParseDefinitions not supported 'Map' yet.")
 	}
 }
 

--- a/parser.go
+++ b/parser.go
@@ -445,11 +445,11 @@ func (parser *Parser) parseTypeSpec(pkgName string, typeSpec *ast.TypeSpec, prop
 		}
 
 	case *ast.ArrayType:
-		log.Print("ParseDefinitions not supported 'Array' yet.")
+		log.Println("ParseDefinitions not supported 'Array' yet.")
 	case *ast.InterfaceType:
-		log.Print("ParseDefinitions not supported 'Interface' yet.")
+		log.Println("ParseDefinitions not supported 'Interface' yet.")
 	case *ast.MapType:
-		log.Print("ParseDefinitions not supported 'Map' yet.")
+		log.Println("ParseDefinitions not supported 'Map' yet.")
 	}
 }
 


### PR DESCRIPTION
**Describe the PR**
sorry wasn't able to implement the method. This just removes the panic from parseTypeSpec.

**Relation issue**
https://github.com/swaggo/swag/issues/207