### PR TITLE
Add support for map and struct pointer types and selector in array pointer

### DIFF
--- a/property.go
+++ b/property.go
@@ -86,6 +86,14 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 		if astTypeSelectorExpr, ok := ptr.X.(*ast.SelectorExpr); ok {
 			return parseFieldSelectorExpr(astTypeSelectorExpr, parser, newProperty)
 		}
+		// TODO support custom pointer type?
+		if _, ok := ptr.X.(*ast.MapType); ok { // if map
+			//TODO support map
+			return propertyName{SchemaType: "object", ArrayType: "object"}
+		}
+		if _, ok := ptr.X.(*ast.StructType); ok { // if struct
+			return propertyName{SchemaType: "object", ArrayType: "object"}
+		}
 		if astTypeIdent, ok := ptr.X.(*ast.Ident); ok {
 			name := astTypeIdent.Name
 			schemeType := TransToValidSchemeType(name)

--- a/property.go
+++ b/property.go
@@ -114,6 +114,9 @@ func getPropertyName(field *ast.Field, parser *Parser) propertyName {
 			return parseFieldSelectorExpr(astTypeArrayExpr, parser, newArrayProperty)
 		}
 		if astTypeArrayExpr, ok := astTypeArray.Elt.(*ast.StarExpr); ok {
+			if astTypeArraySel, ok := astTypeArrayExpr.X.(*ast.SelectorExpr); ok {
+				return parseFieldSelectorExpr(astTypeArraySel, parser, newArrayProperty)
+			}
 			if astTypeArrayIdent, ok := astTypeArrayExpr.X.(*ast.Ident); ok {
 				name := TransToValidSchemeType(astTypeArrayIdent.Name)
 				return propertyName{SchemaType: "array", ArrayType: name}

--- a/property_test.go
+++ b/property_test.go
@@ -141,6 +141,33 @@ func TestGetPropertyNameStarExprIdent(t *testing.T) {
 	assert.Equal(t, expected, getPropertyName(input, New()))
 }
 
+func TestGetPropertyNameStarExprMap(t *testing.T) {
+	input := &ast.Field{
+		Type: &ast.StarExpr{
+			Star: 1026,
+			X: &ast.MapType{
+				Map: 1027,
+				Key: &ast.Ident{
+					NamePos: 1034,
+					Name:    "string",
+					Obj:     (*ast.Object)(nil),
+				},
+				Value: &ast.Ident{
+					NamePos: 1041,
+					Name:    "string",
+					Obj:     (*ast.Object)(nil),
+				},
+			},
+		},
+	}
+	expected := propertyName{
+		"object",
+		"object",
+		"",
+	}
+	assert.Equal(t, expected, getPropertyName(input, New()))
+}
+
 func TestGetPropertyNameArrayStarExpr(t *testing.T) {
 	input := &ast.Field{
 		Type: &ast.ArrayType{

--- a/property_test.go
+++ b/property_test.go
@@ -190,6 +190,35 @@ func TestGetPropertyNameArrayStarExpr(t *testing.T) {
 	assert.Equal(t, expected, getPropertyName(input, New()))
 }
 
+func TestGetPropertyNameArrayStarExprSelector(t *testing.T) {
+	input := &ast.Field{
+		Type: &ast.ArrayType{
+			Lbrack: 1111,
+			Len:    nil,
+			Elt: &ast.StarExpr{
+				X: &ast.SelectorExpr{
+					X: &ast.Ident{
+						NamePos: 1136,
+						Name:    "hoge",
+						Obj:     (*ast.Object)(nil),
+					},
+					Sel: &ast.Ident{
+						NamePos: 1141,
+						Name:    "ObjectId",
+						Obj:     (*ast.Object)(nil),
+					},
+				},
+			},
+		},
+	}
+	expected := propertyName{
+		"array",
+		"string",
+		"",
+	}
+	assert.Equal(t, expected, getPropertyName(input, New()))
+}
+
 func TestGetPropertyNameMap(t *testing.T) {
 	input := &ast.Field{
 		Type: &ast.MapType{


### PR DESCRIPTION
Add support for map and struct pointer types. 
Add support for selector expression in array pointer type 
Should address #221.
