### PR TITLE
fix: add include, and exclude is invalid if include is set

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -13,6 +13,7 @@ import (
 const (
 	searchDirFlag        = "dir"
 	excludeFlag          = "exclude"
+	includeFlag          = "include"
 	generalInfoFlag      = "generalInfo"
 	propertyStrategyFlag = "propertyStrategy"
 	outputFlag           = "output"
@@ -37,6 +38,10 @@ var initFlags = []cli.Flag{
 		Aliases: []string{"d"},
 		Value:   "./",
 		Usage:   "Directory you want to parse",
+	},
+	&cli.StringFlag{
+		Name:  includeFlag,
+		Usage: "include directories and files when searching, comma separated, exclude is invalid if include is set",
 	},
 	&cli.StringFlag{
 		Name:  excludeFlag,
@@ -100,6 +105,7 @@ func initAction(c *cli.Context) error {
 
 	return gen.New().Build(&gen.Config{
 		SearchDir:           c.String(searchDirFlag),
+		Includes:            c.String(includeFlag),
 		Excludes:            c.String(excludeFlag),
 		MainAPIFile:         c.String(generalInfoFlag),
 		PropNamingStrategy:  strategy,

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -39,6 +39,9 @@ type Config struct {
 	// SearchDir the swag would be parse
 	SearchDir string
 
+	// includes dirs and files in SearchDir,comma separated
+	Includes string
+
 	// excludes dirs and files in SearchDir,comma separated
 	Excludes string
 
@@ -82,6 +85,7 @@ func (g *Gen) Build(config *Config) error {
 	log.Println("Generate swagger docs....")
 	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
 		swag.SetExcludedDirsAndFiles(config.Excludes),
+		swag.SetIncludedDirsAndFiles(config.Includes),
 		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir))
 	p.PropNamingStrategy = config.PropNamingStrategy
 	p.ParseVendor = config.ParseVendor


### PR DESCRIPTION
**Describe the PR**
add include , if include is set ,exclude path is invalid.

**Relation issue**
#905 

**Additional context**
i find struct type define also be ignore by exclude args, so move the skip excloud path function and add include.  Welcome to discuss this idea
