### PR TITLE
Support colletionFormat for array params in query; Exclude directories and files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ import "github.com/swaggo/files" // swagger embed files
 
 // @host localhost:8080
 // @BasePath /api/v1
+// @query.collection.format multi
 
 // @securityDefinitions.basic BasicAuth
 
@@ -327,6 +328,7 @@ $ swag init
 | license.url  | A URL to the license used for the API. MUST be in the format of a URL.                       | // @license.url http://www.apache.org/licenses/LICENSE-2.0.html |
 | host        | The host (name or ip) serving the API.     | // @host localhost:8080         |
 | BasePath    | The base path on which the API is served. | // @BasePath /api/v1             |
+| query.collection.format | The default collection(array) param format in query,enums:csv,multi,pipes,tsv,ssv. If not set, csv is the default.| // @query.collection.format multi
 | schemes     | The transfer protocol for the operation that separated by spaces. | // @schemes http https |
 | x-name      | The extension key, must be start by x- and take only json value | // @x-example-key {"key": "value"} |
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Swag converts Go annotations to Swagger Documentation 2.0. We've created a varie
 	- [Example value of struct](#example-value-of-struct)
 	- [Description of struct](#description-of-struct)
 	- [Use swaggertype tag to supported custom type](#use-swaggertype-tag-to-supported-custom-type)
+	- [Use swaggerignore tag to exclude a field](#use-swaggerignore-tag-to-exclude-a-field)
 	- [Add extension info to struct field](#add-extension-info-to-struct-field)
+	- [Rename model to display](#rename-model-to-display)
 	- [How to using security annotations](#how-to-using-security-annotations)
 - [About the Project](#about-the-project)
 
@@ -594,6 +596,17 @@ generated swagger doc as follows:
   }
 }
 
+```
+
+
+### Use swaggerignore tag to exclude a field
+
+```go
+type Account struct {
+    ID   string    `json:"id"`
+    Name string     `json:"name"`
+    Ignored int     `swaggerignore:"true"`
+}
 ```
 
 ### Add extension info to struct field

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Field Name | Type | Description
 <a name="parameterMinLength"></a>minLength | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.
 <a name="parameterEnums"></a>enums | [\*] | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
 <a name="parameterFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](https://swagger.io/specification/v2/#dataTypeFormat) for further details.
-<a name="parameterCollectionFormat"></a>collectionFormat | `string` | Can only be used in @Param comment. Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
+<a name="parameterCollectionFormat"></a>collectionFormat | `string` |Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
 
 ### Future
 

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 // @Param string query string false "string valid" minlength(5) maxlength(10)
 // @Param int query int false "int valid" mininum(1) maxinum(10)
 // @Param default query string false "string default" default(A)
+// @Param collection query []string false "string collection" collectionFormat(multi)
 ```
 
 It also works for the struct fields:
@@ -461,6 +462,7 @@ Field Name | Type | Description
 <a name="parameterMinLength"></a>minLength | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.2.2.
 <a name="parameterEnums"></a>enums | [\*] | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.5.1.
 <a name="parameterFormat"></a>format | `string` | The extending format for the previously mentioned [`type`](#parameterType). See [Data Type Formats](https://swagger.io/specification/v2/#dataTypeFormat) for further details.
+<a name="parameterCollectionFormat"></a>collectionFormat | `string` | Can only be used in @Param comment. Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
 
 ### Future
 
@@ -471,7 +473,6 @@ Field Name | Type | Description
 <a name="parameterMaxItems"></a>maxItems | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.2.
 <a name="parameterMinItems"></a>minItems | `integer` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.3.
 <a name="parameterUniqueItems"></a>uniqueItems | `boolean` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.3.4.
-<a name="parameterCollectionFormat"></a>collectionFormat | `string` | Determines the format of the array if type array is used. Possible values are: <ul><li>`csv` - comma separated values `foo,bar`. <li>`ssv` - space separated values `foo bar`. <li>`tsv` - tab separated values `foo\tbar`. <li>`pipes` - pipe separated values <code>foo&#124;bar</code>. <li>`multi` - corresponds to multiple parameter instances instead of multiple values for a single instance `foo=bar&foo=baz`. This is valid only for parameters [`in`](#parameterIn) "query" or "formData". </ul> Default value is `csv`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ USAGE:
 OPTIONS:
    --generalInfo value, -g value       Go file path in which 'swagger general API Info' is written (default: "main.go")
    --dir value, -d value               Directory you want to parse (default: "./")
+   --exclude value                     Exclude directoies and files, comma separated
    --propertyStrategy value, -p value  Property Naming Strategy like snakecase,camelcase,pascalcase (default: "camelcase")
    --output value, -o value            Output directory for all the generated files(swagger.json, swagger.yaml and doc.go) (default: "./docs")
    --parseVendor                       Parse go files in 'vendor' folder, disabled by default

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	searchDirFlag        = "dir"
+	excludeFlag          = "exclude"
 	generalInfoFlag      = "generalInfo"
 	propertyStrategyFlag = "propertyStrategy"
 	outputFlag           = "output"
@@ -31,6 +32,10 @@ var initFlags = []cli.Flag{
 		Name:  searchDirFlag + ", d",
 		Value: "./",
 		Usage: "Directory you want to parse",
+	},
+	&cli.StringFlag{
+		Name:  excludeFlag,
+		Usage: "exclude directories and files when searching, comma separated",
 	},
 	&cli.StringFlag{
 		Name:  propertyStrategyFlag + ", p",
@@ -72,6 +77,7 @@ func initAction(c *cli.Context) error {
 
 	return gen.New().Build(&gen.Config{
 		SearchDir:          c.String(searchDirFlag),
+		Excludes:           c.String(excludeFlag),
 		MainAPIFile:        c.String(generalInfoFlag),
 		PropNamingStrategy: strategy,
 		OutputDir:          c.String(outputFlag),

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -39,6 +39,9 @@ type Config struct {
 	// SearchDir the swag would be parse
 	SearchDir string
 
+	// excludes dirs and files in SearchDir,comma separated
+	Excludes string
+
 	// OutputDir represents the output directory for all the generated files
 	OutputDir string
 
@@ -68,7 +71,8 @@ func (g *Gen) Build(config *Config) error {
 	}
 
 	log.Println("Generate swagger docs....")
-	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir))
+	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
+		swag.SetExcludedDirsAndFiles(config.Excludes))
 	p.PropNamingStrategy = config.PropNamingStrategy
 	p.ParseVendor = config.ParseVendor
 	p.ParseDependency = config.ParseDependency

--- a/operation.go
+++ b/operation.go
@@ -152,7 +152,9 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 		objectType = "array"
 		refType = strings.TrimPrefix(refType, "[]")
 		refType = TransToValidSchemeType(refType)
-		collectionFormat = TransToValidCollectionFormat(operation.parser.collectionFormatInQuery)
+		if operation.parser != nil {
+			collectionFormat = TransToValidCollectionFormat(operation.parser.collectionFormatInQuery)
+		}
 	} else if pos := strings.IndexRune(refType, ']'); pos > 0 && strings.HasPrefix(refType, "[") { //for example: [csv]int
 		objectType = "array"
 		collectionFormat = TransToValidCollectionFormat(refType[1:pos])

--- a/operation_test.go
+++ b/operation_test.go
@@ -441,7 +441,7 @@ func TestParseParamCommentQueryArray(t *testing.T) {
 
 // Test ParseParamComment Query Params
 func TestParseParamCommentQueryArrayFormat(t *testing.T) {
-	comment := `@Param names query [multi]string true "Users List"`
+	comment := `@Param names query []string true "Users List" collectionFormat(multi)`
 	operation := NewOperation()
 	err := operation.ParseComment(comment, nil)
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -2,7 +2,6 @@ package swag
 
 import (
 	"encoding/json"
-	"fmt"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -448,7 +447,6 @@ func TestParseParamCommentQueryArrayFormat(t *testing.T) {
 
 	assert.NoError(t, err)
 	b, _ := json.MarshalIndent(operation, "", "    ")
-	fmt.Println(string(b))
 	expected := `{
     "parameters": [
         {

--- a/operation_test.go
+++ b/operation_test.go
@@ -2,6 +2,7 @@ package swag
 
 import (
 	"encoding/json"
+	"fmt"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -429,6 +430,33 @@ func TestParseParamCommentQueryArray(t *testing.T) {
             "items": {
                 "type": "string"
             },
+            "description": "Users List",
+            "name": "names",
+            "in": "query",
+            "required": true
+        }
+    ]
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+// Test ParseParamComment Query Params
+func TestParseParamCommentQueryArrayFormat(t *testing.T) {
+	comment := `@Param names query [multi]string true "Users List"`
+	operation := NewOperation()
+	err := operation.ParseComment(comment, nil)
+
+	assert.NoError(t, err)
+	b, _ := json.MarshalIndent(operation, "", "    ")
+	fmt.Println(string(b))
+	expected := `{
+    "parameters": [
+        {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "collectionFormat": "multi",
             "description": "Users List",
             "name": "names",
             "in": "query",

--- a/parser.go
+++ b/parser.go
@@ -113,6 +113,7 @@ func SetMarkdownFileDirectory(directoryPath string) func(*Parser) {
 	}
 }
 
+// SetExcludedDirsAndFiles sets directories and files to be excluded when searching
 func SetExcludedDirsAndFiles(excludes string) func(*Parser) {
 	return func(p *Parser) {
 		for _, f := range strings.Split(excludes, ",") {

--- a/parser.go
+++ b/parser.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -126,7 +125,7 @@ func (parser *Parser) ParseAPI(searchDir string, mainAPIFile string) error {
 	}
 
 	if parser.ParseDependency {
-		pkgName, err := getPkgName(path.Dir(absMainAPIFilePath))
+		pkgName, err := getPkgName(filepath.Dir(absMainAPIFilePath))
 		if err != nil {
 			return err
 		}
@@ -1478,22 +1477,14 @@ func (parser *Parser) parseFile(path string) error {
 
 // Skip returns filepath.SkipDir error if match vendor and hidden folder
 func (parser *Parser) Skip(path string, f os.FileInfo) error {
-
-	if !parser.ParseVendor { // ignore vendor
-		if f.IsDir() && f.Name() == "vendor" {
+	if f.IsDir() {
+		if !parser.ParseVendor && f.Name() == "vendor" || //ignore "vendor"
+			f.Name() == "docs" || //exclude docs
+			len(f.Name()) > 1 && f.Name()[0] == '.' { // exclude all hidden folder
 			return filepath.SkipDir
 		}
 	}
 
-	// issue
-	if f.IsDir() && f.Name() == "docs" {
-		return filepath.SkipDir
-	}
-
-	// exclude all hidden folder
-	if f.IsDir() && len(f.Name()) > 1 && f.Name()[0] == '.' {
-		return filepath.SkipDir
-	}
 	return nil
 }
 

--- a/parser.go
+++ b/parser.go
@@ -1172,6 +1172,12 @@ func (parser *Parser) parseField(pkgName string, field *ast.Field) (*structField
 	}
 	// `json:"tag"` -> json:"tag"
 	structTag := reflect.StructTag(strings.Replace(field.Tag.Value, "`", "", -1))
+
+	if ignoreTag := structTag.Get("swaggerignore"); ignoreTag == "true" {
+		structField.name = ""
+		return structField, nil
+	}
+
 	jsonTag := structTag.Get("json")
 	// json:"tag,hoge"
 	if strings.Contains(jsonTag, ",") {
@@ -1184,6 +1190,7 @@ func (parser *Parser) parseField(pkgName string, field *ast.Field) (*structField
 	}
 	if jsonTag == "-" {
 		structField.name = ""
+		return structField, nil
 	} else if jsonTag != "" {
 		structField.name = jsonTag
 	}

--- a/parser.go
+++ b/parser.go
@@ -67,6 +67,9 @@ type Parser struct {
 
 	// markdownFileDir holds the path to the folder, where markdown files are stored
 	markdownFileDir string
+
+	// collectionFormatInQuery set the default collectionFormat other thn 'csv' for array in query params
+	collectionFormatInQuery string
 }
 
 // New creates a new Parser with default properties.
@@ -299,7 +302,8 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 					return err
 				}
 				securityMap[value] = securitySchemeOAuth2AccessToken(attrMap["@authorizationurl"], attrMap["@tokenurl"], scopes)
-
+			case "@query.collection.format":
+				parser.collectionFormatInQuery = value
 			default:
 				prefixExtension := "@x-"
 				if len(attribute) > 5 { // Prefix extension + 1 char + 1 space  + 1 char

--- a/parser.go
+++ b/parser.go
@@ -67,7 +67,7 @@ type Parser struct {
 	// markdownFileDir holds the path to the folder, where markdown files are stored
 	markdownFileDir string
 
-	// collectionFormatInQuery set the default collectionFormat other thn 'csv' for array in query params
+	// collectionFormatInQuery set the default collectionFormat otherwise then 'csv' for array in query params
 	collectionFormatInQuery string
 }
 

--- a/schema.go
+++ b/schema.go
@@ -84,6 +84,16 @@ func IsGolangPrimitiveType(typeName string) bool {
 	}
 }
 
+// TransToValidCollectionFormat determine valid collection format
+func TransToValidCollectionFormat(format string) string {
+	switch format {
+	case "csv", "multi", "pipes", "tsv", "ssv":
+		return format
+	default:
+		return ""
+	}
+}
+
 // TypeDocName get alias from comment '// @name ', otherwise the original type name to display in doc
 func TypeDocName(pkgName string, spec *ast.TypeSpec) string {
 	if spec != nil {


### PR DESCRIPTION
**Describe the PR**
feature: support collectionFormat for array params in query.
feature: use  flag -exclude to exclude directories and files when searching APIs.
Fix bug: can't find dependent packages when running on windows and both --dir and --parseDependency are set.

**Relation issue**
#636 #640
