### PR TITLE
fix x-logo vendor extension

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -102,6 +102,9 @@ func New(options ...func(*Parser)) *Parser {
 						Contact: &spec.ContactInfo{},
 						License: &spec.License{},
 					},
+					VendorExtensible: spec.VendorExtensible{
+						Extensions: spec.Extensions{},
+					},
 				},
 				Paths: &spec.Paths{
 					Paths: make(map[string]spec.PathItem),
@@ -358,7 +361,12 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 						if err := json.Unmarshal([]byte(split[1]), &valueJSON); err != nil {
 							return fmt.Errorf("annotation %s need a valid json value", attribute)
 						}
-						parser.swagger.AddExtension(extensionName, valueJSON)
+
+						if strings.Contains(extensionName, "logo") {
+							parser.swagger.Info.Extensions.Add(extensionName, valueJSON)
+						} else {
+							parser.swagger.AddExtension(extensionName, valueJSON)
+						}
 					}
 				}
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -37,7 +37,12 @@ func TestParser_ParseGeneralApiInfo(t *testing.T) {
             "name": "Apache 2.0",
             "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "1.0"
+        "version": "1.0",
+        "x-logo": {
+            "altText": "Petstore logo",
+            "backgroundColor": "#FFFFFF",
+            "url": "https://redocly.github.io/redoc/petstore-logo.png"
+        }
     },
     "host": "petstore.swagger.io",
     "basePath": "/v2",

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -45,5 +45,6 @@ package main
 
 // @x-google-endpoints [{"name":"name.endpoints.environment.cloud.goog","allowCors":true}]
 // @x-google-marks "marks values"
+// @x-logo {"url":"https://redocly.github.io/redoc/petstore-logo.png", "altText": "Petstore logo", "backgroundColor": "#FFFFFF"}
 
 func main() {}


### PR DESCRIPTION
**Describe the PR**
the x-logo vendor extension must reside inside the info element. 

**Relation issue**
none

**Additional context**
I just used the existing vendor extension parsing logic to achieve that.
