### PR TITLE
Router path now supports plus sign

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -386,7 +386,7 @@ func (operation *Operation) ParseProduceComment(commentLine string) error {
 
 // ParseRouterComment parses comment for gived `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string) error {
-	re := regexp.MustCompile(`([\w\.\/\-{}]+)[^\[]+\[([^\]]+)`)
+	re := regexp.MustCompile(`([\w\.\/\-{}\+]+)[^\[]+\[([^\]]+)`)
 	var matches []string
 
 	if matches = re.FindStringSubmatch(commentLine); len(matches) != 3 {

--- a/operation_test.go
+++ b/operation_test.go
@@ -105,6 +105,15 @@ func TestParseRouterComment(t *testing.T) {
 	assert.Equal(t, "GET", operation.HTTPMethod)
 }
 
+func TestParseRouterCommentWithPlusSign(t *testing.T) {
+	comment := `/@Router /customer/get-wishlist/{proxy+} [post]`
+	operation := NewOperation()
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "/customer/get-wishlist/{proxy+}", operation.Path)
+	assert.Equal(t, "POST", operation.HTTPMethod)
+}
+
 func TestParseRouterCommentOccursErr(t *testing.T) {
 	comment := `/@Router /customer/get-wishlist/{wishlist_id}`
 	operation := NewOperation()


### PR DESCRIPTION


**Describe the PR**
Added support for the `+` sign in Router path param. 

**Relation issue**
Didn't raise an issue, but asked on StackOverflow if there was a way of doing this prior to the PR
https://stackoverflow.com/questions/52515452/how-to-set-escape-proxy-as-a-path-with-gin-and-swagger

**Additional context**
I wanted to generate swagger containing the plus sign, like so:

```
"/exampleapp/proxy/{proxy+}": {
            "get": {
                "produces": [
                    "application/json"
                ],
                "summary": "GET proxied request"
            }
        }
```

However, due to the regex the RouterParser uses, it was being dropped, so I ended up with:

```
"/exampleapp/proxy/{proxy": {
            "get": {
                "produces": [
                    "application/json"
                ],
                "summary": "GET proxied request"
            }
        }
```

AWS API  Gateway parses swagger files, and in order to enable proxying of requests you must:
`Create a proxy resource with a greedy path variable of {proxy+}`, so this change allows me to generate a valid swagger for that scenario

See: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-proxy-resource?icmpid=docs_apigateway_console 