### PR TITLE
Update example go.mod (example/object-map-example/go.mod)

### DIFF
--- a/example/object-map-example/go.mod
+++ b/example/object-map-example/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/gin-gonic/gin v1.6.3
 	github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
-	github.com/swaggo/gin-swagger v1.2.0
+	github.com/swaggo/gin-swagger v1.3.0
 	github.com/swaggo/swag v1.5.1
 )


### PR DESCRIPTION
Update gin-swagger dependency version to mitigate issue with missing dep (github.com/ugorji/go v1.1.5-pre).

Issue link: https://github.com/swaggo/swag/issues/826
