### PR TITLE
add filename info when panic

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -92,8 +92,8 @@ func (parser *Parser) ParseAPI(searchDir string, mainAPIFile string) error {
 		parser.ParseType(astFile)
 	}
 
-	for _, astFile := range parser.files {
-		parser.ParseRouterAPIInfo(astFile)
+	for fileName, astFile := range parser.files {
+		parser.ParseRouterAPIInfo(fileName, astFile)
 	}
 
 	parser.ParseDefinitions()
@@ -331,7 +331,7 @@ func GetSchemes(commentLine string) []string {
 }
 
 // ParseRouterAPIInfo parses router api info for given astFile
-func (parser *Parser) ParseRouterAPIInfo(astFile *ast.File) {
+func (parser *Parser) ParseRouterAPIInfo(fileName string, astFile *ast.File) {
 	for _, astDescription := range astFile.Decls {
 		switch astDeclaration := astDescription.(type) {
 		case *ast.FuncDecl:
@@ -340,7 +340,7 @@ func (parser *Parser) ParseRouterAPIInfo(astFile *ast.File) {
 				operation.parser = parser
 				for _, comment := range astDeclaration.Doc.List {
 					if err := operation.ParseComment(comment.Text, astFile); err != nil {
-						log.Panicf("ParseComment panic:%+v", err)
+						log.Panicf("ParseComment panic in file %s :%+v", fileName, err)
 					}
 				}
 				var pathItem spec.PathItem

--- a/parser_test.go
+++ b/parser_test.go
@@ -2114,7 +2114,7 @@ func Test(){
 
 	p := New()
 	assert.Panics(t, func() {
-		p.ParseRouterAPIInfo(f)
+		p.ParseRouterAPIInfo("", f)
 	})
 }
 
@@ -2131,7 +2131,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2154,7 +2154,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2177,7 +2177,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2200,7 +2200,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2223,7 +2223,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2246,7 +2246,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2269,7 +2269,7 @@ func Test(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 
@@ -2300,7 +2300,7 @@ func Test3(){
 		panic(err)
 	}
 	p := New()
-	p.ParseRouterAPIInfo(f)
+	p.ParseRouterAPIInfo("", f)
 
 	ps := p.swagger.Paths.Paths
 


### PR DESCRIPTION
**Describe the PR**
show the file name when ParseRouterAPIInfo panic

**Relation issue**
no issue

**Additional context**
When I use this tool. My project has many file in one package. 
So add File name in panic can hep use to found where has wrong more quickly
