### PR TITLE
feat: support go-playground/validator tags.

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -234,7 +234,20 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 	switch paramType {
 	case "path", "header":
 		switch objectType {
-		case ARRAY, OBJECT:
+		case ARRAY:
+			if !IsPrimitiveType(refType) {
+				return fmt.Errorf("%s is not supported array type for %s", refType, paramType)
+			}
+			param.SimpleSchema.Type = objectType
+			if operation.parser != nil {
+				param.CollectionFormat = TransToValidCollectionFormat(operation.parser.collectionFormatInQuery)
+			}
+			param.SimpleSchema.Items = &spec.Items{
+				SimpleSchema: spec.SimpleSchema{
+					Type: refType,
+				},
+			}
+		case OBJECT:
 			return fmt.Errorf("%s is not supported type for %s", refType, paramType)
 		}
 	case "query", "formData":

--- a/operation_test.go
+++ b/operation_test.go
@@ -1040,7 +1040,7 @@ func TestParseResponseCommentParamMissing(t *testing.T) {
 }
 
 // Test ParseParamComment
-func TestParseParamCommentByPathType(t *testing.T) {
+func TestParseParamCommentByParamType(t *testing.T) {
 	t.Parallel()
 
 	comment := `@Param some_id path int true "Some ID"`
@@ -1092,25 +1092,18 @@ func TestParseParamCommentBodyArray(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
-// Test ParseParamComment header Params
-func TestParseParamCommentHeaderArray(t *testing.T) {
-	t.Parallel()
+// Test ParseParamComment Params
+func TestParseParamCommentArray(t *testing.T) {
+	paramTypes := []string{"header", "path", "query"}
 
-	comment := `@Param names header []string true "Users List"`
-	operation := NewOperation(nil)
-	assert.Error(t, operation.ParseComment(comment, nil))
-}
+	for _, paramType := range paramTypes {
+		t.Run(paramType, func(t *testing.T) {
+			operation := NewOperation(nil)
+			err := operation.ParseComment(`@Param names `+paramType+` []string true "Users List"`, nil)
 
-// Test ParseParamComment Query Params
-func TestParseParamCommentQueryArray(t *testing.T) {
-	t.Parallel()
-
-	operation := NewOperation(nil)
-	err := operation.ParseComment(`@Param names query []string true "Users List"`, nil)
-
-	assert.NoError(t, err)
-	b, _ := json.MarshalIndent(operation, "", "    ")
-	expected := `{
+			assert.NoError(t, err)
+			b, _ := json.MarshalIndent(operation, "", "    ")
+			expected := `{
     "parameters": [
         {
             "type": "array",
@@ -1119,15 +1112,17 @@ func TestParseParamCommentQueryArray(t *testing.T) {
             },
             "description": "Users List",
             "name": "names",
-            "in": "query",
+            "in": "` + paramType + `",
             "required": true
         }
     ]
 }`
-	assert.Equal(t, expected, string(b))
+			assert.Equal(t, expected, string(b))
 
-	err = operation.ParseComment(`@Param names query []model.User true "Users List"`, nil)
-	assert.Error(t, err)
+			err = operation.ParseComment(`@Param names `+paramType+` []model.User true "Users List"`, nil)
+			assert.Error(t, err)
+		})
+	}
 }
 
 // Test TestParseParamCommentDefaultValue Query Params

--- a/parser.go
+++ b/parser.go
@@ -1090,6 +1090,10 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 
 	schema.Description = structField.desc
 	schema.ReadOnly = structField.readOnly
+	if !reflect.ValueOf(schema.SchemaProps.Ref).IsZero() && schema.ReadOnly {
+		schema.AllOf = []spec.Schema{*RefSchema(strings.TrimPrefix(schema.SchemaProps.Ref.Ref.String(), "#/definitions/"))}
+		schema.Ref = spec.Ref{} // clear out existing ref
+	}
 	schema.Default = structField.defaultValue
 	schema.Example = structField.exampleValue
 	if structField.schemaType != ARRAY {

--- a/parser.go
+++ b/parser.go
@@ -1758,7 +1758,7 @@ func (parser *Parser) parseValidTags(validTag string, sf *structField) {
 					continue
 				}
 			}
-			for i, _ := range valValues {
+			for i := range valValues {
 				value, err := defineType(enumType, valValues[i])
 				if err != nil {
 					continue

--- a/parser.go
+++ b/parser.go
@@ -1057,7 +1057,7 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 		return map[string]spec.Schema{typeName: *schema}, nil, nil
 	}
 
-	ps := newTagBaseFieldParser(parser, field)
+	ps := parser.fieldParserFactory(parser, field)
 
 	ok, err := ps.ShouldSkip()
 	if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1155,6 +1155,8 @@ func TestParseSimpleApi_ForSnakecase(t *testing.T) {
                 },
                 "price": {
                     "type": "number",
+                    "maximum": 130,
+                    "minimum": 0,
                     "multipleOf": 0.01,
                     "example": 3.25
                 },


### PR DESCRIPTION
**Describe the PR**
Support `go-playground/validator`.
Support for parsing more tags of validator, such as  max\min\oneof. 

example: 
```
type JsonResponse struct {
	Errno  int         `json:"errno" validate:"required,max=1000,min=10"`
	ErrMsg string      `json:"errmsg" validate:"required,max=1000,min=10,oneof=success fail"`
	Data   interface{} `json:"data"`
}
```
after:
```
{
    "response.JsonResponse": {
            "type": "object",
            "required": [
                "errmsg",
                "errno"
            ],
            "properties": {
                "data": {},
                "errmsg": {
                    "type": "string",
                    "maxLength": 1000,
                    "minLength": 10,
                    "enum": [
                        "success",
                        "fail"
                    ] 
                },
                "errno": {
                    "type": "integer",
                    "maximum": 1000,
                    "minimum": 10
                }
            }
        }
}
```

**Relation issue**
https://github.com/swaggo/swag/issues/995
