### PR TITLE
issue-665: fix example when using `json=",string"`

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -3111,3 +3111,96 @@ func Fun()  {
 	ref = path.Get.Responses.ResponsesProps.StatusCodeResponses[200].ResponseProps.Schema.Ref
 	assert.Equal(t, "#/definitions/Teacher", ref.String())
 }
+
+func TestParseJSONFieldString(t *testing.T) {
+	expected := `{
+    "swagger": "2.0",
+    "info": {
+        "description": "This is a sample server.",
+        "title": "Swagger Example API",
+        "contact": {},
+        "license": {},
+        "version": "1.0"
+    },
+    "host": "localhost:4000",
+    "basePath": "/",
+    "paths": {
+        "/do-something": {
+            "post": {
+                "description": "Does something",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Call DoSomething",
+                "parameters": [
+                    {
+                        "description": "My Struct",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/main.MyStruct"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.MyStruct"
+                        }
+                    },
+                    "500": {}
+                }
+            }
+        }
+    },
+    "definitions": {
+        "main.MyStruct": {
+            "type": "object",
+            "properties": {
+                "boolvar": {
+                    "description": "boolean as a string",
+                    "type": "string",
+                    "example": "false"
+                },
+                "floatvar": {
+                    "description": "float as a string",
+                    "type": "string",
+                    "example": "0"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64",
+                    "example": 1
+                },
+                "myint": {
+                    "description": "integer as string",
+                    "type": "string",
+                    "example": "0"
+                },
+                "name": {
+                    "type": "string",
+                    "example": "poti"
+                },
+                "truebool": {
+                    "description": "boolean as a string",
+                    "type": "string",
+                    "example": "true"
+                }
+            }
+        }
+    }
+}`
+
+	searchDir := "testdata/json_field_string"
+	mainAPIFile := "main.go"
+	p := New()
+	err := p.ParseAPI(searchDir, mainAPIFile)
+	assert.NoError(t, err)
+	b, _ := json.MarshalIndent(p.swagger, "", "    ")
+	assert.Equal(t, expected, string(b))
+}

--- a/testdata/json_field_string/main.go
+++ b/testdata/json_field_string/main.go
@@ -1,39 +1,43 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
 type MyStruct struct {
-	ID int `json:"id" example:"1" format:"int64"`
-	// Post name
-	Name string `json:"name" example:"poti"`
-	// Post data
-	Data struct {
-		// Post tag
-		Tag []string `json:"name"`
-	} `json:"data"`
-	// Integer represented by a string
-	MyInt int `json:"myint,string"`
+	ID       int     `json:"id" example:"1" format:"int64"`
+	Name     string  `json:"name" example:"poti"`
+	Intvar   int     `json:"myint,string"`                   // integer as string
+	Boolvar  bool    `json:",string"`                        // boolean as a string
+	TrueBool bool    `json:"truebool,string" example:"true"` // boolean as a string
+	Floatvar float64 `json:",string"`                        // float as a string
 }
 
 // @Summary Call DoSomething
-// @Description Does something, but internal (non-exported) fields inside a struct won't be marshaled into JSON
+// @Description Does something
 // @Accept  json
 // @Produce  json
-// @Success 200 {string} MyStruct
-// @Router /so-something [get]
+// @Param body body MyStruct true "My Struct"
+// @Success 200 {object} MyStruct
+// @Failure 500
+// @Router /do-something [post]
 func DoSomething(c *gin.Context) {
-	//write your code
+	objectFromJSON := new(MyStruct)
+	if err := c.BindJSON(&objectFromJSON); err != nil {
+		c.AbortWithError(http.StatusInternalServerError, err)
+	}
+	c.JSON(http.StatusOK, objectFromJSON)
 }
 
 // @title Swagger Example API
 // @version 1.0
 // @description This is a sample server.
 // @host localhost:4000
-// @basePath /api
+// @basePath /
 func main() {
 	r := gin.New()
-	r.GET("/do-something", api.DoSomething)
+	r.POST("/do-something", DoSomething)
 	r.Run()
 }


### PR DESCRIPTION
**Describe the PR**
Fix the json example when a struct field has the `json:",string"` tag.

**Relation issue**
https://github.com/swaggo/swag/issues/665

**Additional context**
encoding/json states:

> The "string" option signals that a field is stored as JSON inside a JSON-encoded string. It applies only to fields of string, floating point, integer, or boolean types. This extra level of encoding is sometimes used when communicating with JavaScript programs:

---

Before this fix, the provided example would fail json.Unmarshal:
![Screenshot_20200414_215316](https://user-images.githubusercontent.com/5046551/79289418-8f760e00-7e9f-11ea-9d58-15c1d15b3463.png)

After fix:
![Screenshot_20200414_215541](https://user-images.githubusercontent.com/5046551/79289481-baf8f880-7e9f-11ea-888b-583fbe9235ea.png)



