### PR TITLE
Add absent "deprecated" annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ When a short string in your documentation is insufficient, or you need images, c
 | header      | Header in response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                            |
 | router      | Path definition that separated by spaces. `path`,`[httpMethod]`                                                            |
 | x-name      | The extension key, must be start by x- and take only json value.                                                           |
+| deprecated  | Mark endpoint as deprecated.                                                                                               |
 
 
 


### PR DESCRIPTION
## Describe the PR

There is `@deprecated` annotation which was not documented. I just added it to the readme.

## Additional context

https://github.com/swaggo/swag/blob/67cb0975876f155725732d1aeb87fb8310e6aaf9/operation.go#L98-L99
