### PR TITLE
fix: only execute 'go list' when enable 'parseDependency' flag

### DIFF
--- a/example/basic/api/api.go
+++ b/example/basic/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/swaggo/swag/example/basic/web"
 )
 
 // GetStringByInt example
@@ -17,6 +18,7 @@ import (
 // @Failure 404 {object} web.APIError "Can not find ID"
 // @Router /testapi/get-string-by-int/{some_id} [get]
 func GetStringByInt(c *gin.Context) {
+	 _ :=web.Pet{}
 	//write your code
 }
 

--- a/example/basic/api/api.go
+++ b/example/basic/api/api.go
@@ -18,7 +18,7 @@ import (
 // @Failure 404 {object} web.APIError "Can not find ID"
 // @Router /testapi/get-string-by-int/{some_id} [get]
 func GetStringByInt(c *gin.Context) {
-	 _ :=web.Pet{}
+	_ := web.Pet{}
 	//write your code
 }
 

--- a/parser.go
+++ b/parser.go
@@ -119,16 +119,14 @@ func (parser *Parser) ParseAPI(searchDir string, mainAPIFile string) error {
 		return err
 	}
 
-	pkgName, err := getPkgName(path.Dir(absMainAPIFilePath))
-	if err != nil {
-		return err
-	}
-
-	if err := t.Resolve(pkgName); err != nil {
-		return fmt.Errorf("pkg %s cannot find all dependencies, %s", pkgName, err)
-	}
-
 	if parser.ParseDependency {
+		pkgName, err := getPkgName(path.Dir(absMainAPIFilePath))
+		if err != nil {
+			return err
+		}
+		if err := t.Resolve(pkgName); err != nil {
+			return fmt.Errorf("pkg %s cannot find all dependencies, %s", pkgName, err)
+		}
 		for i := 0; i < len(t.Root.Deps); i++ {
 			if err := parser.getAllGoFileInfoFromDeps(&t.Root.Deps[i]); err != nil {
 				return err

--- a/parser.go
+++ b/parser.go
@@ -1014,27 +1014,31 @@ func (parser *Parser) parseAnonymousField(pkgName string, field *ast.Field) (map
 	}
 
 	typeSpec := parser.TypeDefinitions[pkgName][typeName]
-	schema, err := parser.parseTypeExpr(pkgName, typeName, typeSpec.Type)
-	if err != nil {
-		return properties, []string{}, err
-	}
-	schemaType := "unknown"
-	if len(schema.SchemaProps.Type) > 0 {
-		schemaType = schema.SchemaProps.Type[0]
-	}
-
-	switch schemaType {
-	case "object":
-		for k, v := range schema.SchemaProps.Properties {
-			properties[k] = v
+	if typeSpec != nil {
+		schema, err := parser.parseTypeExpr(pkgName, typeName, typeSpec.Type)
+		if err != nil {
+			return properties, []string{}, err
 		}
-	case "array":
-		properties[typeName] = schema
-	default:
-		Printf("Can't extract properties from a schema of type '%s'", schemaType)
+		schemaType := "unknown"
+		if len(schema.SchemaProps.Type) > 0 {
+			schemaType = schema.SchemaProps.Type[0]
+		}
+
+		switch schemaType {
+		case "object":
+			for k, v := range schema.SchemaProps.Properties {
+				properties[k] = v
+			}
+		case "array":
+			properties[typeName] = schema
+		default:
+			Printf("Can't extract properties from a schema of type '%s'", schemaType)
+		}
+
+		return properties, schema.SchemaProps.Required, nil
 	}
 
-	return properties, schema.SchemaProps.Required, nil
+	return properties, nil, nil
 }
 
 func (parser *Parser) parseField(field *ast.Field) (*structField, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -2642,7 +2642,7 @@ func TestFixes432(t *testing.T) {
 	}
 }
 
-func TestParseOutsideDependencies(t *testing.T){
+func TestParseOutsideDependencies(t *testing.T) {
 	searchDir := "testdata/pare_outside_dependencies"
 	mainAPIFile := "cmd/main.go"
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -2641,3 +2641,14 @@ func TestFixes432(t *testing.T) {
 		t.Error("Failed to ignore valid pkg: " + err.Error())
 	}
 }
+
+func TestParseOutsideDependencies(t *testing.T){
+	searchDir := "testdata/pare_outside_dependencies"
+	mainAPIFile := "cmd/main.go"
+
+	p := New()
+	p.ParseDependency = true
+	if err := p.ParseAPI(searchDir, mainAPIFile); err != nil {
+		t.Error("Failed to parse api: " + err.Error())
+	}
+}

--- a/testdata/pare_outside_dependencies/cmd/main.go
+++ b/testdata/pare_outside_dependencies/cmd/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/swaggo/swag/example/basic/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server Petstore server.
+// @termsOfService http://swagger.io/terms/
+
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host petstore.swagger.io
+// @BasePath /v2
+func main() {
+	_ := web.Pet{}
+	r := gin.New()
+	r.GET("/testapi/get-string-by-int/:some_id", api.GetStringByInt)
+	r.GET("//testapi/get-struct-array-by-string/:some_id", api.GetStructArrayByString)
+	r.POST("/testapi/upload", api.Upload)
+	r.Run()
+
+}


### PR DESCRIPTION
as title