### PR TITLE
routerPattern should be follow RFC3986

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -437,7 +437,7 @@ func parseMimeTypeList(mimeTypeList string, typeList *[]string, format string) e
 	return nil
 }
 
-var routerPattern = regexp.MustCompile(`^(/[\w\.\/\-{}\+:]+)[[:blank:]]+\[(\w+)]`)
+var routerPattern = regexp.MustCompile(`^(/[\w\.\/\-{}_~%]+)[[:blank:]]+\[(\w+)]`)
 
 // ParseRouterComment parses comment for gived `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string) error {


### PR DESCRIPTION
**Describe the PR**
Current `routerPattern` does not match the path specification described in RFC3986.
OpenAPI 2.0 does not say any about acceptable characters except `{` and `}` (template characters).
Therefore, `routerPattern` should accept all non-reserved characters and should not accept reserved characters described in RFC3986.

**Relation issue**
none

**Additional context**
nothing