### PR TITLE
Fix issue with generating docs for embedded structures with alias instead of package name

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -880,12 +880,8 @@ func (parser *Parser) parseStructField(pkgName string, field *ast.Field) (map[st
 
 			switch schemaType {
 			case "object":
-				if len(schema.SchemaProps.Properties) > 0 {
-					for k, v := range schema.SchemaProps.Properties {
-						properties[k] = v
-					}
-				} else if schema.AdditionalProperties != nil {
-					properties[typeName] = *schema
+				for k, v := range schema.SchemaProps.Properties {
+					properties[k] = v
 				}
 			case "array":
 				properties[typeName] = *schema

--- a/parser.go
+++ b/parser.go
@@ -859,6 +859,17 @@ func (parser *Parser) parseStructField(pkgName string, field *ast.Field) (map[st
 		}
 
 		typeSpec := parser.TypeDefinitions[pkgName][typeName]
+		if typeSpec == nil {
+			// Check if the pkg name is an alias and try to define type spec using real package name
+			if aliases, ok := parser.ImportAliases[pkgName]; ok {
+				for alias := range aliases {
+					typeSpec = parser.TypeDefinitions[alias][typeName]
+					if typeSpec != nil {
+						break
+					}
+				}
+			}
+		}
 		if typeSpec != nil {
 			schema, err := parser.parseTypeExpr(pkgName, typeName, typeSpec.Type)
 			if err != nil {

--- a/testdata/alias_import/data/applicationresponse.go
+++ b/testdata/alias_import/data/applicationresponse.go
@@ -5,6 +5,8 @@ import (
 )
 
 type ApplicationResponse struct {
+	typesapplication.TypeToEmbed
+
 	Application      typesapplication.Application   `json:"application"`
 	ApplicationArray []typesapplication.Application `json:"application_array"`
 	ApplicationTime  typesapplication.DateOnly      `json:"application_time"`

--- a/testdata/alias_import/expected.json
+++ b/testdata/alias_import/expected.json
@@ -56,6 +56,9 @@
                 },
                 "application_time": {
                     "type": "string"
+                },
+                "embedded": {
+                    "type": "string"
                 }
             }
         },

--- a/testdata/alias_import/types/application.go
+++ b/testdata/alias_import/types/application.go
@@ -7,3 +7,7 @@ type Application struct {
 }
 
 type DateOnly time.Time
+
+type TypeToEmbed struct {
+	Embedded string
+}


### PR DESCRIPTION
**Issue**

For example, there's a package `github.com/user/repo/common` which contains type `Common`:

```go
package common

type Common struct {
    ID int `json:"id"
}
```

If we embed this type in another struct but use an alias instead of the real package name, **swag** will generate wrong documentation:

```go
package main

import (
    c "github.com/user/repo/common"
)

type Response struct {
    c.Common
    Name string `json:"name"
} 
```
Generated documentation:

```json
{
    "definitions": {
        "main.Response": {
            "type": "object",
            "properties": {
                "name": {
                    "type": "string"
                }
            }
        }
    }
}
```

**Solution**

We can suppose that `pkgName` is a package alias, if [`typeSpec`](https://github.com/swaggo/swag/compare/master...ShoshinNikita:master#diff-f615844d3497ff38db57e459d6ef657bR861) is `nil`. So, we can just iterate through import aliases and check can we get non-nil `typeSpec`