### PR TITLE
fully support map and optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,7 +598,7 @@ generated swagger doc as follows:
 
 ```go
 type Account struct {
-    ID   int    `json:"id"   extensions:"x-nullable,x-abc=def"` // extensions fields must start with "x-"
+    ID   string    `json:"id"   extensions:"x-nullable,x-abc=def"` // extensions fields must start with "x-"
 }
 ```
 

--- a/parser.go
+++ b/parser.go
@@ -682,8 +682,6 @@ func (parser *Parser) parseTypeExpr(pkgName, typeName string, typeExpr ast.Expr)
 				},
 			},
 		}, nil
-		/*schema := parser.swagger.Definitions[refTypeName]
-		return &schema, nil*/
 
 	// type Foo *Baz
 	case *ast.StarExpr:

--- a/parser_test.go
+++ b/parser_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -254,13 +253,8 @@ func TestGetAllGoFileInfo(t *testing.T) {
 	err := p.getAllGoFileInfo(searchDir)
 
 	assert.NoError(t, err)
-	if runtime.GOOS == "windows" {
-		assert.NotEmpty(t, p.files["testdata\\pet\\main.go"])
-		assert.NotEmpty(t, p.files["testdata\\pet\\web\\handler.go"])
-	} else {
-		assert.NotEmpty(t, p.files["testdata/pet/main.go"])
-		assert.NotEmpty(t, p.files["testdata/pet/web/handler.go"])
-	}
+	assert.NotEmpty(t, p.files["testdata/pet/main.go"])
+	assert.NotEmpty(t, p.files["testdata/pet/web/handler.go"])
 	assert.Equal(t, 2, len(p.files))
 }
 

--- a/testdata/composition/expected.json
+++ b/testdata/composition/expected.json
@@ -144,12 +144,7 @@
         "api.BarMap": {
             "type": "object",
             "additionalProperties": {
-                "type": "object",
-                "properties": {
-                    "field2": {
-                        "type": "string"
-                    }
-                }
+                "$ref": "#/definitions/api.Bar"
             }
         },
         "api.Foo": {
@@ -177,7 +172,7 @@
                 "field3": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/definitions/MapValue"
+                        "$ref": "#/definitions/api.MapValue"
                     }
                 }
             }


### PR DESCRIPTION
1. optimization: parseTypeExpr return poionter to spec.Schema.
2. optimization: struct parsed as definition ref, which may decrease output size.
3. fully support map type, including map[string]interface{},map[string]primitive, also fix bug described in #581.

