### PR TITLE
support boolean false value in extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ type Account struct {
 
 ```go
 type Account struct {
-    ID   string    `json:"id"   extensions:"x-nullable,x-abc=def"` // extensions fields must start with "x-"
+    ID   string    `json:"id"   extensions:"x-nullable,x-abc=def,!x-omitempty"` // extensions fields must start with "x-"
 }
 ```
 
@@ -688,7 +688,8 @@ generate swagger doc as follows:
         "id": {
             "type": "string",
             "x-nullable": true,
-            "x-abc": "def"
+            "x-abc": "def",
+            "x-omitempty": false
         }
     }
 }

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -656,7 +656,7 @@ type Account struct {
 
 ```go
 type Account struct {
-    ID   string    `json:"id"   extensions:"x-nullable,x-abc=def"` // 扩展字段必须以"x-"开头
+    ID   string    `json:"id"   extensions:"x-nullable,x-abc=def,!x-omitempty"` // 扩展字段必须以"x-"开头
 }
 ```
 
@@ -669,7 +669,8 @@ type Account struct {
         "id": {
             "type": "string",
             "x-nullable": true,
-            "x-abc": "def"
+            "x-abc": "def",
+            "x-omitempty": false
         }
     }
 }

--- a/parser.go
+++ b/parser.go
@@ -1073,7 +1073,11 @@ func (parser *Parser) parseFieldTag(field *ast.Field, types []string) (*structFi
 			if len(parts) == 2 {
 				structField.extensions[parts[0]] = parts[1]
 			} else {
-				structField.extensions[parts[0]] = true
+				if len(parts[0]) > 0 && string(parts[0][0]) == "!" {
+					structField.extensions[string(parts[0][1:])] = false
+				} else {
+					structField.extensions[parts[0]] = true
+				}
 			}
 		}
 	}

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -600,7 +600,8 @@
         "middlename": {
           "type": "string",
           "x-abc": "def",
-          "x-nullable": true
+          "x-nullable": true,
+          "x-omitempty": false
         }
       }
     },

--- a/testdata/simple/web/handler.go
+++ b/testdata/simple/web/handler.go
@@ -53,7 +53,7 @@ type CrossAlias cross.Cross
 
 type Pet2 struct {
 	ID         int        `json:"id"`
-	MiddleName *string    `json:"middlename" extensions:"x-nullable,x-abc=def"`
+	MiddleName *string    `json:"middlename" extensions:"x-nullable,x-abc=def,!x-omitempty"`
 	DeletedAt  *time.Time `json:"deleted_at"`
 }
 


### PR DESCRIPTION
**Describe the PR**
This change supports to use boolean false value as extension values. Currently, extensions field only supports boolean true and string values. However, boolean false value is needed for some frequently used extensions such as `x-omitempty`.

All swagger extensions should start with `x-`, so prefix `!` does not break anything and it can be a good rule.

**Relation issue**

None

**Additional context**

My first approach was like `x-omitempty=false`, but it may break some extensions that uses `false` as string value. 

