### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Dockerfile References: https://docs.docker.com/engine/reference/builder/
+
+# Start from the latest golang base image
+FROM golang:1.14-alpine as builder
+
+# Set the Current Working Directory inside the container
+WORKDIR /app
+
+# Copy go mod and sum files
+COPY go.mod go.sum ./
+
+# Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
+RUN go mod download
+
+# Copy the source from the current directory to the Working Directory inside the container
+COPY . .
+
+# Build the Go app
+RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o swag cmd/swag/main.go
+
+
+######## Start a new stage from scratch #######
+FROM scratch
+
+WORKDIR /root/
+
+# Copy the Pre-built binary file from the previous stage
+COPY --from=builder /app/swag .
+


### PR DESCRIPTION
**Describe the PR**

I provided a Dockerfile that enables us to use a precompiled swag-binary in Dockerfiles for Swagger-Doc generation Automation.

**Relation issue**
No issue.

**Additional context**
I've built an [image](https://hub.docker.com/r/itinance/swag) and pushed it to DockerHub. Now we can use it like this in a Dockerfile:

`COPY --from=itinance/swag /root/swag /usr/local/bin`
