### PR TITLE
Support response model composition 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Swag converts Go annotations to Swagger Documentation 2.0. We've created a varie
  - [Examples](#examples)
 	- [Descriptions over multiple lines](#descriptions-over-multiple-lines)
 	- [User defined structure with an array type](#user-defined-structure-with-an-array-type)
+	- [Model composition in response](#model-composition-in-response)
 	- [Add a headers in response](#add-a-headers-in-response) 
 	- [Use multiple path params](#use-multiple-path-params)
 	- [Example value of struct](#example-value-of-struct)

--- a/README.md
+++ b/README.md
@@ -496,6 +496,32 @@ type Account struct {
     Name string `json:"name" example:"account name"`
 }
 ```
+
+### Model composition in response
+```go
+@success 200 {object} jsonresult.JSONResult{data=proto.Order} "desc"
+```
+
+```go
+type JSONResult struct {
+	Code    int          `json:"code" `
+	Message string       `json:"message"`
+	Data    interface{}  `json:"data"`
+}
+
+type Order struct { //in `proto` package
+	...
+}
+```
+
+- also support array of objects and primitive types as nested response
+```go
+@success 200 {object} jsonresult.JSONResult{data=[]proto.Order} "desc"
+@success 200 {object} jsonresult.JSONResult{data=string} "desc"
+@success 200 {object} jsonresult.JSONResult{data=[]string} "desc"
+```
+
+
 ### Add a headers in response
 
 ```go

--- a/operation.go
+++ b/operation.go
@@ -663,7 +663,7 @@ func (nested *nestedField) fillNestedSchema(response *spec.Response, ref spec.Re
 			Properties: props,
 		},
 	}
-	response.Schema.AllOf = []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}, nestedSpec}
+	response.Schema.AllOf = []spec.Schema{{SchemaProps: spec.SchemaProps{Ref: ref}}, nestedSpec}
 }
 
 var nestedObjectPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)=([^\[\]]*)\}$`)

--- a/operation.go
+++ b/operation.go
@@ -647,7 +647,7 @@ func (nested *nestedField) getSchema() *spec.Schema {
 	return &spec.Schema{SchemaProps: spec.SchemaProps{Ref: nested.Ref}}
 }
 
-func (nested *nestedField) fillNestedSchema(response spec.Response, ref spec.Ref) {
+func (nested *nestedField) fillNestedSchema(response *spec.Response, ref spec.Ref) {
 	props := make(map[string]spec.Schema, 0)
 	if nested.IsArray {
 		props[nested.Name] = spec.Schema{SchemaProps: spec.SchemaProps{
@@ -663,9 +663,7 @@ func (nested *nestedField) fillNestedSchema(response spec.Response, ref spec.Ref
 			Properties: props,
 		},
 	}
-	response.Schema.AllOf = make([]spec.Schema, 0)
-	response.Schema.AllOf = append(response.Schema.AllOf, spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}})
-	response.Schema.AllOf = append(response.Schema.AllOf, nestedSpec)
+	response.Schema.AllOf = []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}},nestedSpec}
 }
 
 var nestedObjectPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)=([^\[\]]*)\}$`)
@@ -748,7 +746,7 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 		if nested == nil {
 			response.Schema.Ref = ref
 		} else {
-			nested.fillNestedSchema(response, ref)
+			nested.fillNestedSchema(&response, ref)
 		}
 
 	} else if schemaType == "array" {

--- a/operation.go
+++ b/operation.go
@@ -663,7 +663,7 @@ func (nested *nestedField) fillNestedSchema(response *spec.Response, ref spec.Re
 			Properties: props,
 		},
 	}
-	response.Schema.AllOf = []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}},nestedSpec}
+	response.Schema.AllOf = []spec.Schema{spec.Schema{SchemaProps: spec.SchemaProps{Ref: ref}}, nestedSpec}
 }
 
 var nestedObjectPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)=([^\[\]]*)\}$`)

--- a/operation_test.go
+++ b/operation_test.go
@@ -188,6 +188,180 @@ func TestParseResponseCommentWithObjectType(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseResponseCommentWithNestedPrimitiveType(t *testing.T) {
+	comment := `@Success 200 {object} model.CommonHeader{data=string} "Error message, if code != 200`
+	operation := NewOperation()
+	operation.parser = New()
+
+	operation.parser.TypeDefinitions["model"] = make(map[string]*ast.TypeSpec)
+	operation.parser.TypeDefinitions["model"]["CommonHeader"] = &ast.TypeSpec{}
+
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+
+	response := operation.Responses.StatusCodeResponses[200]
+	assert.Equal(t, `Error message, if code != 200`, response.Description)
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "Error message, if code != 200",
+            "schema": {
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/model.CommonHeader"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+
+func TestParseResponseCommentWithNestedPrimitiveArrayType(t *testing.T) {
+	comment := `@Success 200 {object} model.CommonHeader{data=[]string} "Error message, if code != 200`
+	operation := NewOperation()
+	operation.parser = New()
+
+	operation.parser.TypeDefinitions["model"] = make(map[string]*ast.TypeSpec)
+	operation.parser.TypeDefinitions["model"]["CommonHeader"] = &ast.TypeSpec{}
+
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+
+	response := operation.Responses.StatusCodeResponses[200]
+	assert.Equal(t, `Error message, if code != 200`, response.Description)
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "Error message, if code != 200",
+            "schema": {
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/model.CommonHeader"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+
+func TestParseResponseCommentWithNestedObjectType(t *testing.T) {
+	comment := `@Success 200 {object} model.CommonHeader{data=model.Payload} "Error message, if code != 200`
+	operation := NewOperation()
+	operation.parser = New()
+
+	operation.parser.TypeDefinitions["model"] = make(map[string]*ast.TypeSpec)
+	operation.parser.TypeDefinitions["model"]["CommonHeader"] = &ast.TypeSpec{}
+	operation.parser.TypeDefinitions["model"]["Payload"] = &ast.TypeSpec{}
+
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+
+	response := operation.Responses.StatusCodeResponses[200]
+	assert.Equal(t, `Error message, if code != 200`, response.Description)
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "Error message, if code != 200",
+            "schema": {
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/model.CommonHeader"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "$ref": "#/definitions/model.Payload"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+func TestParseResponseCommentWithNestedArrayObjectType(t *testing.T) {
+	comment := `@Success 200 {object} model.CommonHeader{data=[]model.Payload} "Error message, if code != 200`
+	operation := NewOperation()
+	operation.parser = New()
+
+	operation.parser.TypeDefinitions["model"] = make(map[string]*ast.TypeSpec)
+	operation.parser.TypeDefinitions["model"]["CommonHeader"] = &ast.TypeSpec{}
+	operation.parser.TypeDefinitions["model"]["Payload"] = &ast.TypeSpec{}
+
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+
+	response := operation.Responses.StatusCodeResponses[200]
+	assert.Equal(t, `Error message, if code != 200`, response.Description)
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "Error message, if code != 200",
+            "schema": {
+                "allOf": [
+                    {
+                        "$ref": "#/definitions/model.CommonHeader"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "data": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/model.Payload"
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseResponseCommentWithObjectTypeInSameFile(t *testing.T) {
 	comment := `@Success 200 {object} testOwner "Error message, if code != 200"`
 	operation := NewOperation()

--- a/operation_test.go
+++ b/operation_test.go
@@ -229,7 +229,6 @@ func TestParseResponseCommentWithNestedPrimitiveType(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
-
 func TestParseResponseCommentWithNestedPrimitiveArrayType(t *testing.T) {
 	comment := `@Success 200 {object} model.CommonHeader{data=[]string} "Error message, if code != 200`
 	operation := NewOperation()
@@ -273,7 +272,6 @@ func TestParseResponseCommentWithNestedPrimitiveArrayType(t *testing.T) {
 }`
 	assert.Equal(t, expected, string(b))
 }
-
 
 func TestParseResponseCommentWithNestedObjectType(t *testing.T) {
 	comment := `@Success 200 {object} model.CommonHeader{data=model.Payload} "Error message, if code != 200`


### PR DESCRIPTION
**Describe the PR**
Add support for inheritance/Model Composition in Response with allOf and ref.

syntax:
```go
// @success 200 {object} jsonresult.JSONResult{data=proto.Order} "desc"
// @success 200 {object} jsonresult.JSONResult{data=[]proto.Order} "desc"
// @success 200 {object} jsonresult.JSONResult{data=string} "desc"
// @success 200 {object} jsonresult.JSONResult{data=[]string} "desc"
```

please see generated result in testcases of this PR.

**Relation issue**
https://github.com/swaggo/swag/issues/650

