### PR TITLE
if the tag @hidden is in the route annotations it will skip it

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
-
 	"github.com/swaggo/swag"
 	"github.com/swaggo/swag/gen"
 	"github.com/urfave/cli/v2"
+	"log"
+	"os"
 )
 
 const (

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,5 @@
+package swag
+
+import "errors"
+
+var ErrIsHidden = errors.New("endpoint is hidden")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.20.3
 	github.com/stretchr/testify v1.7.0
+	github.com/urfave/cli v1.22.5
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/tools v0.1.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-openapi/spec v0.20.3
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli v1.22.5
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/tools v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/operation.go
+++ b/operation.go
@@ -90,6 +90,8 @@ func (operation *Operation) ParseComment(comment string, astFile *ast.File) erro
 
 	var err error
 	switch lowerAttribute {
+	case "@hidden":
+		return ErrIsHidden
 	case "@description":
 		operation.ParseDescriptionComment(lineRemainder)
 	case "@description.markdown":

--- a/parser.go
+++ b/parser.go
@@ -564,6 +564,9 @@ func (parser *Parser) ParseRouterAPIInfo(fileName string, astFile *ast.File) err
 				operation := NewOperation(parser, SetCodeExampleFilesDirectory(parser.codeExampleFilesDir)) //for per 'function' comment, create a new 'Operation' object
 				for _, comment := range astDeclaration.Doc.List {
 					if err := operation.ParseComment(comment.Text, astFile); err != nil {
+						if errors.Is(ErrIsHidden, err) {
+							break
+						}
 						return fmt.Errorf("ParseComment error in file %s :%+v", fileName, err)
 					}
 				}


### PR DESCRIPTION
**Describe the PR**
I had a large number of routes and needed some of them just hidden from the swagger.yaml/json file. So I added a new condition for the tag @hidden. If this tag is present, swag will skip that route.
Ex:

```
/ ShowAccount godoc
// @Hidden
// @Summary Show a account
// @Description get string by ID
// @ID get-string-by-int
// @Accept  json
// @Produce  json
// @Param id path int true "Account ID"
// @Success 200 {object} model.Account
// @Header 200 {string} Token "qwerty"
// @Failure 400,404 {object} httputil.HTTPError
// @Failure 500 {object} httputil.HTTPError
// @Failure default {object} httputil.DefaultError
// @Router /accounts/{id} [get]
func (c *Controller) ShowAccount(ctx *gin.Context) {
```

In the example above, swag will skip the /accounts/{id} [get]  documentation specifcally

**Relation issue**
https://github.com/swaggo/swag/issues/661


**Additional context**
I found necessary to create a error file and the error ErrIsHidden to return when a route is skipped and identify the error
The tag should be on the top of the annotations for best performance
