### PR TITLE
Support enums on array parameters

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -339,7 +339,7 @@ func (operation *Operation) parseAndExtractionParamAttribute(commentLine, object
 		}
 		switch attrKey {
 		case "enums":
-			err := setEnumParam(attr, schemaType, param)
+			err := setEnumParam(attr, objectType, schemaType, param)
 			if err != nil {
 				return err
 			}
@@ -418,7 +418,7 @@ func setNumberParam(name, schemaType, attr, commentLine string) (float64, error)
 	return n, nil
 }
 
-func setEnumParam(attr, schemaType string, param *spec.Parameter) error {
+func setEnumParam(attr, objectType, schemaType string, param *spec.Parameter) error {
 	for _, e := range strings.Split(attr, ",") {
 		e = strings.TrimSpace(e)
 
@@ -426,7 +426,13 @@ func setEnumParam(attr, schemaType string, param *spec.Parameter) error {
 		if err != nil {
 			return err
 		}
-		param.Enum = append(param.Enum, value)
+
+		switch objectType {
+		case ARRAY:
+			param.Items.Enum = append(param.Items.Enum, value)
+		default:
+			param.Enum = append(param.Enum, value)
+		}
 	}
 	return nil
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -1510,6 +1510,35 @@ func TestParseParamCommentByDefault(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseParamArrayWithEnums(t *testing.T) {
+	comment := `@Param field query []string true "An enum collection" collectionFormat(csv) enums(also,valid)`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+
+	assert.NoError(t, err)
+	b, _ := json.MarshalIndent(operation, "", "    ")
+	expected := `{
+    "parameters": [
+        {
+            "type": "array",
+            "items": {
+                "enum": [
+                    "also",
+                    "valid"
+                ],
+                "type": "string"
+            },
+            "collectionFormat": "csv",
+            "description": "An enum collection",
+            "name": "field",
+            "in": "query",
+            "required": true
+        }
+    ]
+}`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseIdComment(t *testing.T) {
 	comment := `@Id myOperationId`
 	operation := NewOperation(nil)


### PR DESCRIPTION
**Describe the PR**
Adds support for including enums on array query parameters. If the parameter type is an array, the enum values are added to the items field on the parameter instead.

**Relation issue**
https://github.com/swaggo/swag/issues/918

**Additional context**
None