### PR TITLE
feat:  migrate to using`/urfave/cli/v2` 

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -55,7 +55,7 @@ var initFlags = []cli.Flag{
 		Value: "",
 		Usage: "Parse folder containing markdown files to use as description, disabled by default",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  "generatedTime",
 		Usage: "Generate timestamp at the top of docs.go, true by default",
 	},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/swaggo/swag"
 	"github.com/swaggo/swag/gen"
-	"github.com/urfave/cli"
+	"github.com/urfave/cli/v2"
 )
 
 const (

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -78,7 +78,7 @@ func initAction(c *cli.Context) error {
 		ParseVendor:        c.Bool(parseVendorFlag),
 		ParseDependency:    c.Bool(parseDependencyFlag),
 		MarkdownFilesDir:   c.String(markdownFilesFlag),
-		GeneratedTime:      c.BoolT(generatedTimeFlag),
+		GeneratedTime:      c.Bool(generatedTimeFlag),
 	})
 }
 
@@ -86,7 +86,7 @@ func main() {
 	app := cli.NewApp()
 	app.Version = swag.Version
 	app.Usage = "Automatically generate RESTful API documentation with Swagger 2.0 for Go."
-	app.Commands = []cli.Command{
+	app.Commands = &[]cli.Command{
 		{
 			Name:    "init",
 			Aliases: []string{"i"},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -55,7 +55,7 @@ var initFlags = []cli.Flag{
 		Value: "",
 		Usage: "Parse folder containing markdown files to use as description, disabled by default",
 	},
-	cli.BoolTFlag{
+	cli.BoolFlag{
 		Name:  "generatedTime",
 		Usage: "Generate timestamp at the top of docs.go, true by default",
 	},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -55,7 +55,7 @@ var initFlags = []cli.Flag{
 		Value: "",
 		Usage: "Parse folder containing markdown files to use as description, disabled by default",
 	},
-	&cli.BoolTFlag{
+	cli.BoolTFlag{
 		Name:  "generatedTime",
 		Usage: "Generate timestamp at the top of docs.go, true by default",
 	},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -86,7 +86,7 @@ func main() {
 	app := cli.NewApp()
 	app.Version = swag.Version
 	app.Usage = "Automatically generate RESTful API documentation with Swagger 2.0 for Go."
-	app.Commands = *[]cli.Command{
+	app.Commands = []&cli.Command{
 		{
 			Name:    "init",
 			Aliases: []string{"i"},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -86,7 +86,7 @@ func main() {
 	app := cli.NewApp()
 	app.Version = swag.Version
 	app.Usage = "Automatically generate RESTful API documentation with Swagger 2.0 for Go."
-	app.Commands = &[]cli.Command{
+	app.Commands = *[]cli.Command{
 		{
 			Name:    "init",
 			Aliases: []string{"i"},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -86,7 +86,7 @@ func main() {
 	app := cli.NewApp()
 	app.Version = swag.Version
 	app.Usage = "Automatically generate RESTful API documentation with Swagger 2.0 for Go."
-	app.Commands = []&cli.Command{
+	app.Commands = []*cli.Command{
 		{
 			Name:    "init",
 			Aliases: []string{"i"},

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -22,40 +22,40 @@ const (
 )
 
 var initFlags = []cli.Flag{
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  generalInfoFlag + ", g",
 		Value: "main.go",
 		Usage: "Go file path in which 'swagger general API Info' is written",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  searchDirFlag + ", d",
 		Value: "./",
 		Usage: "Directory you want to parse",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  propertyStrategyFlag + ", p",
 		Value: "camelcase",
 		Usage: "Property Naming Strategy like snakecase,camelcase,pascalcase",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  outputFlag + ", o",
 		Value: "./docs",
 		Usage: "Output directory for all the generated files(swagger.json, swagger.yaml and doc.go)",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  parseVendorFlag,
 		Usage: "Parse go files in 'vendor' folder, disabled by default",
 	},
-	cli.BoolFlag{
+	&cli.BoolFlag{
 		Name:  parseDependencyFlag,
 		Usage: "Parse go files in outside dependency folder, disabled by default",
 	},
-	cli.StringFlag{
+	&cli.StringFlag{
 		Name:  markdownFilesFlag + ", md",
 		Value: "",
 		Usage: "Parse folder containing markdown files to use as description, disabled by default",
 	},
-	cli.BoolTFlag{
+	&cli.BoolTFlag{
 		Name:  "generatedTime",
 		Usage: "Generate timestamp at the top of docs.go, true by default",
 	},

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
 	github.com/swaggo/gin-swagger v1.2.0
-	github.com/urfave/cli v1.22.2
+	github.com/urfave/cli/v2 v2.1.1
 	golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59
 )
 

--- a/go.sum
+++ b/go.sum
@@ -97,9 +97,10 @@ github.com/ugorji/go v1.1.5-pre/go.mod h1:FwP/aQVg39TXzItUBMwnWp9T9gPQnXw4Poh4/o
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.5-pre h1:5YV9PsFAN+ndcCtTM7s60no7nY7eTG3LPtxhSwuxzCs=
 github.com/ugorji/go/codec v1.1.5-pre/go.mod h1:tULtS6Gy1AE1yCENaw4Vb//HLH5njI2tfCQDUqRd8fI=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
-github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
-github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.1.1 h1:Qt8FeAtxE/vfdrLmR3rxR6JRE0RoVmbXu8+6kZtYU4k=
+github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/net v0.0.0-20181005035420-146acd28ed58/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
**Describe the PR**
`go get -u github.com/swaggo/swag/cmd/swag` results in some errors because the `https://github.com/urfave/cli` implementation changed.

Snippet of the error message:
```
../github.com/swaggo/swag/cmd/swag/main.go:25:16: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
../github.com/swaggo/swag/cmd/swag/main.go:30:16: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
../github.com/swaggo/swag/cmd/swag/main.go:35:16: cannot use cli.StringFlag literal (type cli.StringFlag) as type cli.Flag in array or slice literal:
	cli.StringFlag does not implement cli.Flag (Apply method has pointer receiver)
```

**Additional context**
Sorry for the number of commits, I edited directly on GitHub.
