### PR TITLE
Multiline description for api info

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,16 @@ Field Name | Type | Description
 
 ## TIPS
 
+### Descriptions over multiple lines
+
+You can add descriptions spanning multiple lines in either the general api description or routes definitions like so: 
+
+```go
+// @description This is the first line
+// @description This is the second line
+// @description And so forth.
+```
+
 ### User defined structure with an array type
 
 ```go

--- a/operation.go
+++ b/operation.go
@@ -53,7 +53,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 		if operation.Description == "" {
 			operation.Description = lineRemainder
 		} else {
-			operation.Description += "<br>" + lineRemainder
+			operation.Description += "\n" + lineRemainder
 		}
 	case "@summary":
 		operation.Summary = lineRemainder

--- a/operation_test.go
+++ b/operation_test.go
@@ -662,6 +662,6 @@ func TestParseMultiDescription(t *testing.T) {
 
 	b, _ := json.MarshalIndent(operation, "", "    ")
 
-	expected := `"description": "line one\u003cbr\u003eline two x"`
+	expected := `"description": "line one\nline two x"`
 	assert.Contains(t, string(b), expected)
 }

--- a/parser.go
+++ b/parser.go
@@ -130,7 +130,11 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 				case "@title":
 					parser.swagger.Info.Title = strings.TrimSpace(commentLine[len(attribute):])
 				case "@description":
-					parser.swagger.Info.Description = strings.TrimSpace(commentLine[len(attribute):])
+					if parser.swagger.Info.Description == "{{.Description}}" {
+						parser.swagger.Info.Description = strings.TrimSpace(commentLine[len(attribute):])
+					} else {
+						parser.swagger.Info.Description += "\n" + strings.TrimSpace(commentLine[len(attribute):])
+					}
 				case "@termsofservice":
 					parser.swagger.Info.TermsOfService = strings.TrimSpace(commentLine[len(attribute):])
 				case "@contact.name":

--- a/parser_test.go
+++ b/parser_test.go
@@ -21,7 +21,7 @@ func TestParser_ParseGeneralApiInfo(t *testing.T) {
 	expected := `{
     "swagger": "2.0",
     "info": {
-        "description": "This is a sample server Petstore server.",
+        "description": "This is a sample server Petstore server.\nIt has a lot of beatiful features.",
         "title": "Swagger Example API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -3,6 +3,7 @@ package main
 // @title Swagger Example API
 // @version 1.0
 // @description This is a sample server Petstore server.
+// @description It has a lot of beatiful features.
 // @termsOfService http://swagger.io/terms/
 
 // @contact.name API Support


### PR DESCRIPTION
**Describe the PR**
This adds multiline description for the general api info. It also changes the behaviour of the multiline description in the routes definition to use `\n` instead of `<br/>` as this is generally considered bad practice.

**Relation issue**
#276