### PR TITLE
Release swag for Linux/ARM64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,15 @@
 build:
   main: cmd/swag/main.go
+  goos:
+    - linux
+    - darwin
+  goarch:
+    - amd64
+    - arm64
+    - 386
+  ignore:
+    - goos: darwin
+      goarch: arm64
 archive:
   replacements:
     darwin: Darwin
@@ -7,6 +17,7 @@ archive:
     windows: Windows
     386: i386
     amd64: x86_64
+    arm64: aarch64
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
**Describe the PR**

Added ARM64 architecture to .goreleaser.yml for releasing Linux/ARM64 binary.

Signed-off-by: odidev <odidev@puresoftware.com>

**Relation issue**

Resolves #841 

**Additional context**

N/A
