### PR TITLE
fix: missing schema convert

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -347,7 +347,7 @@ func (parser *Parser) ParseType(astFile *ast.File) {
 					typeName := fmt.Sprintf("%v", typeSpec.Type)
 					// check if its a custom primitive type
 					if IsGolangPrimitiveType(typeName) {
-						parser.CustomPrimitiveTypes[typeSpec.Name.String()] = typeName
+						parser.CustomPrimitiveTypes[typeSpec.Name.String()] = TransToValidSchemeType(typeName)
 					} else {
 						parser.TypeDefinitions[astFile.Name.String()][typeSpec.Name.String()] = typeSpec
 					}


### PR DESCRIPTION
**Describe the PR**
fix missing schema convert

ex:

```
type Gender int32

type User struct {
	Name string
	Sex  Gender
}
```

the generated doc should be `sex integer` but not `sex int32`
