### PR TITLE
feat: generate formData params via go struct

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -167,12 +167,12 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 	param := createParameter(paramType, description, name, refType, required)
 
 	switch paramType {
-	case "path", "header", "formData":
+	case "path", "header":
 		switch objectType {
 		case ARRAY, OBJECT:
 			return fmt.Errorf("%s is not supported type for %s", refType, paramType)
 		}
-	case "query":
+	case "query", "formData":
 		switch objectType {
 		case ARRAY:
 			if !IsPrimitiveType(refType) {


### PR DESCRIPTION
**Describe the PR**
Allow generate params for formData by using go struct.

**Relation issue**
Intended to resolve https://github.com/swaggo/swag/issues/300

**Additional context**
`go test` passed even if I didn't change anything related to the unit test, it seems the old test doesn't cover this case. I didn't add any extra test cases for this PR since I'm not sure about how to write unit test for this case. Hope that's okay.

btw if this PR can get merged, the documentation may also need to update.