### PR TITLE
Added support for @x- attributes on security definition

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -80,7 +80,7 @@ func TestParser_ParseGeneralApiInfo(t *testing.T) {
             "scopes": {
                 "admin": " Grants read and write access to administrative information"
             },
-            "x-tokenName": "id_token"
+            "x-tokenname": "id_token"
         },
         "OAuth2Application": {
             "type": "oauth2",
@@ -98,7 +98,8 @@ func TestParser_ParseGeneralApiInfo(t *testing.T) {
             "scopes": {
                 "admin": " Grants read and write access to administrative information",
                 "write": " Grants write access"
-            }
+            },
+            "x-google-audiences": "some_audience.google.com"
         },
         "OAuth2Password": {
             "type": "oauth2",

--- a/testdata/main.go
+++ b/testdata/main.go
@@ -31,6 +31,7 @@ package main
 // @authorizationurl https://example.com/oauth/authorize
 // @scope.write Grants write access
 // @scope.admin Grants read and write access to administrative information
+// @x-google-audiences some_audience.google.com
 
 // @securitydefinitions.oauth2.password OAuth2Password
 // @tokenUrl https://example.com/oauth/token


### PR DESCRIPTION
Relates to issue #970.

Before this PR the only `@x-` attribute supported on the security definition was the hardcoded `x-tokenName`. After this PR all the `@x-` attributes that are parsed in the same block than the security definition are going to be added.

Added extra logic for not adding twice the `@x-` attributes that are present on the security definition and removed the hardcoded case scenario for token name as well.