### PR TITLE
Reduce code complexity

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -69,7 +69,7 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	var err error
 	switch lowerAttribute {
 	case "@description":
-		operation.ParseDescription(lineRemainder)
+		operation.ParseDescriptionComment(lineRemainder)
 	case "@summary":
 		operation.Summary = lineRemainder
 	case "@id":
@@ -99,7 +99,8 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	return err
 }
 
-func (operation *Operation) ParseDescription(lineRemainder string) {
+// ParseDescriptionComment godoc
+func (operation *Operation) ParseDescriptionComment(lineRemainder string) {
 	if operation.Description == "" {
 		operation.Description = lineRemainder
 		return
@@ -107,6 +108,7 @@ func (operation *Operation) ParseDescription(lineRemainder string) {
 	operation.Description += "\n" + lineRemainder
 }
 
+// ParseMetadata godoc
 func (operation *Operation) ParseMetadata(attribute, lowerAttribute, lineRemainder string) error {
 	// parsing specific meta data extensions
 	if strings.HasPrefix(lowerAttribute, "@x-") {

--- a/operation.go
+++ b/operation.go
@@ -62,17 +62,14 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	if len(commentLine) == 0 {
 		return nil
 	}
-
 	attribute := strings.Fields(commentLine)[0]
 	lineRemainder := strings.TrimSpace(commentLine[len(attribute):])
 	lowerAttribute := strings.ToLower(attribute)
+
+	var err error
 	switch lowerAttribute {
 	case "@description":
-		if operation.Description == "" {
-			operation.Description = lineRemainder
-		} else {
-			operation.Description += "\n" + lineRemainder
-		}
+		operation.ParseDescription(lineRemainder)
 	case "@summary":
 		operation.Summary = lineRemainder
 	case "@id":
@@ -80,41 +77,37 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 	case "@tags":
 		operation.ParseTagsComment(lineRemainder)
 	case "@accept":
-		if err := operation.ParseAcceptComment(lineRemainder); err != nil {
-			return err
-		}
+		err = operation.ParseAcceptComment(lineRemainder)
 	case "@produce":
-		if err := operation.ParseProduceComment(lineRemainder); err != nil {
-			return err
-		}
+		err = operation.ParseProduceComment(lineRemainder)
 	case "@param":
-		if err := operation.ParseParamComment(lineRemainder, astFile); err != nil {
-			return err
-		}
+		err = operation.ParseParamComment(lineRemainder, astFile)
 	case "@success", "@failure":
-		if err := operation.ParseResponseComment(lineRemainder, astFile); err != nil {
-			if err := operation.ParseEmptyResponseComment(lineRemainder); err != nil {
-				if err := operation.ParseEmptyResponseOnly(lineRemainder); err != nil {
-					return err
-				}
-			}
-		}
+		err = operation.ParseResponseComment(lineRemainder, astFile)
 	case "@header":
-		if err := operation.ParseResponseHeaderComment(lineRemainder, astFile); err != nil {
-			return err
-		}
+		err = operation.ParseResponseHeaderComment(lineRemainder, astFile)
 	case "@router":
-		if err := operation.ParseRouterComment(lineRemainder); err != nil {
-			return err
-		}
+		err = operation.ParseRouterComment(lineRemainder)
 	case "@security":
-		if err := operation.ParseSecurityComment(lineRemainder); err != nil {
-			return err
-		}
+		err = operation.ParseSecurityComment(lineRemainder)
 	case "@deprecated":
 		operation.Deprecate()
+	default:
+		err = operation.ParseMetadata(attribute, lowerAttribute, lineRemainder)
 	}
 
+	return err
+}
+
+func (operation *Operation) ParseDescription(lineRemainder string) {
+	if operation.Description == "" {
+		operation.Description = lineRemainder
+		return
+	}
+	operation.Description += "\n" + lineRemainder
+}
+
+func (operation *Operation) ParseMetadata(attribute, lowerAttribute, lineRemainder string) error {
 	// parsing specific meta data extensions
 	if strings.HasPrefix(lowerAttribute, "@x-") {
 		if len(lineRemainder) == 0 {
@@ -127,7 +120,6 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 		}
 		operation.Operation.AddExtension(attribute[1:], valueJSON) // Trim "@" at head
 	}
-
 	return nil
 }
 
@@ -241,90 +233,50 @@ var regexAttributes = map[string]*regexp.Regexp{
 func (operation *Operation) parseAndExtractionParamAttribute(commentLine, schemaType string, param *spec.Parameter) error {
 	schemaType = TransToValidSchemeType(schemaType)
 	for attrKey, re := range regexAttributes {
+		attr, err := findAttr(re, commentLine)
+		if err != nil {
+			continue
+		}
 		switch attrKey {
 		case "enums":
-			enums, err := findAttrList(re, commentLine)
+			err := setEnumParam(attr, schemaType, param)
 			if err != nil {
-				break
-			}
-			for _, e := range enums {
-				e = strings.TrimSpace(e)
-
-				value, err := defineType(schemaType, e)
-				if err != nil {
-					return err
-				}
-				param.Enum = append(param.Enum, value)
+				return err
 			}
 		case "maxinum":
-			attr, err := findAttr(re, commentLine)
+			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
-				break
-			}
-			if schemaType != "integer" && schemaType != "number" {
-				return fmt.Errorf("maxinum is attribute to set to a number. comment=%s got=%s", commentLine, schemaType)
-			}
-			n, err := strconv.ParseFloat(attr, 64)
-			if err != nil {
-				return fmt.Errorf("maximum is allow only a number. comment=%s got=%s", commentLine, attr)
+				return err
 			}
 			param.Maximum = &n
 		case "mininum":
-			attr, err := findAttr(re, commentLine)
+			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
-				break
-			}
-			if schemaType != "integer" && schemaType != "number" {
-				return fmt.Errorf("mininum is attribute to set to a number. comment=%s got=%s", commentLine, schemaType)
-			}
-			n, err := strconv.ParseFloat(attr, 64)
-			if err != nil {
-				return fmt.Errorf("mininum is allow only a number got=%s", attr)
+				return err
 			}
 			param.Minimum = &n
 		case "default":
-			attr, err := findAttr(re, commentLine)
-			if err != nil {
-				break
-			}
 			value, err := defineType(schemaType, attr)
 			if err != nil {
 				return nil
 			}
 			param.Default = value
 		case "maxlength":
-			attr, err := findAttr(re, commentLine)
+			n, err := setStringParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
-				break
-			}
-			if schemaType != "string" {
-				return fmt.Errorf("maxlength is attribute to set to a number. comment=%s got=%s", commentLine, schemaType)
-			}
-			n, err := strconv.ParseInt(attr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("maxlength is allow only a number got=%s", attr)
+				return err
 			}
 			param.MaxLength = &n
 		case "minlength":
-			attr, err := findAttr(re, commentLine)
+			n, err := setStringParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
-				break
-			}
-			if schemaType != "string" {
-				return fmt.Errorf("maxlength is attribute to set to a number. comment=%s got=%s", commentLine, schemaType)
-			}
-			n, err := strconv.ParseInt(attr, 10, 64)
-			if err != nil {
-				return fmt.Errorf("minlength is allow only a number got=%s", attr)
+				return err
 			}
 			param.MinLength = &n
 		case "format":
-			attr, err := findAttr(re, commentLine)
-			if err != nil {
-				break
-			}
 			param.Format = attr
 		}
+
 	}
 	return nil
 }
@@ -339,12 +291,39 @@ func findAttr(re *regexp.Regexp, commentLine string) (string, error) {
 	return strings.TrimSpace(attr[l+1 : r]), nil
 }
 
-func findAttrList(re *regexp.Regexp, commentLine string) ([]string, error) {
-	attr, err := findAttr(re, commentLine)
-	if err != nil {
-		return []string{""}, err
+func setStringParam(name, schemaType, attr, commentLine string) (int64, error) {
+	if schemaType != "string" {
+		return 0, fmt.Errorf("%s is attribute to set to a number. comment=%s got=%s", name, commentLine, schemaType)
 	}
-	return strings.Split(attr, ","), nil
+	n, err := strconv.ParseInt(attr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s is allow only a number got=%s", name, attr)
+	}
+	return n, nil
+}
+
+func setNumberParam(name, schemaType, attr, commentLine string) (float64, error) {
+	if schemaType != "integer" && schemaType != "number" {
+		return 0, fmt.Errorf("%s is attribute to set to a number. comment=%s got=%s", name, commentLine, schemaType)
+	}
+	n, err := strconv.ParseFloat(attr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("maximum is allow only a number. comment=%s got=%s", commentLine, attr)
+	}
+	return n, nil
+}
+
+func setEnumParam(attr, schemaType string, param *spec.Parameter) error {
+	for _, e := range strings.Split(attr, ",") {
+		e = strings.TrimSpace(e)
+
+		value, err := defineType(schemaType, e)
+		if err != nil {
+			return err
+		}
+		param.Enum = append(param.Enum, value)
+	}
+	return nil
 }
 
 // defineType enum value define the type (object and array unsupported)
@@ -519,7 +498,11 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 	var matches []string
 
 	if matches = responsePattern.FindStringSubmatch(commentLine); len(matches) != 5 {
-		return fmt.Errorf("can not parse response comment \"%s\"", commentLine)
+		err := operation.ParseEmptyResponseComment(commentLine)
+		if err != nil {
+			return operation.ParseEmptyResponseOnly(commentLine)
+		}
+		return err
 	}
 
 	response := spec.Response{}

--- a/parser.go
+++ b/parser.go
@@ -184,288 +184,144 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 	parser.swagger.Swagger = "2.0"
 	securityMap := map[string]*spec.SecurityScheme{}
 
-	if fileTree.Comments != nil {
-	nextComments:
-		for _, comment := range fileTree.Comments {
-			comments := strings.Split(comment.Text(), "\n")
-			// Comments belongs to operation ?
-			for _, commentLine := range comments {
-				attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
-				switch attribute {
-				case "@summary", "@router", "@success", "@failure":
-					continue nextComments
-				}
+	if fileTree.Comments == nil {
+		return errors.Wrap(err, "General api info is missing")
+	}
+
+	for _, comment := range fileTree.Comments {
+		if !isGeneralApiComment(comment) {
+			continue
+		}
+		comments := strings.Split(comment.Text(), "\n")
+		previousAttribute := ""
+		// parsing classic meta data model
+		for i, commentLine := range comments {
+			attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
+			value := strings.TrimSpace(commentLine[len(attribute):])
+			multilineBlock := false
+			if previousAttribute == attribute {
+				multilineBlock = true
 			}
-			previousAttribute := ""
-			// parsing classic meta data model
-			for _, commentLine := range comments {
-				attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
-				value := strings.TrimSpace(commentLine[len(attribute):])
-				multilineBlock := false
-				if previousAttribute == attribute {
-					multilineBlock = true
-				}
-				switch attribute {
-				case "@version":
-					parser.swagger.Info.Version = value
-				case "@title":
-					parser.swagger.Info.Title = value
-				case "@description":
-					if multilineBlock {
-						parser.swagger.Info.Description += "\n" + value
-						continue
-					}
-					parser.swagger.Info.Description = value
-				case "@description.markdown":
-					filePath, err := getMarkdownFileForTag("api", parser.markdownFileDir)
-					if err != nil {
-						return err
-					}
-
-					commentInfo, err := ioutil.ReadFile(parser.markdownFileDir + "/" + filePath)
-					if err != nil {
-						return errors.New("Failed to find matching markdown file for api description: " + "api" + " error: " + err.Error())
-					}
-
-					parser.swagger.Info.Description = string(commentInfo)
-				case "@termsofservice":
-					parser.swagger.Info.TermsOfService = value
-				case "@contact.name":
-					parser.swagger.Info.Contact.Name = value
-				case "@contact.email":
-					parser.swagger.Info.Contact.Email = value
-				case "@contact.url":
-					parser.swagger.Info.Contact.URL = value
-				case "@license.name":
-					parser.swagger.Info.License.Name = value
-				case "@license.url":
-					parser.swagger.Info.License.URL = value
-				case "@host":
-					parser.swagger.Host = value
-				case "@basepath":
-					parser.swagger.BasePath = value
-				case "@schemes":
-					parser.swagger.Schemes = getSchemes(commentLine)
-				case "@tag.name":
-					parser.swagger.Tags = append(parser.swagger.Tags, spec.Tag{
-						TagProps: spec.TagProps{
-							Name: value,
-						},
-					})
-				case "@tag.description":
-					tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
-					tag.TagProps.Description = value
-					replaceLastTag(parser.swagger.Tags, tag)
-				case "@tag.description.markdown":
-					tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
-					filePath, err := getMarkdownFileForTag(tag.TagProps.Name, parser.markdownFileDir)
-					if err != nil {
-						return err
-					}
-
-					commentInfo, err := ioutil.ReadFile(parser.markdownFileDir + "/" + filePath)
-					if err != nil {
-						return errors.New("Failed to find matching markdown file for tag: " + tag.TagProps.Name + " error: " + err.Error())
-					}
-
-					tag.TagProps.Description = string(commentInfo)
-					replaceLastTag(parser.swagger.Tags, tag)
-				case "@tag.docs.url":
-					tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
-					tag.TagProps.ExternalDocs = &spec.ExternalDocumentation{
-						URL: value,
-					}
-					replaceLastTag(parser.swagger.Tags, tag)
-				case "@tag.docs.description":
-					tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
-					if tag.TagProps.ExternalDocs == nil {
-						return errors.New("@tag.docs.description needs to come after a @tags.docs.url")
-					}
-					tag.TagProps.ExternalDocs.Description = value
-					replaceLastTag(parser.swagger.Tags, tag)
-				}
-				previousAttribute = attribute
-			}
-			// parsing specific meta data extensions
-			for _, commentLine := range comments {
-				prefixExtension := "@x-"
-				split := strings.Split(commentLine, " ")
-				if len(split[0]) < len(prefixExtension) {
+			switch attribute {
+			case "@version":
+				parser.swagger.Info.Version = value
+			case "@title":
+				parser.swagger.Info.Title = value
+			case "@description":
+				if multilineBlock {
+					parser.swagger.Info.Description += "\n" + value
 					continue
 				}
-				attribute := strings.ToLower(split[0])
-				switch attribute[:len(prefixExtension)] {
-				case prefixExtension:
-					var valueJSON interface{}
-					split = strings.SplitAfter(commentLine, attribute+" ")
-					if len(split) < 2 {
-						return errors.New(attribute + " need a value")
+				parser.swagger.Info.Description = value
+			case "@description.markdown":
+				commentInfo, err := getMarkdownForTag("api", parser.markdownFileDir)
+				if err != nil {
+					return err
+				}
+				parser.swagger.Info.Description = string(commentInfo)
+			case "@termsofservice":
+				parser.swagger.Info.TermsOfService = value
+			case "@contact.name":
+				parser.swagger.Info.Contact.Name = value
+			case "@contact.email":
+				parser.swagger.Info.Contact.Email = value
+			case "@contact.url":
+				parser.swagger.Info.Contact.URL = value
+			case "@license.name":
+				parser.swagger.Info.License.Name = value
+			case "@license.url":
+				parser.swagger.Info.License.URL = value
+			case "@host":
+				parser.swagger.Host = value
+			case "@basepath":
+				parser.swagger.BasePath = value
+			case "@schemes":
+				parser.swagger.Schemes = getSchemes(commentLine)
+			case "@tag.name":
+				parser.swagger.Tags = append(parser.swagger.Tags, spec.Tag{
+					TagProps: spec.TagProps{
+						Name: value,
+					},
+				})
+			case "@tag.description":
+				tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
+				tag.TagProps.Description = value
+				replaceLastTag(parser.swagger.Tags, tag)
+			case "@tag.description.markdown":
+				tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
+				commentInfo, err := getMarkdownForTag(tag.TagProps.Name, parser.markdownFileDir)
+				if err != nil {
+					return err
+				}
+				tag.TagProps.Description = string(commentInfo)
+				replaceLastTag(parser.swagger.Tags, tag)
+			case "@tag.docs.url":
+				tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
+				tag.TagProps.ExternalDocs = &spec.ExternalDocumentation{
+					URL: value,
+				}
+				replaceLastTag(parser.swagger.Tags, tag)
+			case "@tag.docs.description":
+				tag := parser.swagger.Tags[len(parser.swagger.Tags)-1]
+				if tag.TagProps.ExternalDocs == nil {
+					return errors.New("@tag.docs.description needs to come after a @tags.docs.url")
+				}
+				tag.TagProps.ExternalDocs.Description = value
+				replaceLastTag(parser.swagger.Tags, tag)
+			case "@securitydefinitions.basic":
+				securityMap[value] = spec.BasicAuth()
+			case "@securitydefinitions.apikey":
+				attrMap, _, err := extractSecurityAttribute(attribute, []string{"@in", "@name"}, comments[i+1:])
+				if err != nil {
+					return err
+				}
+				securityMap[value] = spec.APIKeyAuth(attrMap["@name"], attrMap["@in"])
+			case "@securitydefinitions.oauth2.application":
+				attrMap, scopes, err := extractSecurityAttribute(attribute, []string{"@tokenurl"}, comments[i+1:])
+				if err != nil {
+					return err
+				}
+				securityMap[value] = securitySchemeOAuth2Application(attrMap["@tokenurl"], scopes)
+			case "@securitydefinitions.oauth2.implicit":
+				attrMap, scopes, err := extractSecurityAttribute(attribute, []string{"@authorizationurl"}, comments[i+1:])
+				if err != nil {
+					return err
+				}
+				securityMap[value] = securitySchemeOAuth2Implicit(attrMap["@authorizationurl"], scopes)
+			case "@securitydefinitions.oauth2.password":
+				attrMap, scopes, err := extractSecurityAttribute(attribute, []string{"@tokenurl"}, comments[i+1:])
+				if err != nil {
+					return err
+				}
+				securityMap[value] = securitySchemeOAuth2Password(attrMap["@tokenurl"], scopes)
+			case "@securitydefinitions.oauth2.accesscode":
+				attrMap, scopes, err := extractSecurityAttribute(attribute, []string{"@tokenurl", "@authorizationurl"}, comments[i+1:])
+				if err != nil {
+					return err
+				}
+				securityMap[value] = securitySchemeOAuth2AccessToken(attrMap["@authorizationurl"], attrMap["@tokenurl"], scopes)
+
+			default:
+				prefixExtension := "@x-"
+				if len(attribute) > 5 { // Prefix extension + 1 char + 1 space  + 1 char
+					if attribute[:len(prefixExtension)] == prefixExtension {
+						var valueJSON interface{}
+						split := strings.SplitAfter(commentLine, attribute+" ")
+						if len(split) < 2 {
+							return errors.New(attribute + " need a value")
+						}
+						extensionName := "x-" + strings.SplitAfter(attribute, prefixExtension)[1]
+						if err := json.Unmarshal([]byte(split[1]), &valueJSON); err != nil {
+							return errors.New(attribute + " need a valid json value")
+						}
+						parser.swagger.AddExtension(extensionName, valueJSON)
 					}
-					extensionName := "x-" + strings.SplitAfter(attribute, prefixExtension)[1]
-					if err := json.Unmarshal([]byte(split[1]), &valueJSON); err != nil {
-						return errors.New(attribute + " need a valid json value")
-					}
-					parser.swagger.AddExtension(extensionName, valueJSON)
 				}
 			}
-			// parsing specific meta data securities
-			for i := 0; i < len(comments); i++ {
-				attribute := strings.ToLower(strings.Split(comments[i], " ")[0])
-				switch attribute {
-				case "@securitydefinitions.basic":
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = spec.BasicAuth()
-				case "@securitydefinitions.apikey":
-					attrMap := map[string]string{}
-					for _, v := range comments[i+1:] {
-						securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-						if securityAttr == "@in" || securityAttr == "@name" {
-							attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
-						}
-						// next securityDefinitions
-						if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
-							break
-						}
-					}
-					if len(attrMap) != 2 {
-						return errors.New("@securitydefinitions.apikey is @name and @in required")
-					}
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = spec.APIKeyAuth(attrMap["@name"], attrMap["@in"])
-				case "@securitydefinitions.oauth2.application":
-					attrMap := map[string]string{}
-					scopes := map[string]string{}
-					for _, v := range comments[i+1:] {
-						securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-						if securityAttr == "@tokenurl" {
-							attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
-						} else {
-							isExists, err := isExistsScope(securityAttr)
-							if err != nil {
-								return err
-							}
-							if isExists {
-								scopScheme, err := getScopeScheme(securityAttr)
-								if err != nil {
-									return err
-								}
-								scopes[scopScheme] = v[len(securityAttr):]
-							}
-						}
-						// next securityDefinitions
-						if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
-							break
-						}
-					}
-					if len(attrMap) != 1 {
-						return errors.New("@securitydefinitions.oauth2.application is @tokenUrl required")
-					}
-					securityScheme := spec.OAuth2Application(attrMap["@tokenurl"])
-					for scope, description := range scopes {
-						securityScheme.AddScope(scope, description)
-					}
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = securityScheme
-				case "@securitydefinitions.oauth2.implicit":
-					attrMap := map[string]string{}
-					scopes := map[string]string{}
-					for _, v := range comments[i+1:] {
-						securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-						if securityAttr == "@authorizationurl" {
-							attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
-						} else {
-							isExists, err := isExistsScope(securityAttr)
-							if err != nil {
-								return err
-							}
-							if isExists {
-								scopScheme, err := getScopeScheme(securityAttr)
-								if err != nil {
-									return err
-								}
-								scopes[scopScheme] = v[len(securityAttr):]
-							}
-						}
-						// next securityDefinitions
-						if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
-							break
-						}
-					}
-					if len(attrMap) != 1 {
-						return errors.New("@securitydefinitions.oauth2.implicit is @authorizationUrl required")
-					}
-					securityScheme := spec.OAuth2Implicit(attrMap["@authorizationurl"])
-					for scope, description := range scopes {
-						securityScheme.AddScope(scope, description)
-					}
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = securityScheme
-				case "@securitydefinitions.oauth2.password":
-					attrMap := map[string]string{}
-					scopes := map[string]string{}
-					for _, v := range comments[i+1:] {
-						securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-						if securityAttr == "@tokenurl" {
-							attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
-						} else {
-							isExists, err := isExistsScope(securityAttr)
-							if err != nil {
-								return err
-							}
-							if isExists {
-								scopScheme, err := getScopeScheme(securityAttr)
-								if err != nil {
-									return err
-								}
-								scopes[scopScheme] = v[len(securityAttr):]
-							}
-						}
-						// next securityDefinitions
-						if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
-							break
-						}
-					}
-					if len(attrMap) != 1 {
-						return errors.New("@securitydefinitions.oauth2.password is @tokenUrl required")
-					}
-					securityScheme := spec.OAuth2Password(attrMap["@tokenurl"])
-					for scope, description := range scopes {
-						securityScheme.AddScope(scope, description)
-					}
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = securityScheme
-				case "@securitydefinitions.oauth2.accesscode":
-					attrMap := map[string]string{}
-					scopes := map[string]string{}
-					for _, v := range comments[i+1:] {
-						securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-						if securityAttr == "@tokenurl" || securityAttr == "@authorizationurl" {
-							attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
-						} else {
-							isExists, err := isExistsScope(securityAttr)
-							if err != nil {
-								return err
-							}
-							if isExists {
-								scopScheme, err := getScopeScheme(securityAttr)
-								if err != nil {
-									return err
-								}
-								scopes[scopScheme] = v[len(securityAttr):]
-							}
-						}
-						// next securityDefinitions
-						if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
-							break
-						}
-					}
-					if len(attrMap) != 2 {
-						return errors.New("@securitydefinitions.oauth2.accessCode is @tokenUrl and @authorizationUrl required")
-					}
-					securityScheme := spec.OAuth2AccessToken(attrMap["@authorizationurl"], attrMap["@tokenurl"])
-					for scope, description := range scopes {
-						securityScheme.AddScope(scope, description)
-					}
-					securityMap[strings.TrimSpace(comments[i][len(attribute):])] = securityScheme
-				}
-			}
+			previousAttribute = attribute
 		}
 	}
+
 	if len(securityMap) > 0 {
 		parser.swagger.SecurityDefinitions = securityMap
 	}
@@ -473,10 +329,87 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 	return nil
 }
 
-func getMarkdownFileForTag(tagName string, dirPath string) (string, error) {
+func isGeneralApiComment(comment *ast.CommentGroup) bool {
+	for _, commentLine := range strings.Split(comment.Text(), "\n") {
+		attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
+		switch attribute {
+		// The @summary, @router, @success,@failure  annotation belongs to Operation
+		case "@summary", "@router", "@success", "@failure":
+			return false
+		}
+	}
+	return true
+}
+
+func extractSecurityAttribute(context string, search []string, lines []string) (map[string]string, map[string]string, error) {
+	attrMap := map[string]string{}
+	scopes := map[string]string{}
+	for _, v := range lines {
+		securityAttr := strings.ToLower(strings.Split(v, " ")[0])
+		for _, find_term := range search {
+			if securityAttr == find_term {
+				attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
+				continue
+			}
+		}
+		isExists, err := isExistsScope(securityAttr)
+		if err != nil {
+			return nil, nil, err
+		}
+		if isExists {
+			scopScheme, err := getScopeScheme(securityAttr)
+			if err != nil {
+				return nil, nil, err
+			}
+			scopes[scopScheme] = v[len(securityAttr):]
+		}
+		// next securityDefinitions
+		if strings.Index(securityAttr, "@securitydefinitions.") == 0 {
+			break
+		}
+	}
+	if len(attrMap) != len(search) {
+		return nil, nil, fmt.Errorf("%s is %v required", context, search)
+	}
+	return attrMap, scopes, nil
+}
+
+func securitySchemeOAuth2Application(tokenurl string, scopes map[string]string) *spec.SecurityScheme {
+	securityScheme := spec.OAuth2Application(tokenurl)
+	for scope, description := range scopes {
+		securityScheme.AddScope(scope, description)
+	}
+	return securityScheme
+}
+
+func securitySchemeOAuth2Implicit(authorizationurl string, scopes map[string]string) *spec.SecurityScheme {
+	securityScheme := spec.OAuth2Implicit(authorizationurl)
+	for scope, description := range scopes {
+		securityScheme.AddScope(scope, description)
+	}
+	return securityScheme
+}
+
+func securitySchemeOAuth2Password(tokenurl string, scopes map[string]string) *spec.SecurityScheme {
+	securityScheme := spec.OAuth2Password(tokenurl)
+	for scope, description := range scopes {
+		securityScheme.AddScope(scope, description)
+	}
+	return securityScheme
+}
+
+func securitySchemeOAuth2AccessToken(authorizationurl, tokenurl string, scopes map[string]string) *spec.SecurityScheme {
+	securityScheme := spec.OAuth2AccessToken(authorizationurl, tokenurl)
+	for scope, description := range scopes {
+		securityScheme.AddScope(scope, description)
+	}
+	return securityScheme
+}
+
+func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
 	filesInfos, err := ioutil.ReadDir(dirPath)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	for _, fileInfo := range filesInfos {
@@ -490,11 +423,15 @@ func getMarkdownFileForTag(tagName string, dirPath string) (string, error) {
 		}
 
 		if strings.Contains(fileName, tagName) {
-			return fileName, nil
+			commentInfo, err := ioutil.ReadFile(filepath.Join(dirPath, fileName))
+			if err != nil {
+				return nil, errors.New("Failed to find matching markdown file for api description: " + "api" + " error: " + err.Error())
+			}
+			return commentInfo, nil
 		}
 	}
 
-	return "", errors.New("Unable to find Markdown file in the given directory")
+	return nil, errors.New("Unable to find Markdown file in the given directory")
 }
 
 func getScopeScheme(scope string) (string, error) {
@@ -702,49 +639,7 @@ func (parser *Parser) parseTypeExpr(pkgName, typeName string, typeExpr ast.Expr)
 			return schema, nil
 		}
 
-		extraRequired := make([]string, 0)
-		properties := make(map[string]spec.Schema)
-		for _, field := range expr.Fields.List {
-			var fieldProps map[string]spec.Schema
-			var requiredFromAnon []string
-			if field.Names == nil {
-				var err error
-				fieldProps, requiredFromAnon, err = parser.parseAnonymousField(pkgName, field)
-				if err != nil {
-					return spec.Schema{}, err
-				}
-				extraRequired = append(extraRequired, requiredFromAnon...)
-			} else {
-				var err error
-				fieldProps, err = parser.parseStruct(pkgName, field)
-				if err != nil {
-					return spec.Schema{}, err
-				}
-			}
-
-			for k, v := range fieldProps {
-				properties[k] = v
-			}
-		}
-
-		// collect requireds from our properties and anonymous fields
-		required := parser.collectRequiredFields(pkgName, properties, extraRequired)
-
-		// unset required from properties because we've collected them
-		for k, prop := range properties {
-			tname := prop.SchemaProps.Type[0]
-			if tname != "object" {
-				prop.SchemaProps.Required = make([]string, 0)
-			}
-			properties[k] = prop
-		}
-
-		return spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Type:       []string{"object"},
-				Properties: properties,
-				Required:   required,
-			}}, nil
+		return parser.parseStruct(pkgName, expr.Fields)
 
 	// type Foo Baz
 	case *ast.Ident:
@@ -814,6 +709,41 @@ func (parser *Parser) parseTypeExpr(pkgName, typeName string, typeExpr ast.Expr)
 	}, nil
 }
 
+func (parser *Parser) parseStruct(pkgName string, fields *ast.FieldList) (spec.Schema, error) {
+
+	extraRequired := make([]string, 0)
+	properties := make(map[string]spec.Schema)
+	for _, field := range fields.List {
+		fieldProps, requiredFromAnon, err := parser.parseStructField(pkgName, field)
+		if err != nil {
+			return spec.Schema{}, err
+		}
+		extraRequired = append(extraRequired, requiredFromAnon...)
+		for k, v := range fieldProps {
+			properties[k] = v
+		}
+	}
+
+	// collect requireds from our properties and anonymous fields
+	required := parser.collectRequiredFields(pkgName, properties, extraRequired)
+
+	// unset required from properties because we've collected them
+	for k, prop := range properties {
+		tname := prop.SchemaProps.Type[0]
+		if tname != "object" {
+			prop.SchemaProps.Required = make([]string, 0)
+		}
+		properties[k] = prop
+	}
+
+	return spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type:       []string{"object"},
+			Properties: properties,
+			Required:   required,
+		}}, nil
+}
+
 type structField struct {
 	name         string
 	schemaType   string
@@ -831,14 +761,55 @@ type structField struct {
 	extensions   map[string]interface{}
 }
 
-func (parser *Parser) parseStruct(pkgName string, field *ast.Field) (map[string]spec.Schema, error) {
+func (parser *Parser) parseStructField(pkgName string, field *ast.Field) (map[string]spec.Schema, []string, error) {
 	properties := map[string]spec.Schema{}
+
+	if field.Names == nil {
+		fullTypeName, err := getFieldType(field.Type)
+		if err != nil {
+			return properties, []string{}, nil
+		}
+
+		typeName := fullTypeName
+
+		if splits := strings.Split(fullTypeName, "."); len(splits) > 1 {
+			pkgName = splits[0]
+			typeName = splits[1]
+		}
+
+		typeSpec := parser.TypeDefinitions[pkgName][typeName]
+		if typeSpec != nil {
+			schema, err := parser.parseTypeExpr(pkgName, typeName, typeSpec.Type)
+			if err != nil {
+				return properties, []string{}, err
+			}
+			schemaType := "unknown"
+			if len(schema.SchemaProps.Type) > 0 {
+				schemaType = schema.SchemaProps.Type[0]
+			}
+
+			switch schemaType {
+			case "object":
+				for k, v := range schema.SchemaProps.Properties {
+					properties[k] = v
+				}
+			case "array":
+				properties[typeName] = schema
+			default:
+				Printf("Can't extract properties from a schema of type '%s'", schemaType)
+			}
+			return properties, schema.SchemaProps.Required, nil
+		}
+
+		return properties, nil, nil
+	}
+
 	structField, err := parser.parseField(field)
 	if err != nil {
-		return properties, nil
+		return properties, nil, nil
 	}
 	if structField.name == "" {
-		return properties, nil
+		return properties, nil, nil
 	}
 	var desc string
 	if field.Doc != nil {
@@ -848,7 +819,6 @@ func (parser *Parser) parseStruct(pkgName string, field *ast.Field) (map[string]
 		desc = strings.TrimSpace(field.Comment.Text())
 	}
 	// TODO: find package of schemaType and/or arrayType
-
 	if structField.crossPkg != "" {
 		pkgName = structField.crossPkg
 	}
@@ -892,9 +862,9 @@ func (parser *Parser) parseStruct(pkgName string, field *ast.Field) (map[string]
 				if expr, ok := astTypeArray.Elt.(*ast.StructType); ok {
 					for _, field := range expr.Fields.List {
 						var fieldProps map[string]spec.Schema
-						fieldProps, err = parser.parseStruct(pkgName, field)
+						fieldProps, _, err = parser.parseStructField(pkgName, field)
 						if err != nil {
-							return properties, err
+							return properties, nil, err
 						}
 						for k, v := range fieldProps {
 							props[k] = v
@@ -978,9 +948,9 @@ func (parser *Parser) parseStruct(pkgName string, field *ast.Field) (map[string]
 			props := map[string]spec.Schema{}
 			nestRequired := make([]string, 0)
 			for _, v := range nestStruct.Fields.List {
-				p, err := parser.parseStruct(pkgName, v)
+				p, _, err := parser.parseStructField(pkgName, v)
 				if err != nil {
-					return properties, err
+					return properties, nil, err
 				}
 				for k, v := range p {
 					if v.SchemaProps.Type[0] != "object" {
@@ -1011,71 +981,30 @@ func (parser *Parser) parseStruct(pkgName string, field *ast.Field) (map[string]
 			}
 		}
 	}
-	return properties, nil
+	return properties, nil, nil
 }
 
-func (parser *Parser) parseAnonymousField(pkgName string, field *ast.Field) (map[string]spec.Schema, []string, error) {
-	properties := make(map[string]spec.Schema)
+func getFieldType(field interface{}) (string, error) {
 
-	fullTypeName := ""
-	switch ftype := field.Type.(type) {
+	switch ftype := field.(type) {
 	case *ast.Ident:
-		fullTypeName = ftype.Name
-	case *ast.StarExpr:
-		if ftypeX, ok := ftype.X.(*ast.Ident); ok {
-			fullTypeName = ftypeX.Name
-		} else if ftypeX, ok := ftype.X.(*ast.SelectorExpr); ok {
-			if packageX, ok := ftypeX.X.(*ast.Ident); ok {
-				fullTypeName = fmt.Sprintf("%s.%s", packageX.Name, ftypeX.Sel.Name)
-			}
-		} else {
-			Printf("Composite field type of '%T' is unhandle by parser. Skipping", ftype)
-			return properties, []string{}, nil
-		}
+		return ftype.Name, nil
+
 	case *ast.SelectorExpr:
-		packageX, ok := ftype.X.(*ast.Ident)
-		if !ok {
-			Printf("Composite field type of '%T' is unhandle by parser. Skipping", ftype)
-			return properties, []string{}, nil
-		}
-		fullTypeName = fmt.Sprintf("%s.%s", packageX.Name, ftype.Sel.Name)
-	default:
-		Printf("Field type of '%T' is unsupported. Skipping", ftype)
-		return properties, []string{}, nil
-	}
-
-	typeName := fullTypeName
-	if splits := strings.Split(fullTypeName, "."); len(splits) > 1 {
-		pkgName = splits[0]
-		typeName = splits[1]
-	}
-
-	typeSpec := parser.TypeDefinitions[pkgName][typeName]
-	if typeSpec != nil {
-		schema, err := parser.parseTypeExpr(pkgName, typeName, typeSpec.Type)
+		packageName, err := getFieldType(ftype.X)
 		if err != nil {
-			return properties, []string{}, err
+			return "", err
 		}
-		schemaType := "unknown"
-		if len(schema.SchemaProps.Type) > 0 {
-			schemaType = schema.SchemaProps.Type[0]
-		}
+		return fmt.Sprintf("%s.%s", packageName, ftype.Sel.Name), nil
 
-		switch schemaType {
-		case "object":
-			for k, v := range schema.SchemaProps.Properties {
-				properties[k] = v
-			}
-		case "array":
-			properties[typeName] = schema
-		default:
-			Printf("Can't extract properties from a schema of type '%s'", schemaType)
+	case *ast.StarExpr:
+		fullName, err := getFieldType(ftype.X)
+		if err != nil {
+			return "", err
 		}
-
-		return properties, schema.SchemaProps.Required, nil
+		return fullName, nil
 	}
-
-	return properties, nil, nil
+	return "", errors.New("unknown field type")
 }
 
 func (parser *Parser) parseField(field *ast.Field) (*structField, error) {
@@ -1083,6 +1012,7 @@ func (parser *Parser) parseField(field *ast.Field) (*structField, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if len(prop.ArrayType) == 0 {
 		if err := CheckSchemaType(prop.SchemaType); err != nil {
 			return nil, err
@@ -1092,6 +1022,7 @@ func (parser *Parser) parseField(field *ast.Field) (*structField, error) {
 			return nil, err
 		}
 	}
+
 	structField := &structField{
 		name:       field.Names[0].Name,
 		schemaType: prop.SchemaType,

--- a/parser.go
+++ b/parser.go
@@ -189,7 +189,7 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 	}
 
 	for _, comment := range fileTree.Comments {
-		if !isGeneralApiComment(comment) {
+		if !isGeneralAPIComment(comment) {
 			continue
 		}
 		comments := strings.Split(comment.Text(), "\n")
@@ -329,7 +329,7 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 	return nil
 }
 
-func isGeneralApiComment(comment *ast.CommentGroup) bool {
+func isGeneralAPIComment(comment *ast.CommentGroup) bool {
 	for _, commentLine := range strings.Split(comment.Text(), "\n") {
 		attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
 		switch attribute {
@@ -346,8 +346,8 @@ func extractSecurityAttribute(context string, search []string, lines []string) (
 	scopes := map[string]string{}
 	for _, v := range lines {
 		securityAttr := strings.ToLower(strings.Split(v, " ")[0])
-		for _, find_term := range search {
-			if securityAttr == find_term {
+		for _, findterm := range search {
+			if securityAttr == findterm {
 				attrMap[securityAttr] = strings.TrimSpace(v[len(securityAttr):])
 				continue
 			}


### PR DESCRIPTION
**Describe the PR**
code-refactoring


```
$ ~/go/bin/gocyclo -over 15 .
48 swag (*Parser).parseField parser.go:1010:1
46 swag (*Parser).ParseGeneralAPIInfo parser.go:177:1
33 swag (*Parser).parseStructField parser.go:764:1
16 swag (*Operation).parseAndExtractionParamAttribute operation.go:233:1
```

**Relation issue**
None

**Additional context**
Original [results](https://goreportcard.com/report/github.com/swaggo/swag)
```
Gocyclo calculates cyclomatic complexities of functions in Go source code. The cyclomatic complexity of a function is calculated according to the following rules: 1 is the base complexity of a function +1 for each 'if', 'for', 'case', '&&' or '||' Go Report Card warns on functions with cyclomatic complexity > 15.

swag/parser.go
Line 177: warning: cyclomatic complexity 83 of function (*Parser).ParseGeneralAPIInfo() is high (> 15) (gocyclo)
Line 1081: warning: cyclomatic complexity 48 of function (*Parser).parseField() is high (> 15) (gocyclo)
Line 834: warning: cyclomatic complexity 23 of function (*Parser).parseStruct() is high (> 15) (gocyclo)
Line 694: warning: cyclomatic complexity 22 of function (*Parser).parseTypeExpr() is high (> 15) (gocyclo)
Line 1017: warning: cyclomatic complexity 17 of function (*Parser).parseAnonymousField() is high (> 15) (gocyclo)
swag/operation.go
Line 241: warning: cyclomatic complexity 29 of function (*Operation).parseAndExtractionParamAttribute() is high (> 15) (gocyclo)
Line 60: warning: cyclomatic complexity 27 of function (*Operation).ParseComment() is high (> 15) (gocyclo)
```