### PR TITLE
feat: add defaultRequired support

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -22,6 +22,7 @@ const (
 	parseInternalFlag    = "parseInternal"
 	generatedTimeFlag    = "generatedTime"
 	parseDepthFlag       = "parseDepth"
+	defaultRequiredFlag  = "defaultRequired"
 )
 
 var initFlags = []cli.Flag{
@@ -80,6 +81,10 @@ var initFlags = []cli.Flag{
 		Value: 100,
 		Usage: "Dependency parse depth",
 	},
+	&cli.BoolFlag{
+		Name:  defaultRequiredFlag,
+		Usage: "Add required to the field by default",
+	},
 }
 
 func initAction(c *cli.Context) error {
@@ -103,6 +108,7 @@ func initAction(c *cli.Context) error {
 		ParseInternal:      c.Bool(parseInternalFlag),
 		GeneratedTime:      c.Bool(generatedTimeFlag),
 		ParseDepth:         c.Int(parseDepthFlag),
+		DefaultRequired:    c.Bool(defaultRequiredFlag),
 	})
 }
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -68,6 +68,9 @@ type Config struct {
 
 	// ParseDepth dependency parse depth
 	ParseDepth int
+
+	// Add required to the field by default
+	DefaultRequired bool
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json
@@ -83,6 +86,7 @@ func (g *Gen) Build(config *Config) error {
 	p.ParseVendor = config.ParseVendor
 	p.ParseDependency = config.ParseDependency
 	p.ParseInternal = config.ParseInternal
+	p.DefaultRequired = config.DefaultRequired
 
 	if err := p.ParseAPI(config.SearchDir, config.MainAPIFile, config.ParseDepth); err != nil {
 		return err


### PR DESCRIPTION
**Describe the PR**
add defaultRequired support

**Additional context**

90% of the request fields of our API are required，100% of response fields in our API are required.
Each field add `validate:"required` is easy to miss.
