### PR TITLE
Fix: Structural error ref and type cannot be sibling

### DIFF
--- a/example/basic/docs/docs.go
+++ b/example/basic/docs/docs.go
@@ -100,7 +100,6 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.Pet"
                         }
                     }

--- a/example/celler/docs/docs.go
+++ b/example/celler/docs/docs.go
@@ -104,7 +104,6 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/model.AddAccount"
                         }
                     }
@@ -261,7 +260,6 @@ var doc = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/model.UpdateAccount"
                         }
                     }

--- a/example/markdown/docs/swagger.json
+++ b/example/markdown/docs/swagger.json
@@ -59,7 +59,6 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/api.User"
                         }
                     }
@@ -103,7 +102,6 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/api.User"
                         }
                     }

--- a/operation.go
+++ b/operation.go
@@ -199,7 +199,6 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 			if err := operation.registerSchemaType(refType, astFile); err != nil {
 				return err
 			}
-			param.Schema.Type = spec.StringOrArray{objectType}
 			param.Schema.Ref = spec.Ref{
 				Ref: jsonreference.MustCreateRef("#/definitions/" + refType),
 			}

--- a/operation_test.go
+++ b/operation_test.go
@@ -431,7 +431,6 @@ func TestParseParamCommentByBodyType(t *testing.T) {
             "in": "body",
             "required": true,
             "schema": {
-                "type": "object",
                 "$ref": "#/definitions/model.OrderRow"
             }
         }

--- a/parser_test.go
+++ b/parser_test.go
@@ -378,7 +378,6 @@ func TestParseSimpleApi1(t *testing.T) {
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.Pet"
                         }
                     }
@@ -806,7 +805,6 @@ func TestParseSimpleApi1(t *testing.T) {
                     "type": "boolean"
                 },
                 "cross": {
-                    "type": "object",
                     "$ref": "#/definitions/cross.Cross"
                 },
                 "crosses": {
@@ -1005,7 +1003,6 @@ func TestParseSimpleApi_ForSnakecase(t *testing.T) {
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.Pet"
                         }
                     }
@@ -1489,7 +1486,6 @@ func TestParseSimpleApi_ForLowerCamelcase(t *testing.T) {
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.Pet"
                         }
                     }
@@ -2045,7 +2041,6 @@ func TestParseModelNotUnderRoot(t *testing.T) {
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/data.Foo"
                         }
                     }

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -57,14 +57,12 @@ var doc = `{
                     "400": {
                         "description": "We need ID!!",
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.APIError"
                         }
                     },
                     "404": {
                         "description": "Can not find ID",
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.APIError"
                         }
                     }
@@ -119,14 +117,12 @@ var doc = `{
                     "400": {
                         "description": "We need ID!!",
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.APIError"
                         }
                     },
                     "404": {
                         "description": "Can not find ID",
                         "schema": {
-                            "type": "object",
                             "$ref": "#/definitions/web.APIError"
                         }
                     }


### PR DESCRIPTION
**Describe the PR**
There's an error in Swagger JSON generated, it is because the swag generated below JSON:

```
'200':
    description: OK
        schema:
            type: object
            $ref: '#/definitions/objects.V1UserObjectResponse'
```

Above JSON will cause below error:
```
Structural error at paths./v2/users/{userId}.post.responses.200.schema
should NOT have additional properties
additionalProperty: type
Jump to line 87
```

**Relation issue**
- 

**Additional context**
-
