### PR TITLE
Correctly parse format on array fields

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1013,11 +1013,14 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 	schema.ReadOnly = structField.readOnly
 	schema.Default = structField.defaultValue
 	schema.Example = structField.exampleValue
-	schema.Format = structField.formatType
+	if structField.schemaType != ARRAY {
+		schema.Format = structField.formatType
+	}
 	schema.Extensions = structField.extensions
 	eleSchema := schema
 	if structField.schemaType == ARRAY {
 		eleSchema = schema.Items.Schema
+		eleSchema.Format = structField.formatType
 	}
 	eleSchema.Maximum = structField.maximum
 	eleSchema.Minimum = structField.minimum

--- a/parser_test.go
+++ b/parser_test.go
@@ -614,9 +614,9 @@ func TestParseSimpleApi_ForSnakecase(t *testing.T) {
                         },
                         "photo_urls": {
                             "type": "array",
-                            "format": "url",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "url"
                             },
                             "example": [
                                 "http://test/image/1.jpg",
@@ -1090,9 +1090,9 @@ func TestParseSimpleApi_ForLowerCamelcase(t *testing.T) {
                         },
                         "photoURLs": {
                             "type": "array",
-                            "format": "url",
                             "items": {
-                                "type": "string"
+                                "type": "string",
+                                "format": "url"
                             },
                             "example": [
                                 "http://test/image/1.jpg",
@@ -2568,6 +2568,14 @@ func TestParseJSONFieldString(t *testing.T) {
                     "description": "boolean as a string",
                     "type": "string",
                     "example": "true"
+                },
+                "uuids": {
+                    "description": "string array with format",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
                 }
             }
         }

--- a/testdata/json_field_string/main.go
+++ b/testdata/json_field_string/main.go
@@ -7,12 +7,13 @@ import (
 )
 
 type MyStruct struct {
-	ID       int     `json:"id" example:"1" format:"int64"`
-	Name     string  `json:"name" example:"poti"`
-	Intvar   int     `json:"myint,string"`                   // integer as string
-	Boolvar  bool    `json:",string"`                        // boolean as a string
-	TrueBool bool    `json:"truebool,string" example:"true"` // boolean as a string
-	Floatvar float64 `json:",string"`                        // float as a string
+	ID       int      `json:"id" example:"1" format:"int64"`
+	Name     string   `json:"name" example:"poti"`
+	Intvar   int      `json:"myint,string"`                            // integer as string
+	Boolvar  bool     `json:",string"`                                 // boolean as a string
+	TrueBool bool     `json:"truebool,string" example:"true"`          // boolean as a string
+	Floatvar float64  `json:",string"`                                 // float as a string
+	UUIDs    []string `json:"uuids" type:"array,string" format:"uuid"` // string array with format
 }
 
 // @Summary Call DoSomething

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -449,9 +449,9 @@
             },
             "photo_urls": {
               "type": "array",
-              "format": "url",
               "items": {
-                "type": "string"
+                "type": "string",
+                "format": "url"
               },
               "example": [
                 "http://test/image/1.jpg",


### PR DESCRIPTION
**Describe the PR**
The format tag used on an array type should place the format in the items object, rather than directly on the type.

**Relation issue**

**Additional context**

Examples of this are available on the Swagger website, under **Array Examples** [here](https://swagger.io/docs/specification/adding-examples/).

```yaml
components:
  schemas:
    ArrayOfInt:
      type: array
      items:
        type: integer
        format: int64
        example: 1
```

```yaml
components:
  schemas:
    ArrayOfInt:
      type: array
      items:
        type: integer
        format: int64
      example: [1, 2, 3]
```