### PR TITLE
Support arrays in path and header params

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -234,7 +234,20 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 	switch paramType {
 	case "path", "header":
 		switch objectType {
-		case ARRAY, OBJECT:
+		case ARRAY:
+			if !IsPrimitiveType(refType) {
+				return fmt.Errorf("%s is not supported array type for %s", refType, paramType)
+			}
+			param.SimpleSchema.Type = objectType
+			if operation.parser != nil {
+				param.CollectionFormat = TransToValidCollectionFormat(operation.parser.collectionFormatInQuery)
+			}
+			param.SimpleSchema.Items = &spec.Items{
+				SimpleSchema: spec.SimpleSchema{
+					Type: refType,
+				},
+			}
+		case OBJECT:
 			return fmt.Errorf("%s is not supported type for %s", refType, paramType)
 		}
 	case "query", "formData":

--- a/operation_test.go
+++ b/operation_test.go
@@ -1040,7 +1040,7 @@ func TestParseResponseCommentParamMissing(t *testing.T) {
 }
 
 // Test ParseParamComment
-func TestParseParamCommentByPathType(t *testing.T) {
+func TestParseParamCommentByParamType(t *testing.T) {
 	t.Parallel()
 
 	comment := `@Param some_id path int true "Some ID"`
@@ -1092,25 +1092,18 @@ func TestParseParamCommentBodyArray(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
-// Test ParseParamComment header Params
-func TestParseParamCommentHeaderArray(t *testing.T) {
-	t.Parallel()
+// Test ParseParamComment Params
+func TestParseParamCommentArray(t *testing.T) {
+	paramTypes := []string{"header", "path", "query"}
 
-	comment := `@Param names header []string true "Users List"`
-	operation := NewOperation(nil)
-	assert.Error(t, operation.ParseComment(comment, nil))
-}
+	for _, paramType := range paramTypes {
+		t.Run(paramType, func(t *testing.T) {
+			operation := NewOperation(nil)
+			err := operation.ParseComment(`@Param names `+paramType+` []string true "Users List"`, nil)
 
-// Test ParseParamComment Query Params
-func TestParseParamCommentQueryArray(t *testing.T) {
-	t.Parallel()
-
-	operation := NewOperation(nil)
-	err := operation.ParseComment(`@Param names query []string true "Users List"`, nil)
-
-	assert.NoError(t, err)
-	b, _ := json.MarshalIndent(operation, "", "    ")
-	expected := `{
+			assert.NoError(t, err)
+			b, _ := json.MarshalIndent(operation, "", "    ")
+			expected := `{
     "parameters": [
         {
             "type": "array",
@@ -1119,15 +1112,17 @@ func TestParseParamCommentQueryArray(t *testing.T) {
             },
             "description": "Users List",
             "name": "names",
-            "in": "query",
+            "in": "` + paramType + `",
             "required": true
         }
     ]
 }`
-	assert.Equal(t, expected, string(b))
+			assert.Equal(t, expected, string(b))
 
-	err = operation.ParseComment(`@Param names query []model.User true "Users List"`, nil)
-	assert.Error(t, err)
+			err = operation.ParseComment(`@Param names `+paramType+` []model.User true "Users List"`, nil)
+			assert.Error(t, err)
+		})
+	}
 }
 
 // Test TestParseParamCommentDefaultValue Query Params


### PR DESCRIPTION
**Describe the PR**
Adds support for array params in paths and headers

**Relation issue**
https://github.com/swaggo/swag/issues/1037

**Additional context**
Arrays are supported in paths and headers [according to the spec](https://swagger.io/docs/specification/2-0/describing-parameters/#array)
