### PR TITLE
Override fields in response, enhancement of PR #651

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ type Account struct {
 
 ### Model composition in response
 ```go
+// JSONResult's data field will be overridden by the specific type proto.Order
 @success 200 {object} jsonresult.JSONResult{data=proto.Order} "desc"
 ```
 
@@ -526,6 +527,10 @@ type Order struct { //in `proto` package
 @success 200 {object} jsonresult.JSONResult{data=[]string} "desc"
 ```
 
+- overriding multiple fields. field will be added if not exists 
+```go
+@success 200 {object} jsonresult.JSONResult{data1=string,data2=[]string,data3=proto.Order,data4=[]proto.Order} "desc"
+```
 
 ### Add a headers in response
 

--- a/operation.go
+++ b/operation.go
@@ -630,7 +630,7 @@ func findTypeDef(importPath, typeName string) (*ast.TypeSpec, error) {
 	return nil, fmt.Errorf("type spec not found")
 }
 
-var responsePattern = regexp.MustCompile(`([\d]+)[\s]+([\w\{\}]+)[\s]+([\w\-\.\/\{\}=\[\]]+)[^"]*(.*)?`)
+var responsePattern = regexp.MustCompile(`([\d]+)[\s]+([\w\{\}]+)[\s]+([\w\-\.\/\{\}=,\[\]]+)[^"]*(.*)?`)
 
 type nestedField struct {
 	Name    string
@@ -640,57 +640,45 @@ type nestedField struct {
 }
 
 func (nested *nestedField) getSchema() *spec.Schema {
-	if IsGolangPrimitiveType(nested.Type) {
+	if IsPrimitiveType(nested.Type) {
 		return &spec.Schema{SchemaProps: spec.SchemaProps{Type: []string{nested.Type}}}
 	}
 
 	return &spec.Schema{SchemaProps: spec.SchemaProps{Ref: nested.Ref}}
 }
 
-func (nested *nestedField) fillNestedSchema(response *spec.Response, ref spec.Ref) {
-	props := make(map[string]spec.Schema, 0)
-	if nested.IsArray {
-		props[nested.Name] = spec.Schema{SchemaProps: spec.SchemaProps{
-			Type:  []string{"array"},
-			Items: &spec.SchemaOrArray{Schema: nested.getSchema()},
-		}}
-	} else {
-		props[nested.Name] = *nested.getSchema()
-	}
-	nestedSpec := spec.Schema{
-		SchemaProps: spec.SchemaProps{
-			Type:       []string{"object"},
-			Properties: props,
-		},
-	}
-	response.Schema.AllOf = []spec.Schema{{SchemaProps: spec.SchemaProps{Ref: ref}}, nestedSpec}
-}
+var nestedPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)\}$`)
+var nestedObjectPattern = regexp.MustCompile(`^(.*)=(.*)$`)
 
-var nestedObjectPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)=([^\[\]]*)\}$`)
-var nestedArrayPattern = regexp.MustCompile(`^([\w\-\.\/]+)\{(.*)=\[\]([^\[\]]*)\}$`)
-
-func (operation *Operation) tryExtractNestedField(specStr string, astFile *ast.File) (refType string, nested *nestedField, err error) {
-	if matches := nestedObjectPattern.FindStringSubmatch(specStr); len(matches) == 4 {
-		refType, nested = matches[1], &nestedField{Name: matches[2], Type: matches[3], IsArray: false}
-	} else if matches := nestedArrayPattern.FindStringSubmatch(specStr); len(matches) == 4 {
-		refType, nested = matches[1], &nestedField{Name: matches[2], Type: matches[3], IsArray: true}
-	} else {
+func (operation *Operation) tryExtractNestedFields(specStr string, astFile *ast.File) (refType string, nestedFields []*nestedField, err error) {
+	if matches := nestedPattern.FindStringSubmatch(specStr); len(matches) != 3 {
 		return specStr, nil, nil
-	}
+	} else {
+		refType = matches[1]
+		fields := strings.Split(matches[2], ",")
+		for _, field := range fields {
+			if matches := nestedObjectPattern.FindStringSubmatch(field); len(matches) == 3 {
+				nested := &nestedField{Name: matches[1], Type: matches[2], IsArray: strings.HasPrefix(matches[2], "[]")}
+				if nested.IsArray {
+					nested.Type = nested.Type[2:]
+				}
+				nested.Type = TransToValidSchemeType(nested.Type)
+				if !IsPrimitiveType(nested.Type) {
+					if operation.parser != nil { // checking refType has existing in 'TypeDefinitions'
+						refType, typeSpec, err := operation.registerSchemaType(nested.Type, astFile)
+						if err != nil {
+							return specStr, nil, err
+						}
 
-	if !IsGolangPrimitiveType(nested.Type) {
-		if operation.parser != nil { // checking refType has existing in 'TypeDefinitions'
-			refType, typeSpec, err := operation.registerSchemaType(nested.Type, astFile)
-			if err != nil {
-				return specStr, nil, err
-			}
-
-			nested.Ref = spec.Ref{
-				Ref: jsonreference.MustCreateRef("#/definitions/" + TypeDocName(refType, typeSpec)),
+						nested.Ref = spec.Ref{
+							Ref: jsonreference.MustCreateRef("#/definitions/" + TypeDocName(refType, typeSpec)),
+						}
+					}
+				}
+				nestedFields = append(nestedFields, nested)
 			}
 		}
 	}
-
 	return
 }
 
@@ -719,7 +707,7 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 	schemaType := strings.Trim(matches[2], "{}")
 	refType := matches[3]
 
-	refType, nested, err := operation.tryExtractNestedField(refType, astFile)
+	refType, nestedFields, err := operation.tryExtractNestedFields(refType, astFile)
 	if err != nil {
 		return err
 	}
@@ -743,10 +731,27 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 			Ref: jsonreference.MustCreateRef("#/definitions/" + TypeDocName(refType, typeSpec)),
 		}
 
-		if nested == nil {
+		if nestedFields == nil {
 			response.Schema.Ref = ref
 		} else {
-			nested.fillNestedSchema(&response, ref)
+			props := make(map[string]spec.Schema)
+			for _, nested := range nestedFields {
+				if nested.IsArray {
+					props[nested.Name] = spec.Schema{SchemaProps: spec.SchemaProps{
+						Type:  []string{"array"},
+						Items: &spec.SchemaOrArray{Schema: nested.getSchema()},
+					}}
+				} else {
+					props[nested.Name] = *nested.getSchema()
+				}
+			}
+			nestedSpec := spec.Schema{
+				SchemaProps: spec.SchemaProps{
+					Type:       []string{"object"},
+					Properties: props,
+				},
+			}
+			response.Schema.AllOf = []spec.Schema{{SchemaProps: spec.SchemaProps{Ref: ref}}, nestedSpec}
 		}
 
 	} else if schemaType == "array" {


### PR DESCRIPTION
Describe the PR
fix bug: int,int32,int64, etc. are not replaced with integer in output docs, PR by #651
feature: support multiple fields overriding.

Relation issue
#650
#651
