### PR TITLE
[FIX] parse comment error integer to string

### DIFF
--- a/example/celler/controller/examples.go
+++ b/example/celler/controller/examples.go
@@ -33,7 +33,7 @@ func (c *Controller) PingExample(ctx *gin.Context) {
 // @Produce json
 // @Param val1 query int true "used for calc"
 // @Param val2 query int true "used for calc"
-// @Success 200 {integer} integer "answer"
+// @Success 200 {integer} string "answer"
 // @Failure 400 {string} string "ok"
 // @Failure 404 {string} string "ok"
 // @Failure 500 {string} string "ok"


### PR DESCRIPTION
**Describe the PR**

fixed this error
```
ParseComment error in file controller/examples.go :can not find schema type: "controller.integer"
```

**Relation issue**
#659

**Additional context**
n
