### PR TITLE
Conflicting package + struct name

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -516,7 +516,8 @@ func (parser *Parser) ParseType(astFile *ast.File) {
 					typeName := fmt.Sprintf("%v", typeSpec.Type)
 					// check if its a custom primitive type
 					if IsGolangPrimitiveType(typeName) {
-						parser.CustomPrimitiveTypes[typeSpec.Name.String()] = TransToValidSchemeType(typeName)
+						var typeSpecFullName = fmt.Sprintf("%s.%s", astFile.Name.String(), typeSpec.Name.String())
+						parser.CustomPrimitiveTypes[typeSpecFullName] = TransToValidSchemeType(typeName)
 					} else {
 						parser.TypeDefinitions[astFile.Name.String()][typeSpec.Name.String()] = typeSpec
 					}
@@ -860,7 +861,7 @@ func (parser *Parser) parseStructField(pkgName string, field *ast.Field) (map[st
 		return properties, nil, nil
 	}
 
-	structField, err := parser.parseField(field)
+	structField, err := parser.parseField(pkgName, field)
 	if err != nil {
 		return properties, nil, err
 	}
@@ -1117,8 +1118,8 @@ func getFieldType(field interface{}) (string, error) {
 	return "", fmt.Errorf("unknown field type %#v", field)
 }
 
-func (parser *Parser) parseField(field *ast.Field) (*structField, error) {
-	prop, err := getPropertyName(field.Type, parser)
+func (parser *Parser) parseField(pkgName string, field *ast.Field) (*structField, error) {
+	prop, err := getPropertyName(pkgName, field.Type, parser)
 	if err != nil {
 		return nil, err
 	}

--- a/property.go
+++ b/property.go
@@ -102,8 +102,8 @@ func getPropertyName(pkgName string, expr ast.Expr, parser *Parser) (propertyNam
 			return propertyName{SchemaType: actualPrimitiveType, ArrayType: actualPrimitiveType}, nil
 		}
 
-		schemeType := TransToValidSchemeType(name)
-		return propertyName{SchemaType: schemeType, ArrayType: schemeType}, nil
+		name = TransToValidSchemeType(name)
+		return propertyName{SchemaType: name, ArrayType: name}, nil
 	default:
 		return propertyName{}, errors.New("not supported" + fmt.Sprint(expr))
 	}

--- a/property.go
+++ b/property.go
@@ -120,15 +120,19 @@ func getArrayPropertyName(pkgName string, astTypeArrayElt ast.Expr, parser *Pars
 	case *ast.SelectorExpr:
 		return parseFieldSelectorExpr(elt, parser, newArrayProperty)
 	case *ast.Ident:
-		name := TransToValidSchemeType(elt.Name)
+		name := elt.Name
 		if actualPrimitiveType, isCustomType := parser.CustomPrimitiveTypes[pkgName+"."+name]; isCustomType {
 			name = actualPrimitiveType
+		} else {
+			name = TransToValidSchemeType(elt.Name)
 		}
 		return propertyName{SchemaType: "array", ArrayType: name}
 	default:
-		name := TransToValidSchemeType(fmt.Sprintf("%s", astTypeArrayElt))
+		name := fmt.Sprintf("%s", astTypeArrayElt)
 		if actualPrimitiveType, isCustomType := parser.CustomPrimitiveTypes[pkgName+"."+name]; isCustomType {
 			name = actualPrimitiveType
+		} else {
+			name = TransToValidSchemeType(name)
 		}
 		return propertyName{SchemaType: "array", ArrayType: name}
 	}

--- a/property_test.go
+++ b/property_test.go
@@ -25,7 +25,7 @@ func TestGetPropertyNameSelectorExpr(t *testing.T) {
 		"string",
 		"",
 	}
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -49,7 +49,7 @@ func TestGetPropertyNameIdentObjectId(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -73,7 +73,7 @@ func TestGetPropertyNameIdentUUID(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -96,7 +96,7 @@ func TestGetPropertyNameIdentDecimal(t *testing.T) {
 		"string",
 		"",
 	}
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -120,7 +120,7 @@ func TestGetPropertyNameIdentTime(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, nil)
+	propertyName, err := getPropertyName("test", input, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -140,7 +140,7 @@ func TestGetPropertyNameStarExprIdent(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -168,7 +168,7 @@ func TestGetPropertyNameStarExprMap(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -187,10 +187,10 @@ func TestGetPropertyNameArrayStarExpr(t *testing.T) {
 	}
 	expected := propertyName{
 		"array",
-		"string",
+		"test.string",
 		"",
 	}
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -220,7 +220,7 @@ func TestGetPropertyNameArrayStarExprSelector(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -237,7 +237,7 @@ func TestGetPropertyNameArrayStructType(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -257,7 +257,7 @@ func TestGetPropertyNameMap(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -270,7 +270,7 @@ func TestGetPropertyNameStruct(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
@@ -283,14 +283,14 @@ func TestGetPropertyNameInterface(t *testing.T) {
 		"",
 	}
 
-	propertyName, err := getPropertyName(input, New())
+	propertyName, err := getPropertyName("test", input, New())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, propertyName)
 }
 
 func TestGetPropertyNameChannel(t *testing.T) {
 	input := &ast.ChanType{}
-	_, err := getPropertyName(input, New())
+	_, err := getPropertyName("test", input, New())
 	assert.Error(t, err)
 }
 

--- a/property_test.go
+++ b/property_test.go
@@ -187,7 +187,7 @@ func TestGetPropertyNameArrayStarExpr(t *testing.T) {
 	}
 	expected := propertyName{
 		"array",
-		"test.string",
+		"string",
 		"",
 	}
 	propertyName, err := getPropertyName("test", input, New())


### PR DESCRIPTION
**Describe the PR**
If code uses two packages that contains types with same name, swag generate wrong json/yaml. This PR fixes this.

**Relation issue**
Fixes #225 

**Additional context**
This changes need testing on bigger swag files.
