### PR TITLE
Ignore swag file from root dir only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ cover.out
 # Etc
 .DS_Store
 
-./swag
-./swag.exe
+/swag
+/swag.exe

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ cover.out
 # Etc
 .DS_Store
 
-swag
-swag.exe
+./swag
+./swag.exe


### PR DESCRIPTION
**Describe the PR**
The `.gitignore` rule `swag` matches not only file in main directory but also folder in `cmd/swag`.
I've changed it to match only in current folder. For visual I've changed also `swag.exe`.

**Additional context**
I've run into the issue when I tried to vendor sources for swag but also for tool. The `main.go` got ignored by git, I've forced git to add it with `git add -f vendor/github.com/swaggo/swag/cmd/swag/main.go`

https://git-scm.com/docs/gitignore#_pattern_format
> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.

