### PR TITLE
Handle duplicate route declaration better

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -60,6 +60,9 @@ type Config struct {
 	// ParseInternal whether swag should parse internal packages
 	ParseInternal bool
 
+	// Strict whether swag should error or warn when it detects cases which are most likely user errors
+	Strict bool
+
 	// MarkdownFilesDir used to find markdownfiles, which can be used for tag descriptions
 	MarkdownFilesDir string
 
@@ -85,7 +88,8 @@ func (g *Gen) Build(config *Config) error {
 	log.Println("Generate swagger docs....")
 	p := swag.New(swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
 		swag.SetExcludedDirsAndFiles(config.Excludes),
-		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir))
+		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir),
+		swag.SetStrict(config.Strict))
 	p.PropNamingStrategy = config.PropNamingStrategy
 	p.ParseVendor = config.ParseVendor
 	p.ParseDependency = config.ParseDependency

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -434,7 +434,11 @@ func TestGen_duplicateRoute(t *testing.T) {
 		PropNamingStrategy: "",
 		ParseDependency:    true,
 	}
-
 	err := New().Build(config)
-	assert.Error(t, err)
+	assert.NoError(t, err)
+
+	// with Strict enabled should cause an error instead of warning about the duplicate route
+	config.Strict = true
+	err = New().Build(config)
+	assert.EqualError(t, err, "route GET /testapi/endpoint is declared multiple times")
 }

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -423,3 +423,18 @@ func TestGen_cgoImports(t *testing.T) {
 		os.Remove(expectedFile)
 	}
 }
+
+func TestGen_duplicateRoute(t *testing.T) {
+	searchDir := "../testdata/duplicate_route"
+
+	config := &Config{
+		SearchDir:          searchDir,
+		MainAPIFile:        "./main.go",
+		OutputDir:          "../testdata/duplicate_route/docs",
+		PropNamingStrategy: "",
+		ParseDependency:    true,
+	}
+
+	err := New().Build(config)
+	assert.Error(t, err)
+}

--- a/packages.go
+++ b/packages.go
@@ -3,6 +3,7 @@ package swag
 import (
 	"go/ast"
 	"go/token"
+	"sort"
 	"strings"
 )
 
@@ -53,10 +54,19 @@ func (pkgs *PackagesDefinitions) CollectAstFile(packageDir, path string, astFile
 	}
 }
 
-// RangeFiles for range the collection of ast.File.
+// RangeFiles for range the collection of ast.File in alphabetic order.
 func (pkgs *PackagesDefinitions) RangeFiles(handle func(filename string, file *ast.File) error) error {
-	for file, info := range pkgs.files {
-		if err := handle(info.Path, file); err != nil {
+	sortedFiles := make([]*AstFileInfo, 0, len(pkgs.files))
+	for _, info := range pkgs.files {
+		sortedFiles = append(sortedFiles, info)
+	}
+
+	sort.Slice(sortedFiles, func(i, j int) bool {
+		return strings.Compare(sortedFiles[i].Path, sortedFiles[j].Path) < 0
+	})
+
+	for _, info := range sortedFiles {
+		if err := handle(info.Path, info.File); err != nil {
 			return err
 		}
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,6 +35,14 @@ func TestSetCodeExamplesDirectory(t *testing.T) {
 	assert.Equal(t, expected, p.codeExampleFilesDir)
 }
 
+func TestSetStrict(t *testing.T) {
+	p := New()
+	assert.Equal(t, false, p.Strict)
+
+	p = New(SetStrict(true))
+	assert.Equal(t, true, p.Strict)
+}
+
 func TestParser_ParseGeneralApiInfo(t *testing.T) {
 	expected := `{
     "schemes": [
@@ -2198,6 +2206,29 @@ func Test3(){
 // 	}
 // }
 
+func TestParser_ParseRouterApiDuplicateRoute(t *testing.T) {
+	src := `
+package test
+
+// @Router /api/{id} [get]
+func Test1(){
+}
+// @Router /api/{id} [get]
+func Test2(){
+}
+`
+	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
+	assert.NoError(t, err)
+
+	p := New(SetStrict(true))
+	err = p.ParseRouterAPIInfo("", f)
+	assert.EqualError(t, err, "route GET /api/{id} is declared multiple times")
+
+	p = New()
+	err = p.ParseRouterAPIInfo("", f)
+	assert.NoError(t, err)
+}
+
 func TestApiParseTag(t *testing.T) {
 	searchDir := "testdata/tags"
 	p := New(SetMarkdownFileDirectory(searchDir))
@@ -2649,6 +2680,64 @@ func TestDefineTypeOfExample(t *testing.T) {
 	example, err = defineTypeOfExample("oops", "", "")
 	assert.Error(t, err)
 	assert.Nil(t, example)
+}
+
+func TestSetRouteMethodOp(t *testing.T) {
+	op := spec.NewOperation("dummy")
+
+	// choosing to test each method explicitly instead of table driven to avoid reliance on helpers
+
+	pathItem := spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodGet, op)
+	assert.Equal(t, op, pathItem.Get)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodPost, op)
+	assert.Equal(t, op, pathItem.Post)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodDelete, op)
+	assert.Equal(t, op, pathItem.Delete)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodPut, op)
+	assert.Equal(t, op, pathItem.Put)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodPatch, op)
+	assert.Equal(t, op, pathItem.Patch)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodHead, op)
+	assert.Equal(t, op, pathItem.Head)
+
+	pathItem = spec.PathItem{}
+	setRouteMethodOp(&pathItem, http.MethodOptions, op)
+	assert.Equal(t, op, pathItem.Options)
+}
+
+func TestHasRouteMethodOp(t *testing.T) {
+	pathItem := spec.PathItem{}
+
+	// assert that an invalid http method produces false
+	assert.False(t, hasRouteMethodOp(pathItem, "OOPSIE"))
+
+	// test each (supported) http method
+	httpMethods := []string{
+		http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodPut,
+		http.MethodPatch, http.MethodHead, http.MethodOptions,
+	}
+	for _, httpMethod := range httpMethods {
+		pathItem = spec.PathItem{}
+
+		// should be false before setting
+		assert.False(t, hasRouteMethodOp(pathItem, httpMethod))
+
+		// and true after we set it
+		// we rely on setRouteMethodOp, which is tested more thoroughly above
+		setRouteMethodOp(&pathItem, httpMethod, spec.NewOperation("dummy"))
+		assert.True(t, hasRouteMethodOp(pathItem, httpMethod))
+	}
 }
 
 type mockFS struct {

--- a/testdata/duplicate_route/api/api.go
+++ b/testdata/duplicate_route/api/api.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"net/http"
+
+	_ "github.com/swaggo/swag/testdata/simple/web"
+)
+
+// @Router /testapi/endpoint [get]
+func FunctionOne(w http.ResponseWriter, r *http.Request) {
+	//write your code
+}
+
+// @Router /testapi/endpoint [get]
+func FunctionTwo(w http.ResponseWriter, r *http.Request) {
+	//write your code
+}

--- a/testdata/duplicate_route/main.go
+++ b/testdata/duplicate_route/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/duplicate_route/api"
+)
+
+func main() {
+	http.HandleFunc("/testapi/endpoint", api.FunctionOne)
+	http.HandleFunc("/testapi/endpoint", api.FunctionTwo)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
Fixes issue when you accidentally have `@Router /some/route` declared twice.  

Previously this would cause either of the 2 definitions to be used and it leaves the user very confused.

Tbh I'd personally just prefer the hard error when this mistake is made, but I think for backwards compatibility it might be nice to either have it warn by default (as it is now in this PR) or have the option to turn it into a warning, so I added the `Strict` option flag.  
I think this could also be useful for more checks in the future?  

Additionally I made `RangeFiles` sort the files to make sure it happens in deterministic order, prior to my fix to warn / error when there's a duplicate route and without this you'd randomly get one of the 2 routes and that *really* confuses the hell of you because instead of thinking you made a mistake it just looks like a very weird bug.  

The "fix issue with files being parsed twice" was something that came up when I added the warning about duplicate routes and I noticed that in `TestGen_cgoImports` it was triggering as well, this was because it was parsing `simple_cgo/api` from *both* the searchDirs and from the `ParseDependency` block.


If you'd like me to split the PR into multiple then please let me know, or if you want it without the `Strict` config option for example