### PR TITLE
feature: support default response, use comma-separated codes to add a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ import (
 // @Param id path int true "Account ID"
 // @Success 200 {object} model.Account
 // @Header 200 {string} Token "qwerty"
-// @Failure 400 {object} httputil.HTTPError
-// @Failure 404 {object} httputil.HTTPError
+// @Failure 400,404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
+// @Failure default {object} httputil.DefaultError
 // @Router /accounts/{id} [get]
 func (c *Controller) ShowAccount(ctx *gin.Context) {
 	id := ctx.Param("id")
@@ -272,9 +272,9 @@ func (c *Controller) ShowAccount(ctx *gin.Context) {
 // @Param q query string false "name search by q"
 // @Success 200 {array} model.Account
 // @Header 200 {string} Token "qwerty"
-// @Failure 400 {object} httputil.HTTPError
-// @Failure 404 {object} httputil.HTTPError
+// @Failure 400,404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
+// @Failure default {object} httputil.DefaultError
 // @Router /accounts [get]
 func (c *Controller) ListAccounts(ctx *gin.Context) {
 	q := ctx.Request.URL.Query().Get("q")
@@ -375,8 +375,9 @@ When a short string in your documentation is insufficient, or you need images, c
 | produce     | A list of MIME types the APIs can produce. Value MUST be as described under [Mime Types](#mime-types).                     |
 | param       | Parameters that separated by spaces. `param name`,`param type`,`data type`,`is mandatory?`,`comment` `attribute(optional)` |
 | security    | [Security](#security) to each API operation.                                                                               |
-| success     | Success response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
-| failure     | Failure response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                              |
+| success     | Success response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                   |
+| failure     | Failure response that separated by spaces. `return code or default`,`{param type}`,`data type`,`comment`                    |
+| response    | As same as `success` and `failure` |
 | header      | Header in response that separated by spaces. `return code`,`{param type}`,`data type`,`comment`                            |
 | router      | Path definition that separated by spaces. `path`,`[httpMethod]`                                                            |
 | x-name      | The extension key, must be start by x- and take only json value.                                                           |
@@ -557,8 +558,11 @@ type DeepObject struct { //in `proto` package
 
 ```go
 // @Success 200 {string} string	"ok"
+// @failure 400 {string} string	"error"
+// @response default {string} string	"other error"
 // @Header 200 {string} Location "/entity/1"
-// @Header 200 {string} Token "qwerty"
+// @Header 200,400,default {string} Token "token"
+// @Header all {string} Token2 "token2"
 ```
 
 ### Use multiple path params

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -241,9 +241,9 @@ import (
 // @Param id path int true "Account ID"
 // @Success 200 {object} model.Account
 // @Header 200 {string} Token "qwerty"
-// @Failure 400 {object} httputil.HTTPError
-// @Failure 404 {object} httputil.HTTPError
+// @Failure 400,404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
+// @Failure default {object} httputil.DefaultError
 // @Router /accounts/{id} [get]
 func (c *Controller) ShowAccount(ctx *gin.Context) {
     id := ctx.Param("id")
@@ -268,9 +268,9 @@ func (c *Controller) ShowAccount(ctx *gin.Context) {
 // @Param q query string false "name search by q"
 // @Success 200 {array} model.Account
 // @Header 200 {string} Token "qwerty"
-// @Failure 400 {object} httputil.HTTPError
-// @Failure 404 {object} httputil.HTTPError
+// @Failure 400,404 {object} httputil.HTTPError
 // @Failure 500 {object} httputil.HTTPError
+// @Failure default {object} httputil.DefaultError
 // @Router /accounts [get]
 func (c *Controller) ListAccounts(ctx *gin.Context) {
     q := ctx.Request.URL.Query().Get("q")
@@ -369,6 +369,7 @@ Example [celler/controller](https://github.com/swaggo/swag/tree/master/example/c
 | security             | 每个API操作的[安全性](#security)。                                                                      |
 | success              | 以空格分隔的成功响应。`return code`,`{param type}`,`data type`,`comment`                                |
 | failure              | 以空格分隔的故障响应。`return code`,`{param type}`,`data type`,`comment`                                |
+| response             | 与success、failure作用相同                                                                               |
 | header               | 以空格分隔的头字段。 `return code`,`{param type}`,`data type`,`comment`                                 |
 | router               | 以空格分隔的路径定义。 `path`,`[httpMethod]`                                                            |
 | x-name               | 扩展字段必须以`x-`开头，并且只能使用json值。                                                            |
@@ -536,8 +537,11 @@ type Order struct { //in `proto` package
 
 ```go
 // @Success 200 {string} string	"ok"
+// @failure 400 {string} string	"error"
+// @response default {string} string	"other error"
 // @Header 200 {string} Location "/entity/1"
-// @Header 200 {string} Token "qwerty"
+// @Header 200,400,default {string} Token "token"
+// @Header all {string} Token2 "token2"
 ```
 
 ### 使用多路径参数

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -356,10 +356,10 @@ swag init
 
 Example [celler/controller](https://github.com/swaggo/swag/tree/master/example/celler/controller)
 
-| 注释                 | 描述                                                                                                    |                                                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| 注释                 | 描述                                                                                                    |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
 | description          | 操作行为的详细说明。                                                                                    |
-| description.markdown | 应用程序的简短描述。该描述将从名为`endpointname.md`的文件中读取。                                       | // @description.file endpoint.description.markdown |
+| description.markdown | 应用程序的简短描述。该描述将从名为`endpointname.md`的文件中读取。                                       |
 | id                   | 用于标识操作的唯一字符串。在所有API操作中必须唯一。                                                     |
 | tags                 | 每个API操作的标签列表，以逗号分隔。                                                                     |
 | summary              | 该操作的简短摘要。                                                                                      |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-openapi/spec v0.19.14
-	github.com/go-openapi/swag v0.19.11 // indirect
 	github.com/go-playground/validator/v10 v10.4.1 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.3 // indirect

--- a/operation.go
+++ b/operation.go
@@ -764,7 +764,7 @@ func (operation *Operation) ParseResponseComment(commentLine string, astFile *as
 				ResponseProps: spec.ResponseProps{Schema: schema, Description: responseDescription},
 			})
 		} else {
-			return fmt.Errorf("unrecognized reponse code in: %s", commentLine)
+			return fmt.Errorf("can not parse response comment \"%s\"", commentLine)
 		}
 	}
 
@@ -825,7 +825,7 @@ func (operation *Operation) ParseResponseHeaderComment(commentLine string, astFi
 				}
 			}
 		} else {
-			return fmt.Errorf("unrecognized reponse code in: %s", commentLine)
+			return fmt.Errorf("can not parse response comment \"%s\"", commentLine)
 		}
 	}
 
@@ -851,7 +851,7 @@ func (operation *Operation) ParseEmptyResponseComment(commentLine string) error 
 			response.Description = responseDescription
 			operation.AddResponse(code, &response)
 		} else {
-			return fmt.Errorf("unrecognized reponse code in: %s", commentLine)
+			return fmt.Errorf("can not parse response comment \"%s\"", commentLine)
 		}
 	}
 
@@ -868,7 +868,7 @@ func (operation *Operation) ParseEmptyResponseOnly(commentLine string) error {
 			//response.Description = http.StatusText(code)
 			operation.AddResponse(code, &response)
 		} else {
-			return fmt.Errorf("unrecognized reponse code in: %s", commentLine)
+			return fmt.Errorf("can not parse response comment \"%s\"", commentLine)
 		}
 	}
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -891,9 +891,17 @@ func TestParseEmptyResponseOnlyCodes(t *testing.T) {
 func TestParseResponseCommentParamMissing(t *testing.T) {
 	operation := NewOperation(nil)
 
-	paramLenErrComment := `@Success notIntCode {string}`
+	paramLenErrComment := `@Success notIntCode`
 	paramLenErr := operation.ParseComment(paramLenErrComment, nil)
-	assert.EqualError(t, paramLenErr, `can not parse response comment "notIntCode {string}"`)
+	assert.EqualError(t, paramLenErr, `can not parse response comment "notIntCode"`)
+
+	paramLenErrComment = `@Success notIntCode {string} string "it ok"`
+	paramLenErr = operation.ParseComment(paramLenErrComment, nil)
+	assert.EqualError(t, paramLenErr, `can not parse response comment "notIntCode {string} string "it ok""`)
+
+	paramLenErrComment = `@Success notIntCode "it ok"`
+	paramLenErr = operation.ParseComment(paramLenErrComment, nil)
+	assert.EqualError(t, paramLenErr, `can not parse response comment "notIntCode "it ok""`)
 }
 
 // Test ParseParamComment

--- a/operation_test.go
+++ b/operation_test.go
@@ -874,9 +874,15 @@ func TestParseEmptyResponseOnlyCodes(t *testing.T) {
 
 	expected := `{
     "responses": {
-        "200": {},
-        "201": {},
-        "default": {}
+        "200": {
+            "description": ""
+        },
+        "201": {
+            "description": ""
+        },
+        "default": {
+            "description": ""
+        }
     }
 }`
 	assert.Equal(t, expected, string(b))

--- a/operation_test.go
+++ b/operation_test.go
@@ -671,6 +671,38 @@ func TestParseResponseCommentWithBasicType(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseResponseCommentWithBasicTypeAndCodes(t *testing.T) {
+	comment := `@Success 200,201,default {string} string "it's ok'"`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "it's ok'",
+            "schema": {
+                "type": "string"
+            }
+        },
+        "201": {
+            "description": "it's ok'",
+            "schema": {
+                "type": "string"
+            }
+        },
+        "default": {
+            "description": "it's ok'",
+            "schema": {
+                "type": "string"
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseEmptyResponseComment(t *testing.T) {
 	comment := `@Success 200 "it's ok"`
 	operation := NewOperation(nil)
@@ -682,6 +714,30 @@ func TestParseEmptyResponseComment(t *testing.T) {
 	expected := `{
     "responses": {
         "200": {
+            "description": "it's ok"
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+func TestParseEmptyResponseCommentWithCodes(t *testing.T) {
+	comment := `@Success 200,201,default "it's ok"`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "it's ok"
+        },
+        "201": {
+            "description": "it's ok"
+        },
+        "default": {
             "description": "it's ok"
         }
     }
@@ -720,7 +776,74 @@ func TestParseResponseCommentWithHeader(t *testing.T) {
 	comment = `@Header 200 "Mallformed"`
 	err = operation.ParseComment(comment, nil)
 	assert.Error(t, err, "ParseComment should not fail")
+}
 
+func TestParseResponseCommentWithHeaderForCodes(t *testing.T) {
+	operation := NewOperation(nil)
+
+	comment := `@Success 200,201,default "it's ok"`
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+
+	comment = `@Header 200,201,default {string} Token "qwerty"`
+	err = operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+
+	comment = `@Header all {string} Token2 "qwerty"`
+	err = operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+
+	b, err := json.MarshalIndent(operation, "", "    ")
+	assert.NoError(t, err)
+
+	expected := `{
+    "responses": {
+        "200": {
+            "description": "it's ok",
+            "headers": {
+                "Token": {
+                    "type": "string",
+                    "description": "qwerty"
+                },
+                "Token2": {
+                    "type": "string",
+                    "description": "qwerty"
+                }
+            }
+        },
+        "201": {
+            "description": "it's ok",
+            "headers": {
+                "Token": {
+                    "type": "string",
+                    "description": "qwerty"
+                },
+                "Token2": {
+                    "type": "string",
+                    "description": "qwerty"
+                }
+            }
+        },
+        "default": {
+            "description": "it's ok",
+            "headers": {
+                "Token": {
+                    "type": "string",
+                    "description": "qwerty"
+                },
+                "Token2": {
+                    "type": "string",
+                    "description": "qwerty"
+                }
+            }
+        }
+    }
+}`
+	assert.Equal(t, expected, string(b))
+
+	comment = `@Header 200 "Mallformed"`
+	err = operation.ParseComment(comment, nil)
+	assert.Error(t, err, "ParseComment should not fail")
 }
 
 func TestParseEmptyResponseOnlyCode(t *testing.T) {
@@ -734,6 +857,24 @@ func TestParseEmptyResponseOnlyCode(t *testing.T) {
 	expected := `{
     "responses": {
         "200": {}
+    }
+}`
+	assert.Equal(t, expected, string(b))
+}
+
+func TestParseEmptyResponseOnlyCodes(t *testing.T) {
+	comment := `@Success 200,201,default`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err, "ParseComment should not fail")
+
+	b, _ := json.MarshalIndent(operation, "", "    ")
+
+	expected := `{
+    "responses": {
+        "200": {},
+        "201": {},
+        "default": {}
     }
 }`
 	assert.Equal(t, expected, string(b))

--- a/parser.go
+++ b/parser.go
@@ -410,7 +410,7 @@ func isGeneralAPIComment(comment *ast.CommentGroup) bool {
 		attribute := strings.ToLower(strings.Split(commentLine, " ")[0])
 		switch attribute {
 		// The @summary, @router, @success,@failure  annotation belongs to Operation
-		case "@summary", "@router", "@success", "@failure":
+		case "@summary", "@router", "@success", "@failure", "@response":
 			return false
 		}
 	}


### PR DESCRIPTION
**Describe the PR**
1. Support default response.  #691  override PR #692
2. Use comma-separated codes to define  the same response for multi-codes in one line.
3. Use comma-separated codes to add a header for multi responses in one line. #785
4. Use keyword 'all' to add a header for all responses. #785

**Relation issue**
#785 #691 

```
// @Success 200 {string} string	"ok"
// @failure 400,401 {string} string	"error"
// @response default {string} string	"other error"
// @Header 200 {string} Location "/entity/1"
// @Header 200,400,default {string} Token "token"
// @Header all {string} Token2 "token2"
```
