### PR TITLE
Fix nested struct parsing

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -563,6 +563,11 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 	schemaType := strings.Trim(matches[2], "{}")
 	refType := matches[3]
 
+	if !IsPrimitiveType(refType) && !strings.Contains(refType, ".") {
+		currentPkgName := astFile.Name.String()
+		refType = currentPkgName + "." + refType
+	}
+
 	if operation.parser != nil { // checking refType has existing in 'TypeDefinitions'
 		if err := operation.registerSchemaType(refType, astFile); err != nil {
 			return err

--- a/parser.go
+++ b/parser.go
@@ -1303,7 +1303,8 @@ func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg) error {
 		return nil
 	}
 
-	files, err := ioutil.ReadDir(pkg.SrcDir) // only parsing files in the dir(don't contains sub dir files)
+	srcDir := pkg.Raw.Dir
+	files, err := ioutil.ReadDir(srcDir) // only parsing files in the dir(don't contains sub dir files)
 	if err != nil {
 		return err
 	}
@@ -1313,7 +1314,7 @@ func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg) error {
 			continue
 		}
 
-		path := filepath.Join(pkg.SrcDir, f.Name())
+		path := filepath.Join(srcDir, f.Name())
 		if err := parser.parseFile(path); err != nil {
 			return err
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2243,6 +2243,22 @@ func TestParseComposition(t *testing.T) {
 	assert.Equal(t, string(expected), string(b))
 }
 
+func TestParseNested(t *testing.T) {
+	searchDir := "testdata/nested"
+	mainAPIFile := "main.go"
+	p := New()
+	p.ParseDependency = true
+	err := p.ParseAPI(searchDir, mainAPIFile)
+	assert.NoError(t, err)
+
+	expected, err := ioutil.ReadFile(path.Join(searchDir, "expected.json"))
+	assert.NoError(t, err)
+
+	b, _ := json.MarshalIndent(p.swagger, "", "    ")
+	Printf(string(b))
+	assert.Equal(t, string(expected), string(b))
+}
+
 func TestParser_ParseStuctArrayObject(t *testing.T) {
 	src := `
 package api

--- a/testdata/nested/api/api.go
+++ b/testdata/nested/api/api.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/swaggo/swag/testdata/nested2"
+)
+
+type Foo struct {
+	Field1      string
+	OutsideData *nested2.Body
+}
+
+// @Description get Foo
+// @ID get-foo
+// @Accept json
+// @Produce json
+// @Success 200 {object} api.Foo
+// @Router /testapi/get-foo [get]
+func GetFoo(c *gin.Context) {
+	//write your code
+	var _ = Foo{}
+}

--- a/testdata/nested/common/data.go
+++ b/testdata/nested/common/data.go
@@ -1,0 +1,5 @@
+package common
+
+type Data struct {
+	Value string `json:"message"`
+}

--- a/testdata/nested/expected.json
+++ b/testdata/nested/expected.json
@@ -1,0 +1,57 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server",
+        "title": "Swagger Example API",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {},
+        "license": {},
+        "version": "1.0"
+    },
+    "host": "petstore.swagger.io",
+    "basePath": "/v2",
+    "paths": {
+        "/testapi/get-foo": {
+            "get": {
+                "description": "get Foo",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "operationId": "get-foo",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Foo"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "api.Foo": {
+            "type": "object",
+            "properties": {
+                "field1": {
+                    "type": "string"
+                },
+                "outsideData": {
+                    "type": "object",
+                    "$ref": "#/definitions/nested2.Body"
+                }
+            }
+        },
+        "nested2.Body": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/testdata/nested/main.go
+++ b/testdata/nested/main.go
@@ -1,0 +1,20 @@
+package composition
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/swaggo/swag/testdata/nested/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server
+// @termsOfService http://swagger.io/terms/
+
+// @host petstore.swagger.io
+// @BasePath /v2
+
+func main() {
+	r := gin.New()
+	r.GET("/testapi/get-foo", api.GetFoo)
+	r.Run()
+}

--- a/testdata/nested2/data.go
+++ b/testdata/nested2/data.go
@@ -1,0 +1,5 @@
+package nested2
+
+type Body struct {
+	Value string `json:"value"`
+}


### PR DESCRIPTION
**Describe the PR**
When I use swag, I found two problems;

1. Nested structs inside can not be parsed correctly.

2. When the response struct and the API function exist in the same file, the struct can not be parsed.



**Relation issue**
https://github.com/swaggo/swag/issues/504

**Additional context**
Add any other context about the problem here.
