### PR TITLE
Correct error in checking for primitive data type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ cover.out
 
 # Etc
 .DS_Store
+
+swag
+swag.exe

--- a/operation.go
+++ b/operation.go
@@ -538,7 +538,7 @@ func findTypeDef(importPath, typeName string) (*ast.TypeSpec, error) {
 
 var responsePattern = regexp.MustCompile(`([\d]+)[\s]+([\w\{\}]+)[\s]+([\w\-\.\/]+)[^"]*(.*)?`)
 
-// ParseResponseComment parses comment for gived `response` comment string.
+// ParseResponseComment parses comment for given `response` comment string.
 func (operation *Operation) ParseResponseComment(commentLine string, astFile *ast.File) error {
 	var matches []string
 
@@ -563,7 +563,7 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 	schemaType := strings.Trim(matches[2], "{}")
 	refType := matches[3]
 
-	if !IsPrimitiveType(refType) && !strings.Contains(refType, ".") {
+	if !IsGolangPrimitiveType(refType) && !strings.Contains(refType, ".") {
 		currentPkgName := astFile.Name.String()
 		refType = currentPkgName + "." + refType
 	}


### PR DESCRIPTION
**Describe the PR**
This PR corrects the error in checking for primitive data type.

**Relation issue**
Bug introduces in https://github.com/swaggo/swag/commit/d74ed70e44450ffd5ca0016f0e78e2c569abbc45.

**Additional context**
I am seeing this error in the latest build:

```
$ swag init -g cmd/cnc.go
2019/09/11 11:35:02 Generate swagger docs....
2019/09/11 11:35:02 Generate general API Info, search dir:./
2019/09/11 11:35:02 ParseComment error in file cmd/cnc.go :can not find schema type: "cmd.int"
```