### PR TITLE
Prevent cmd/swag/main.go from being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-swag
 testdata/simple/docs
 cover.out
 


### PR DESCRIPTION
**Describe the PR**
.gitignore was ignoring a file from the project `cmd/swag/main.go`