### PR TITLE
fix bug for required properties inherited from anonymous field.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -681,6 +681,21 @@ func TestParseSimpleApi(t *testing.T) {
                 }
             }
         },
+        "web.Pet5": {
+            "type": "object",
+            "required": [
+                "name",
+                "odd"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "odd": {
+                    "type": "boolean"
+                }
+            }
+        },
         "web.RevValue": {
             "type": "object",
             "properties": {

--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -92,3 +92,8 @@ func AnonymousStructArray() {
 type Pet3 struct {
 	ID int `json:"id"`
 }
+
+// @Success 200 {object} web.Pet5 "ok"
+func GetPet5() {
+
+}

--- a/testdata/simple/web/handler.go
+++ b/testdata/simple/web/handler.go
@@ -78,3 +78,12 @@ type RevValue struct {
 	Cross   cross.Cross   `json:"cross"`
 	Crosses []cross.Cross `json:"crosses"`
 }
+
+type Pet4 struct {
+	Name string `json:"name" binding:"required"`
+}
+
+type Pet5 struct {
+	*Pet4
+	Odd bool `json:"odd" binding:"required"`
+}


### PR DESCRIPTION
**Describe the PR**
this fixes a bug introduced in https://github.com/swaggo/swag/commit/a2ee966466be717ea86abf7e3d0cd1fe23b6fa46

**Additional context**
The `required` for the `name` property was being dropped for anonymous fields (see `web.Pet5` that I added to the test case).
