### PR TITLE
Add ability to set 'swaggerignore' on embedded fields

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -845,6 +845,13 @@ func (sf *structField) toStandardSchema() *spec.Schema {
 
 func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[string]spec.Schema, []string, error) {
 	if field.Names == nil {
+		if field.Tag != nil {
+			skip, ok := reflect.StructTag(strings.ReplaceAll(field.Tag.Value, "`", "")).Lookup("swaggerignore")
+			if ok && strings.EqualFold(skip, "true") {
+				return nil, nil, nil
+			}
+		}
+
 		typeName, err := getFieldType(field.Type)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
**Describe the PR**
This PR adds ability to set `swaggerignore:"true"` on embedded fields.

**Relation issue**
https://github.com/swaggo/swag/issues/632 

**Additional context**
Currently `swaggerignore` supports only ignoring named fields, while in some cases it is also useful to be able to ignore embedded fields.
