### PR TITLE
Translate array type into a valid swagger type

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -551,6 +551,12 @@ func TestParseSimpleApi(t *testing.T) {
                     "format": "int64",
                     "example": 1
                 },
+                "int_array": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
                 "is_alive": {
                     "type": "boolean",
                     "example": true

--- a/property.go
+++ b/property.go
@@ -96,7 +96,7 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 				return parseFieldSelectorExpr(astTypeArrayExpr, parser, newArrayProperty)
 			}
 			if astTypeArrayIdent, ok := astTypeArray.Elt.(*ast.Ident); ok {
-				name := astTypeArrayIdent.Name
+				name := TransToValidSchemeType(astTypeArrayIdent.Name)
 				return propertyName{SchemaType: "array", ArrayType: name}
 			}
 		}
@@ -107,11 +107,11 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 		}
 		if astTypeArrayExpr, ok := astTypeArray.Elt.(*ast.StarExpr); ok {
 			if astTypeArrayIdent, ok := astTypeArrayExpr.X.(*ast.Ident); ok {
-				name := astTypeArrayIdent.Name
+				name := TransToValidSchemeType(astTypeArrayIdent.Name)
 				return propertyName{SchemaType: "array", ArrayType: name}
 			}
 		}
-		itemTypeName := fmt.Sprintf("%s", astTypeArray.Elt)
+		itemTypeName := TransToValidSchemeType(fmt.Sprintf("%s", astTypeArray.Elt))
 		if actualPrimitiveType, isCustomType := parser.CustomPrimitiveTypes[itemTypeName]; isCustomType {
 			itemTypeName = actualPrimitiveType
 		}

--- a/testdata/simple/web/handler.go
+++ b/testdata/simple/web/handler.go
@@ -32,6 +32,7 @@ type Pet struct {
 	Hidden    string          `json:"-"`
 	UUID      uuid.UUID       `json:"uuid"`
 	Decimal   decimal.Decimal `json:"decimal"`
+	IntArray  []int           `json:"int_array"`
 }
 
 type Tag struct {


### PR DESCRIPTION
First of all, thank you very much for the wonderful project :+1: 

Now to the issue. Previously, the following structure:

    type Foo struct {
        Bar []int
    }

would generate this swagger spec:

    ...
    Bar:
      items:
        type: int
    ...

`int`, however, is not a valid swagger type. It is inserted because array types are not processed by the translation function. This commit applies the type translation function to all the places where array types are used.
