### PR TITLE
Fix docs. Title, Description reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ import (
 func main() {
 
 	// programatically set swagger info
-	docs.Title = "Swagger Example API"
-	docs.Description = "This is a sample server Petstore server."
+	docs.SwaggerInfo.Title = "Swagger Example API"
+	docs.SwaggerInfo.Description = "This is a sample server Petstore server."
 	docs.SwaggerInfo.Version = "1.0"
 	docs.SwaggerInfo.Host = "petstore.swagger.io"
 	docs.SwaggerInfo.BasePath = "/v2"


### PR DESCRIPTION
**Describe the PR**
Fix README.md example when referencing docs.Title and docs.Description
