### PR TITLE
Add support for the attributes in struct fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,16 @@ Make it AND condition
 // @Param default query string false "string default" default(A)
 ```
 
+It also works for the struct fields:
+
+```go
+type Foo struct {
+    Bar string `minLength:"4" maxLength:"16"`
+    Baz int `minimum:"10" maximum:"20" default:"15"`
+    Qux []string `enums:"foo,bar,baz"`
+}
+```
+
 ### Available
 
 Field Name | Type | Description

--- a/parser_test.go
+++ b/parser_test.go
@@ -524,6 +524,8 @@ func TestParseSimpleApi(t *testing.T) {
                                 },
                                 "name": {
                                     "type": "string",
+                                    "maxLength": 16,
+                                    "minLength": 4,
                                     "example": "detail_category_name"
                                 },
                                 "photo_urls": {
@@ -546,6 +548,19 @@ func TestParseSimpleApi(t *testing.T) {
                 "decimal": {
                     "type": "number"
                 },
+                "enum_array": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer",
+                        "enum": [
+                            1,
+                            2,
+                            3,
+                            5,
+                            7
+                        ]
+                    }
+                },
                 "id": {
                     "type": "integer",
                     "format": "int64",
@@ -563,6 +578,7 @@ func TestParseSimpleApi(t *testing.T) {
                 },
                 "is_alive": {
                     "type": "boolean",
+                    "default": true,
                     "example": true
                 },
                 "name": {
@@ -593,10 +609,16 @@ func TestParseSimpleApi(t *testing.T) {
                 },
                 "price": {
                     "type": "number",
+                    "maximum": 1000,
+                    "minimum": 1,
                     "example": 3.25
                 },
                 "status": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "healthy",
+                        "ill"
+                    ]
                 },
                 "tags": {
                     "type": "array",

--- a/schema.go
+++ b/schema.go
@@ -19,6 +19,11 @@ func IsPrimitiveType(typeName string) bool {
 	}
 }
 
+// IsNumericType determines whether the swagger type name is a numeric type
+func IsNumericType(typeName string) bool {
+	return typeName == "integer" || typeName == "number"
+}
+
 // TransToValidSchemeType indicates type will transfer golang basic type to swagger supported type.
 func TransToValidSchemeType(typeName string) string {
 	switch typeName {

--- a/testdata/simple/web/handler.go
+++ b/testdata/simple/web/handler.go
@@ -16,7 +16,7 @@ type Pet struct {
 		PhotoUrls     []string `json:"photo_urls" example:"http://test/image/1.jpg,http://test/image/2.jpg" format:"url"`
 		SmallCategory struct {
 			ID        int      `json:"id" example:"1"`
-			Name      string   `json:"name" example:"detail_category_name" binding:"required"`
+			Name      string   `json:"name" example:"detail_category_name" binding:"required" minLength:"4" maxLength:"16"`
 			PhotoUrls []string `json:"photo_urls" example:"http://test/image/1.jpg,http://test/image/2.jpg"`
 		} `json:"small_category"`
 	} `json:"category"`
@@ -25,14 +25,15 @@ type Pet struct {
 	Tags      []Tag           `json:"tags"`
 	Pets      *[]Pet2         `json:"pets"`
 	Pets2     []*Pet2         `json:"pets2"`
-	Status    string          `json:"status"`
-	Price     float32         `json:"price" example:"3.25"`
-	IsAlive   bool            `json:"is_alive" example:"true"`
+	Status    string          `json:"status" enums:"healthy,ill"`
+	Price     float32         `json:"price" example:"3.25" minimum:"1.0" maximum:"1000"`
+	IsAlive   bool            `json:"is_alive" example:"true" default:"true"`
 	Data      interface{}     `json:"data"`
 	Hidden    string          `json:"-"`
 	UUID      uuid.UUID       `json:"uuid"`
 	Decimal   decimal.Decimal `json:"decimal"`
 	IntArray  []int           `json:"int_array" example:"1,2"`
+	EnumArray []int           `json:"enum_array" enums:"1,2,3,5,7"`
 }
 
 type Tag struct {


### PR DESCRIPTION
This commit adds support for the following attributes in the struct fields:

- `minimum`, for numeric fields, via `minimum:"value"` struct tag
- `maximum`, for numeric fields, via `maximum:"value"` struct tag
- `minLength`, for string fields, via `minLength:"value"` struct tag
- `maxLength`, for string fields, via `maxLength:"value"` struct tag
- `enums`, via `enums:"value1,value2,value3"` struct tag
- `default`, via `default:"value"` struct tag

All these tags except `default` are also supported in array fields.