### PR TITLE
support mapType

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -572,6 +572,16 @@ func (parser *Parser) parseTypeExpr(pkgName, typeName string, typeExpr ast.Expr)
 		}
 
 	// type Foo map[string]Bar
+	case *ast.MapType:
+		itemSchema := parser.parseTypeExpr(pkgName, "", expr.Value)
+		return spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				AdditionalProperties: &spec.SchemaOrBool{
+					Schema: &itemSchema,
+				},
+			},
+		}
 	// ...
 	default:
 		log.Printf("Type definition of type '%T' is not supported yet. Using 'object' instead.\n", typeExpr)


### PR DESCRIPTION
**Describe the PR**
support mapType for data definition.

**Relation issue**


**Additional context**
when I generate the doc file with swag tool, the map type is generated as a object simply. I know this situation can be handled by swagger. I think this may be useful and the change seems pretty small. Hope to contribute this project.
Big thanks!
