### PR TITLE
fix duplicate route order

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -25,7 +25,7 @@ func NewPackagesDefinitions() *PackagesDefinitions {
 }
 
 // CollectAstFile collect ast.file.
-func (pkgs *PackagesDefinitions) CollectAstFile(packageDir, path string, astFile *ast.File) error {
+func (pkgs *PackagesDefinitions) CollectAstFile(packageDir, path string, astFile *ast.File, order int) error {
 	if pkgs.files == nil {
 		pkgs.files = make(map[*ast.File]*AstFileInfo)
 	}
@@ -64,6 +64,7 @@ func (pkgs *PackagesDefinitions) CollectAstFile(packageDir, path string, astFile
 		File:        astFile,
 		Path:        path,
 		PackagePath: packageDir,
+		Order:       order,
 	}
 
 	return nil
@@ -77,6 +78,9 @@ func (pkgs *PackagesDefinitions) RangeFiles(handle func(filename string, file *a
 	}
 
 	sort.Slice(sortedFiles, func(i, j int) bool {
+		if sortedFiles[i].Order != sortedFiles[j].Order {
+			return sortedFiles[i].Order < sortedFiles[j].Order
+		}
 		return strings.Compare(sortedFiles[i].Path, sortedFiles[j].Path) < 0
 	})
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -518,7 +518,7 @@ func TestGetAllGoFileInfo(t *testing.T) {
 	searchDir := "testdata/pet"
 
 	p := New()
-	err := p.getAllGoFileInfo("testdata", searchDir)
+	err := p.getAllGoFileInfo("testdata", searchDir, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(p.packages.files))
@@ -530,7 +530,7 @@ func TestParser_ParseType(t *testing.T) {
 	searchDir := "testdata/simple/"
 
 	p := New()
-	err := p.getAllGoFileInfo("testdata", searchDir)
+	err := p.getAllGoFileInfo("testdata", searchDir, 0)
 	assert.NoError(t, err)
 
 	_, err = p.packages.ParseTypes()
@@ -1909,7 +1909,7 @@ func Test(){
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
 
@@ -1972,11 +1972,11 @@ type ResponseWrapper struct {
 
 	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
 	assert.NoError(t, err)
-	parser.packages.CollectAstFile("api", "api/api.go", f)
+	parser.packages.CollectAstFile("api", "api/api.go", f, 0)
 
 	f2, err := goparser.ParseFile(token.NewFileSet(), "", restsrc, goparser.ParseComments)
 	assert.NoError(t, err)
-	parser.packages.CollectAstFile("rest", "rest/rest.go", f2)
+	parser.packages.CollectAstFile("rest", "rest/rest.go", f2, 0)
 
 	_, err = parser.packages.ParseTypes()
 	assert.NoError(t, err)
@@ -2039,7 +2039,7 @@ func Test(){
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
 
@@ -2166,7 +2166,7 @@ func Test(){
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
@@ -2663,7 +2663,7 @@ func Fun()  {
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
@@ -2701,7 +2701,7 @@ func Fun()  {
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
 
@@ -2742,7 +2742,7 @@ func Fun()  {
 	pkgs.packages = nil
 	pkgs.files = nil
 
-	pkgs.CollectAstFile("api", "api/api.go", f)
+	pkgs.CollectAstFile("api", "api/api.go", f, 0)
 	assert.NotNil(t, pkgs.packages)
 	assert.NotNil(t, pkgs.files)
 }
@@ -2762,13 +2762,13 @@ func Fun()  {
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	assert.NotNil(t, p.packages.files[f])
 
 	astFileInfo := p.packages.files[f]
 
 	// if we collect the same again nothing should happen
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	assert.Equal(t, astFileInfo, p.packages.files[f])
 }
 
@@ -2901,7 +2901,7 @@ func Fun()  {
 	assert.NoError(t, err)
 
 	p := New()
-	p.packages.CollectAstFile("api", "api/api.go", f)
+	p.packages.CollectAstFile("api", "api/api.go", f, 0)
 	p.packages.ParseTypes()
 	err = p.ParseRouterAPIInfo("", f)
 	assert.NoError(t, err)

--- a/testdata/duplicate_route1/api/api.go
+++ b/testdata/duplicate_route1/api/api.go
@@ -1,0 +1,10 @@
+package api
+
+import (
+	"net/http"
+)
+
+// @Description duplicate_route1
+// @Router /testapi/endpoint [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route1/api/api.go
+++ b/testdata/duplicate_route1/api/api.go
@@ -8,3 +8,8 @@ import (
 // @Router /testapi/endpoint [get]
 func Function(w http.ResponseWriter, r *http.Request) {
 }
+
+// @Description route1
+// @Router /testapi/route1 [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route1/main.go
+++ b/testdata/duplicate_route1/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/duplicate_route1/api"
+)
+
+func main() {
+	http.HandleFunc("/testapi/endpoint", api.Function)
+	http.ListenAndServe(":8080", nil)
+}

--- a/testdata/duplicate_route2/api/api.go
+++ b/testdata/duplicate_route2/api/api.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"net/http"
+
+	_ "github.com/swaggo/swag/testdata/duplicate_route3"
+)
+
+// @Description duplicate_route2
+// @Router /testapi/endpoint [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route2/api/api.go
+++ b/testdata/duplicate_route2/api/api.go
@@ -10,3 +10,8 @@ import (
 // @Router /testapi/endpoint [get]
 func Function(w http.ResponseWriter, r *http.Request) {
 }
+
+// @Description route2
+// @Router /testapi/route2 [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route2/main.go
+++ b/testdata/duplicate_route2/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/duplicate_route2/api"
+)
+
+func main() {
+	http.HandleFunc("/testapi/endpoint", api.Function)
+	http.ListenAndServe(":8080", nil)
+}

--- a/testdata/duplicate_route3/api/api.go
+++ b/testdata/duplicate_route3/api/api.go
@@ -1,0 +1,10 @@
+package api
+
+import (
+	"net/http"
+)
+
+// @Description duplicate_route3
+// @Router /testapi/endpoint [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route3/api/api.go
+++ b/testdata/duplicate_route3/api/api.go
@@ -8,3 +8,8 @@ import (
 // @Router /testapi/endpoint [get]
 func Function(w http.ResponseWriter, r *http.Request) {
 }
+
+// @Description route3
+// @Router /testapi/route3 [get]
+func Function(w http.ResponseWriter, r *http.Request) {
+}

--- a/testdata/duplicate_route3/main.go
+++ b/testdata/duplicate_route3/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/duplicate_route3/api"
+)
+
+func main() {
+	http.HandleFunc("/testapi/endpoint", api.Function)
+	http.ListenAndServe(":8080", nil)
+}

--- a/types.go
+++ b/types.go
@@ -45,6 +45,9 @@ type AstFileInfo struct {
 
 	// PackagePath package import path of the ast.File
 	PackagePath string
+
+	// Order
+	Order int
 }
 
 // PackageDefinitions files and definition in a package.


### PR DESCRIPTION
**Describe the PR**

#968 fixes the priority of duplicate routes in alphabetical order in the file path.
But that is not the priority we need in the field.

1. If more than one is specified in the `-dir` option, give priority to the directory at the beginning of the option.
2. Prioritize the source of the dependency over the library of the dependency.

Our project consists of creating a new site by referring to the source of common parts.

In many cases, we believe that this priority specification will work as ideal.
