### PR TITLE
Add link to buffalo-swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $ swag init
 
 - [gin](http://github.com/swaggo/gin-swagger)
 - [echo](http://github.com/swaggo/echo-swagger)
+- [buffalo](https://github.com/swaggo/buffalo-swagger)
 - [net/http](https://github.com/swaggo/http-swagger)
 
 ## How to use it with Gin


### PR DESCRIPTION
Add a link to [buffalo-swagger](https://github.com/swaggo/buffalo-swagger) in the README
Fixes #214 
