### PR TITLE
Fix spelling error in ParseComment

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -184,7 +184,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 	case "formData":
 		param = createParameter(paramType, description, name, TransToValidSchemeType(schemaType), required)
 	default:
-		return fmt.Errorf("%s is not suppoted paramType", paramType)
+		return fmt.Errorf("%s is not supported paramType", paramType)
 	}
 
 	if err := operation.parseAndExtractionParamAttribute(commentLine, schemaType, &param); err != nil {


### PR DESCRIPTION
Fix a minor spelling error "suppoted" -> "supported" in ParseComment.