### PR TITLE
docs.go test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ clean:
 .PHONY: install
 install:
 	$(GOGET) -v github.com/swaggo/swag github.com/swaggo/swag/cmd/swag github.com/swaggo/swag/gen
+	$(GOGET) github.com/alecthomas/template
 	$(GOGET) github.com/stretchr/testify/assert
 
 .PHONY: lint

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -3,6 +3,7 @@ package gen
 import (
 	"github.com/go-openapi/spec"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"testing"
@@ -244,4 +245,26 @@ func TestGen_writeGoDoc(t *testing.T) {
 
 	packageTemplate = swapTemplate
 
+}
+
+func TestGen_GeneratedDoc(t *testing.T) {
+
+	searchDir := "../testdata/simple"
+
+	config := &Config{
+		SearchDir:          searchDir,
+		MainAPIFile:        "./main.go",
+		OutputDir:          "../testdata/simple/docs",
+		PropNamingStrategy: "",
+	}
+
+	assert.NoError(t, New().Build(config))
+	gocmd, err := exec.LookPath("go")
+	assert.NoError(t, err)
+
+	cmd := exec.Command(gocmd, "build", filepath.Join(config.OutputDir, "docs.go"))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	assert.NoError(t, cmd.Run())
 }


### PR DESCRIPTION
**Describe the PR**
Add code coverage for generated docs.go

**Relation issue**
None

**Additional context**
There is 0% coverage for any of the docs.go generated files. 