### PR TITLE
fix bug: []map[string]string type will crash!

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -541,8 +541,9 @@ func (parser *Parser) parseTypeExpr(pkgName, typeName string, typeExpr ast.Expr)
 	case *ast.Ident:
 		refTypeName := fullTypeName(pkgName, expr.Name)
 		if _, isParsed := parser.swagger.Definitions[refTypeName]; !isParsed {
-			typedef := parser.TypeDefinitions[pkgName][expr.Name]
-			parser.ParseDefinition(pkgName, expr.Name, typedef)
+			if typedef, ok := parser.TypeDefinitions[pkgName][expr.Name]; ok{
+				parser.ParseDefinition(pkgName, expr.Name, typedef)
+			}
 		}
 		return parser.swagger.Definitions[refTypeName]
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -455,6 +455,13 @@ func TestParseSimpleApi1(t *testing.T) {
         }
     },
     "definitions": {
+        "api.SwagReturn": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": {}
+            }
+        },
         "cross.Cross": {
             "type": "object",
             "properties": {

--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -107,3 +107,10 @@ func GetPet5b() {
 func GetPet5c() {
 
 }
+
+type SwagReturn []map[string]string
+
+// @Success 200 {object}  api.SwagReturn	"ok"
+func GetPet6MapString() {
+
+}


### PR DESCRIPTION
**Describe the PR**
e.g. add cool parser.
if map value is string,it will crash!

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**

## test code
```go
type SwagReturn []map[string]string

// @Success 200 {object}  main.SwagReturn	"ok"
func test(){}
```
## result
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x13f0b28]

goroutine 1 [running]:
github.com/swaggo/swag.(*Parser).ParseDefinition(0xc000334140, 0xc00002e95a, 0xa, 0xc000454676, 0x6, 0x0)
        /Users/windpro/code/github/swag/parser.go:447 +0x218
github.com/swaggo/swag.(*Parser).parseTypeExpr(0xc000334140, 0xc00002e95a, 0xa, 0x0, 0x0, 0x1596240, 0xc0002f4260, 0x0, 0x0, 0x0, ...)
        /Users/windpro/code/github/swag/parser.go:545 +0x27f
github.com/swaggo/swag.(*Parser).parseTypeExpr(0xc000334140, 0xc00002e95a, 0xa, 0x0, 0x0, 0x1596440, 0xc0003164e0, 0x0, 0x0, 0x0, ...)
        /Users/windpro/code/github/swag/parser.go:580 +0x717
github.com/swaggo/swag.(*Parser).parseTypeExpr(0xc000334140, 0xc00002e95a, 0xa, 0xc000454660, 0xa, 0x1595c00, 0xc000316510, 0x0, 0x0, 0x0, ...)
        /Users/windpro/code/github/swag/parser.go:555 +0x1286
github.com/swaggo/swag.(*Parser).ParseDefinition(0xc000334140, 0xc00002e95a, 0xa, 0xc000454660, 0xa, 0xc0003164b0)
        /Users/windpro/code/github/swag/parser.go:447 +0x26f
github.com/swaggo/swag.(*Parser).ParseDefinitions(0xc000334140)
        /Users/windpro/code/github/swag/parser.go:426 +0x2f2
github.com/swaggo/swag.(*Parser).ParseAPI(0xc000334140, 0x7ffeefbff4b6, 0x35, 0x7ffeefbff469, 0x46, 0x1, 0x1)
        /Users/windpro/code/github/swag/parser.go:99 +0x269
github.com/swaggo/swag/gen.(*Gen).Build(0xc0001c9920, 0x7ffeefbff4b6, 0x35, 0x7ffeefbff469, 0x46, 0x7ffeefbff414, 0x46, 0x7ffeefbff4ff, 0xa, 0x0, ...)
        /Users/windpro/code/github/swag/gen/gen.go:30 +0x28e
main.main.func1(0xc000338160, 0x1010100, 0xc000338160)
        /Users/windpro/code/github/swag/cmd/swag/main.go:33 +0x18a
github.com/urfave/cli.HandleAction(0x146cd60, 0x15274c8, 0xc000338160, 0xc0002ee000, 0x0)
        /Users/windpro/golang/pkg/mod/github.com/urfave/cli@v1.20.0/app.go:490 +0xc8
github.com/urfave/cli.Command.Run(0x15097e0, 0x4, 0x0, 0x0, 0xc0003b00c0, 0x1, 0x1, 0x150c96f, 0xe, 0x0, ...)
        /Users/windpro/golang/pkg/mod/github.com/urfave/cli@v1.20.0/command.go:210 +0x990
github.com/urfave/cli.(*App).Run(0xc0000b2000, 0xc000098180, 0x6, 0x6, 0x0, 0x0)
        /Users/windpro/golang/pkg/mod/github.com/urfave/cli@v1.20.0/app.go:255 +0x687
main.main()
        /Users/windpro/code/github/swag/cmd/swag/main.go:61 +0x4a8
