### PR TITLE
Optional additional parameter when using object in swaggertype

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -155,12 +155,12 @@ func BuildCustomSchema(types []string) (*spec.Schema, error) {
 	}
 
 	switch types[0] {
-	case "primitive":
+	case PRIMITIVE:
 		if len(types) == 1 {
 			return nil, errors.New("need primitive type after primitive")
 		}
 		return BuildCustomSchema(types[1:])
-	case "array":
+	case ARRAY:
 		if len(types) == 1 {
 			return nil, errors.New("need array item type after array")
 		}
@@ -169,9 +169,9 @@ func BuildCustomSchema(types []string) (*spec.Schema, error) {
 			return nil, err
 		}
 		return spec.ArrayProperty(schema), nil
-	case "object":
+	case OBJECT:
 		if len(types) == 1 {
-			return nil, errors.New("need object item type after object")
+			return PrimitiveSchema(types[0]), nil
 		}
 		schema, err := BuildCustomSchema(types[1:])
 		if err != nil {

--- a/schema_test.go
+++ b/schema_test.go
@@ -106,8 +106,8 @@ func TestBuildCustomSchema(t *testing.T) {
 	assert.Equal(t, schema.SchemaProps.Items.Schema.SchemaProps.Type, spec.StringOrArray{"string"})
 
 	schema, err = BuildCustomSchema([]string{"object"})
-	assert.Error(t, err)
-	assert.Nil(t, schema)
+	assert.NoError(t, err)
+	assert.Equal(t, schema.SchemaProps.Type, spec.StringOrArray{"object"})
 
 	schema, err = BuildCustomSchema([]string{"object", "oops"})
 	assert.Error(t, err)


### PR DESCRIPTION
**Describe the PR**
Not requiring an additional parameter to be set when using `object` in `swaggertype`.

**Relation issue**
https://github.com/swaggo/swag/issues/843