### PR TITLE
fix: don't generate license field if it's empty

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -100,7 +100,7 @@ func New(options ...func(*Parser)) *Parser {
 				Info: &spec.Info{
 					InfoProps: spec.InfoProps{
 						Contact: &spec.ContactInfo{},
-						License: &spec.License{},
+						License: nil,
 					},
 				},
 				Paths: &spec.Paths{
@@ -221,6 +221,14 @@ func getPkgName(searchDir string) (string, error) {
 	return outStr, nil
 }
 
+func initIfEmpty(license *spec.License) *spec.License {
+	if license == nil {
+		return new(spec.License)
+	}
+
+	return license
+}
+
 // ParseGeneralAPIInfo parses general api info for given mainAPIFile path
 func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 	fileSet := token.NewFileSet()
@@ -272,8 +280,10 @@ func (parser *Parser) ParseGeneralAPIInfo(mainAPIFile string) error {
 			case "@contact.url":
 				parser.swagger.Info.Contact.URL = value
 			case "@license.name":
+				parser.swagger.Info.License = initIfEmpty(parser.swagger.Info.License)
 				parser.swagger.Info.License.Name = value
 			case "@license.url":
+				parser.swagger.Info.License = initIfEmpty(parser.swagger.Info.License)
 				parser.swagger.Info.License.URL = value
 			case "@host":
 				parser.swagger.Host = value

--- a/parser_test.go
+++ b/parser_test.go
@@ -224,7 +224,6 @@ func TestParser_ParseGeneralApiInfoWithOpsInSameFile(t *testing.T) {
         "title": "Swagger Example API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "paths": {}
@@ -1236,7 +1235,6 @@ func TestParseStructComment(t *testing.T) {
         "description": "This is a sample server Petstore server.",
         "title": "Swagger Example API",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "localhost:4000",
@@ -1325,7 +1323,6 @@ func TestParseNonExportedJSONFields(t *testing.T) {
         "description": "This is a sample server.",
         "title": "Swagger Example API",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "localhost:4000",
@@ -2234,8 +2231,7 @@ func Fun()  {
 `
 	expected := `{
     "info": {
-        "contact": {},
-        "license": {}
+        "contact": {}
     },
     "paths": {
         "/test": {
@@ -2330,7 +2326,6 @@ func TestParseJSONFieldString(t *testing.T) {
         "description": "This is a sample server.",
         "title": "Swagger Example API",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "localhost:4000",

--- a/testdata/composition/expected.json
+++ b/testdata/composition/expected.json
@@ -5,7 +5,6 @@
         "title": "Swagger Example API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "petstore.swagger.io",

--- a/testdata/conflict_name/expected.json
+++ b/testdata/conflict_name/expected.json
@@ -4,7 +4,6 @@
         "description": "test for conflict name",
         "title": "Swag test",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "paths": {

--- a/testdata/nested/expected.json
+++ b/testdata/nested/expected.json
@@ -5,7 +5,6 @@
         "title": "Swagger Example API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {},
-        "license": {},
         "version": "1.0"
     },
     "host": "petstore.swagger.io",


### PR DESCRIPTION
**Describe the PR**
Avoid generate license field with empty content in generated YAML and JSON files when running `swag init`

**Relation issue**
Intended to resolve #767

**Additional context**
Let me know if you need any additional info
