### PR TITLE
fix: router now support colon sign

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -437,7 +437,7 @@ func parseMimeTypeList(mimeTypeList string, typeList *[]string, format string) e
 	return nil
 }
 
-var routerPattern = regexp.MustCompile(`([\w\.\/\-{}\+]+)[^\[]+\[([^\]]+)`)
+var routerPattern = regexp.MustCompile(`^(/[\w\.\/\-{}\+:]+)[[:blank:]]+\[(\w+)]`)
 
 // ParseRouterComment parses comment for gived `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string) error {

--- a/operation_test.go
+++ b/operation_test.go
@@ -120,7 +120,30 @@ func TestParseRouterCommentWithPlusSign(t *testing.T) {
 	assert.Equal(t, "POST", operation.HTTPMethod)
 }
 
-func TestParseRouterCommentOccursErr(t *testing.T) {
+func TestParseRouterCommentWithColonSign(t *testing.T) {
+	comment := `/@Router /customer/get-wishlist/{wishlist_id}:move [post]`
+	operation := NewOperation()
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "/customer/get-wishlist/{wishlist_id}:move", operation.Path)
+	assert.Equal(t, "POST", operation.HTTPMethod)
+}
+
+func TestParseRouterCommentNoColonSignAtPathStartErr(t *testing.T) {
+	comment := `/@Router :customer/get-wishlist/{wishlist_id}:move [post]`
+	operation := NewOperation()
+	err := operation.ParseComment(comment, nil)
+	assert.Error(t, err)
+}
+
+func TestParseRouterCommentMethodSeparationErr(t *testing.T) {
+	comment := `/@Router /api/{id}|,*[get`
+	operation := NewOperation()
+	err := operation.ParseComment(comment, nil)
+	assert.Error(t, err)
+}
+
+func TestParseRouterCommentMethodMissingErr(t *testing.T) {
 	comment := `/@Router /customer/get-wishlist/{wishlist_id}`
 	operation := NewOperation()
 	err := operation.ParseComment(comment, nil)


### PR DESCRIPTION
Useful for custom methods using custom verbs

**Describe the PR**
Add colon sign support for router parse method.

**Relation issue**
https://github.com/swaggo/swag/issues/551

**Additional context**
Custom methods as described in the Google API design documentation (https://cloud.google.com/apis/design/custom_methods) does not work ATM. ex:
/objects:move [post]

Unit test are passing. Fix works well on my side.
Do you want me to change the commit type from "fix" to "feat"?
Is the unit test enough?

Have a good day!