### PR TITLE
Fix typos in maximum/minimum attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 // @Param enumint query int false "int enums" Enums(1, 2, 3)
 // @Param enumnumber query number false "int enums" Enums(1.1, 1.2, 1.3)
 // @Param string query string false "string valid" minlength(5) maxlength(10)
-// @Param int query int false "int valid" mininum(1) maxinum(10)
+// @Param int query int false "int valid" minimum(1) maximum(10)
 // @Param default query string false "string default" default(A)
 // @Param collection query []string false "string collection" collectionFormat(multi)
 ```

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -434,7 +434,7 @@ Example [celler/controller](https://github.com/swaggo/swag/tree/master/example/c
 // @Param enumint query int false "int enums" Enums(1, 2, 3)
 // @Param enumnumber query number false "int enums" Enums(1.1, 1.2, 1.3)
 // @Param string query string false "string valid" minlength(5) maxlength(10)
-// @Param int query int false "int valid" mininum(1) maxinum(10)
+// @Param int query int false "int valid" minimum(1) maximum(10)
 // @Param default query string false "string default" default(A)
 // @Param collection query []string false "string collection" collectionFormat(multi)
 ```

--- a/example/celler/controller/examples.go
+++ b/example/celler/controller/examples.go
@@ -123,7 +123,7 @@ func (c *Controller) SecuritiesExample(ctx *gin.Context) {
 // @Param enumint query int false "int enums" Enums(1, 2, 3)
 // @Param enumnumber query number false "int enums" Enums(1.1, 1.2, 1.3)
 // @Param string query string false "string valid" minlength(5) maxlength(10)
-// @Param int query int false "int valid" mininum(1) maxinum(10)
+// @Param int query int false "int valid" minimum(1) maximum(10)
 // @Param default query string false "string default" default(A)
 // @Success 200 {string} string "answer"
 // @Failure 400 {string} string "ok"

--- a/operation.go
+++ b/operation.go
@@ -274,11 +274,13 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 var regexAttributes = map[string]*regexp.Regexp{
 	// for Enums(A, B)
 	"enums": regexp.MustCompile(`(?i)\s+enums\(.*\)`),
-	// for Minimum(0)
+	// for maximum(0)
 	"maxinum": regexp.MustCompile(`(?i)\s+maxinum\(.*\)`),
-	// for Maximum(0)
+	"maximum": regexp.MustCompile(`(?i)\s+maximum\(.*\)`),
+	// for minimum(0)
 	"mininum": regexp.MustCompile(`(?i)\s+mininum\(.*\)`),
-	// for Maximum(0)
+	"minimum": regexp.MustCompile(`(?i)\s+minimum\(.*\)`),
+	// for default(0)
 	"default": regexp.MustCompile(`(?i)\s+default\(.*\)`),
 	// for minlength(0)
 	"minlength": regexp.MustCompile(`(?i)\s+minlength\(.*\)`),
@@ -303,13 +305,13 @@ func (operation *Operation) parseAndExtractionParamAttribute(commentLine, object
 			if err != nil {
 				return err
 			}
-		case "maxinum":
+		case "maxinum", "maximum":
 			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
 				return err
 			}
 			param.Maximum = &n
-		case "mininum":
+		case "mininum", "minimum":
 			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
 				return err

--- a/operation.go
+++ b/operation.go
@@ -275,11 +275,9 @@ var regexAttributes = map[string]*regexp.Regexp{
 	// for Enums(A, B)
 	"enums": regexp.MustCompile(`(?i)\s+enums\(.*\)`),
 	// for maximum(0)
-	"maxinum": regexp.MustCompile(`(?i)\s+maxinum\(.*\)`),
-	"maximum": regexp.MustCompile(`(?i)\s+maximum\(.*\)`),
+	"maximum": regexp.MustCompile(`(?i)\s+maxinum|maximum\(.*\)`),
 	// for minimum(0)
-	"mininum": regexp.MustCompile(`(?i)\s+mininum\(.*\)`),
-	"minimum": regexp.MustCompile(`(?i)\s+minimum\(.*\)`),
+	"minimum": regexp.MustCompile(`(?i)\s+mininum|minimum\(.*\)`),
 	// for default(0)
 	"default": regexp.MustCompile(`(?i)\s+default\(.*\)`),
 	// for minlength(0)
@@ -305,13 +303,13 @@ func (operation *Operation) parseAndExtractionParamAttribute(commentLine, object
 			if err != nil {
 				return err
 			}
-		case "maxinum", "maximum":
+		case "maximum":
 			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
 				return err
 			}
 			param.Maximum = &n
-		case "mininum", "minimum":
+		case "minimum":
 			n, err := setNumberParam(attrKey, schemaType, attr, commentLine)
 			if err != nil {
 				return err

--- a/operation_test.go
+++ b/operation_test.go
@@ -1268,8 +1268,8 @@ func TestParseParamCommentByMinLength(t *testing.T) {
 	assert.Error(t, operation.ParseComment(comment, nil))
 }
 
-func TestParseParamCommentByMininum(t *testing.T) {
-	comment := `@Param some_id query int true "Some ID" Mininum(10)`
+func TestParseParamCommentByMinimum(t *testing.T) {
+	comment := `@Param some_id query int true "Some ID" Minimum(10)`
 	operation := NewOperation(nil)
 	err := operation.ParseComment(comment, nil)
 
@@ -1289,15 +1289,18 @@ func TestParseParamCommentByMininum(t *testing.T) {
 }`
 	assert.Equal(t, expected, string(b))
 
-	comment = `@Param some_id query string true "Some ID" Mininum(10)`
+	comment = `@Param some_id query int true "Some ID" Mininum(10)`
+	assert.NoError(t, operation.ParseComment(comment, nil))
+
+	comment = `@Param some_id query string true "Some ID" Minimum(10)`
 	assert.Error(t, operation.ParseComment(comment, nil))
 
-	comment = `@Param some_id query integer true "Some ID" Mininum(Goopher)`
+	comment = `@Param some_id query integer true "Some ID" Minimum(Goopher)`
 	assert.Error(t, operation.ParseComment(comment, nil))
 }
 
-func TestParseParamCommentByMaxinum(t *testing.T) {
-	comment := `@Param some_id query int true "Some ID" Maxinum(10)`
+func TestParseParamCommentByMaximum(t *testing.T) {
+	comment := `@Param some_id query int true "Some ID" Maximum(10)`
 	operation := NewOperation(nil)
 	err := operation.ParseComment(comment, nil)
 
@@ -1317,10 +1320,13 @@ func TestParseParamCommentByMaxinum(t *testing.T) {
 }`
 	assert.Equal(t, expected, string(b))
 
-	comment = `@Param some_id query string true "Some ID" Maxinum(10)`
+	comment = `@Param some_id query int true "Some ID" Maxinum(10)`
+	assert.NoError(t, operation.ParseComment(comment, nil))
+
+	comment = `@Param some_id query string true "Some ID" Maximum(10)`
 	assert.Error(t, operation.ParseComment(comment, nil))
 
-	comment = `@Param some_id query integer true "Some ID" Maxinum(Goopher)`
+	comment = `@Param some_id query integer true "Some ID" Maximum(Goopher)`
 	assert.Error(t, operation.ParseComment(comment, nil))
 
 }

--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -26,8 +26,8 @@ func GetStringByInt(c *gin.Context) {
 // @Produce  json
 // @Param some_id path string true "Some ID"
 // @Param category query int true "Category" Enums(1, 2, 3)
-// @Param offset query int true "Offset" Mininum(0) default(0)
-// @Param limit query int true "Limit" Maxinum(50) default(10)
+// @Param offset query int true "Offset" Minimum(0) default(0)
+// @Param limit query int true "Limit" Maximum(50) default(10)
 // @Param q query string true "q" Minlength(1) Maxlength(50) default("")
 // @Success 200 {string} string	"ok"
 // @Failure 400 {object} web.APIError "We need ID!!"

--- a/testdata/simple2/api/api.go
+++ b/testdata/simple2/api/api.go
@@ -25,8 +25,8 @@ func GetStringByInt(c *gin.Context) {
 // @Produce  json
 // @Param some_id path string true "Some ID"
 // @Param category query int true "Category" Enums(1, 2, 3)
-// @Param offset query int true "Offset" Mininum(0) default(0)
-// @Param limit query int true "Limit" Maxinum(50) default(10)
+// @Param offset query int true "Offset" Minimum(0) default(0)
+// @Param limit query int true "Limit" Maximum(50) default(10)
 // @Param q query string true "q" Minlength(1) Maxlength(50) default("")
 // @Success 200 {string} string	"ok"
 // @Failure 400 {object} web.APIError "We need ID!!"

--- a/testdata/simple3/api/api.go
+++ b/testdata/simple3/api/api.go
@@ -25,8 +25,8 @@ func GetStringByInt(c *gin.Context) {
 // @Produce  json
 // @Param some_id path string true "Some ID"
 // @Param category query int true "Category" Enums(1, 2, 3)
-// @Param offset query int true "Offset" Mininum(0) default(0)
-// @Param limit query int true "Limit" Maxinum(50) default(10)
+// @Param offset query int true "Offset" Minimum(0) default(0)
+// @Param limit query int true "Limit" Maximum(50) default(10)
 // @Param q query string true "q" Minlength(1) Maxlength(50) default("")
 // @Success 200 {string} string	"ok"
 // @Failure 400 {object} web.APIError "We need ID!!"


### PR DESCRIPTION
Fixes "maximum" needing to be "maxinum" to work, and "minimum" needing to be "mininum" to work.

Retains support for the old field names and adds tests to ensure the old names continue to work.

**Relation issue**
Fixes https://github.com/swaggo/swag/issues/761