### PR TITLE
Add response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ import (
 // @Produce  json
 // @Param id path int true "Account ID"
 // @Success 200 {object} model.Account
+// @Header 200 {string} Token "qwerty"
 // @Failure 400 {object} httputil.HTTPError
 // @Failure 404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
@@ -241,6 +242,7 @@ func (c *Controller) ShowAccount(ctx *gin.Context) {
 // @Produce  json
 // @Param q query string false "name search by q"
 // @Success 200 {array} model.Account
+// @Header 200 {string} Token "qwerty"
 // @Failure 400 {object} httputil.HTTPError
 // @Failure 404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
@@ -364,6 +366,7 @@ OPTIONS:
 | security           | [Security](#security) to each API operation.                                                                               |
 | success            | Success response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
 | failure            | Failure response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
+| header             | Header in response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
 | router             | Path definition that separated by spaces. `path`,`[httpMethod]`                                                           |
 
 ## Mime Types
@@ -495,6 +498,13 @@ type Account struct {
     ID   int    `json:"id" example:"1"`
     Name string `json:"name" example:"account name"`
 }
+```
+### Add a headers in response
+
+```go
+// @Success 200 {string} string	"ok"
+// @Header 200 {string} Location "/entity/1"
+// @Header 200 {string} Token "qwerty"
 ```
 
 ### Use multiple path params

--- a/operation_test.go
+++ b/operation_test.go
@@ -231,6 +231,31 @@ func TestParseEmptyResponseComment(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseResponseCommentWithHeader(t *testing.T) {
+	comment := `@Success 200 "it's ok"`
+	operation := NewOperation()
+	operation.ParseComment(comment, nil)
+	comment = `@Header 200 {string} Token "qwerty"`
+	operation.ParseComment(comment, nil)
+	b, err := json.MarshalIndent(operation, "", "    ")
+	assert.NoError(t, err)
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "it's ok",
+            "headers": {
+                "Token": {
+                    "type": "string",
+                    "description": "qwerty"
+                }
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseEmptyResponseOnlyCode(t *testing.T) {
 	comment := `@Success 200`
 	operation := NewOperation()
@@ -394,7 +419,7 @@ func TestParseParamCommentNotMatch(t *testing.T) {
 	comment := `@Param some_id body mock true`
 	operation := NewOperation()
 	err := operation.ParseComment(comment, nil)
-	
+
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
New features. Parse header comment and add to response.

Add a comment with header in the same format as the success tag.
`// @Header 200 {string} Location "entity/10"`

It is possible to add multiple headers to the same response code.
Header comment must be defined after success tag.

Example:
```
// @Success 200 {string} string	"hello"
// @Header 200 {string} Location "/entity/1"
// @Header 200 {string} Token "qwerty"
```
will generate
```
  responses:
        "200":
          description: hello
          headers:
            Location:
              description: /entity/1
              type: string
            Token:
              description: qwerty
              type: string
          schema:
            type: string
```