### PR TITLE
add for support paramType 'form'

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -221,7 +221,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 		refType = strings.TrimPrefix(refType, "[]")
 		refType = TransToValidSchemeType(refType)
 	} else if IsPrimitiveType(refType) ||
-		paramType == "formData" && refType == "file" {
+		(paramType == "formData" || paramType == "form") && refType == "file" {
 		objectType = PRIMITIVE
 	}
 
@@ -237,7 +237,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 		case ARRAY, OBJECT:
 			return fmt.Errorf("%s is not supported type for %s", refType, paramType)
 		}
-	case "query", "formData":
+	case "query", "formData", "form":
 		switch objectType {
 		case ARRAY:
 			if !IsPrimitiveType(refType) {


### PR DESCRIPTION
In the last swagger version, I had a large number of param types that used 'form', and I found that in this version, `form` became `formData`. I think simple is good.