### PR TITLE
fix: honor x-order while sorting query parameters

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -247,13 +247,17 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 				}
 				return false
 			}
-			orderedNames := make([]string, 0, len(schema.Properties))
-			for k := range schema.Properties {
-				orderedNames = append(orderedNames, k)
+			items := make(spec.OrderSchemaItems, 0, len(schema.Properties))
+			for k, v := range schema.Properties {
+				items = append(items, spec.OrderSchemaItem{
+					Name:   k,
+					Schema: v,
+				})
 			}
-			sort.Strings(orderedNames)
-			for _, name := range orderedNames {
-				prop := schema.Properties[name]
+			sort.Sort(items)
+			for _, item := range items {
+				name := item.Name
+				prop := item.Schema
 				if len(prop.Type) == 0 {
 					continue
 				}


### PR DESCRIPTION
**Describe the PR**
Instead of always sorting parameters with name, which can surprise users
because x-order is ignored, sort them with the slice type declared in
github.com/go-openapi/spec to reuse its comparison method.

**Relation issue**
https://github.com/swaggo/swag/pull/681

**Additional context**
It can be simplified if https://github.com/go-openapi/spec/pull/117 is merged.