### PR TITLE
add paramType for form

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -181,7 +181,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 				Ref: jsonreference.MustCreateRef("#/definitions/" + schemaType),
 			}
 		}
-	case "formData":
+	case "formData","form":
 		param = createParameter(paramType, description, name, TransToValidSchemeType(schemaType), required)
 	default:
 		return fmt.Errorf("%s is not supported paramType", paramType)


### PR DESCRIPTION
**Describe the PR**
add paramType for form

**Relation issue**
 

**Additional context**
The paramType supported by standard swagger is the keyword "form".
