### PR TITLE
add dollar sign to acceptable router paths

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -582,7 +582,7 @@ func parseMimeTypeList(mimeTypeList string, typeList *[]string, format string) e
 	return nil
 }
 
-var routerPattern = regexp.MustCompile(`^(/[\w./\-{}+:]*)[[:blank:]]+\[(\w+)]`)
+var routerPattern = regexp.MustCompile(`^(/[\w./\-{}+:$]*)[[:blank:]]+\[(\w+)]`)
 
 // ParseRouterComment parses comment for given `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string) error {

--- a/operation_test.go
+++ b/operation_test.go
@@ -173,6 +173,27 @@ func TestParseRouterCommentWithPlusSign(t *testing.T) {
 	assert.Equal(t, "POST", operation.RouterProperties[0].HTTPMethod)
 }
 
+func TestParseRouterCommentWithDollarSign(t *testing.T) {
+	t.Parallel()
+
+	comment := `/@Router /customer/get-wishlist/{wishlist_id}$move [post]`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+	assert.Len(t, operation.RouterProperties, 1)
+	assert.Equal(t, "/customer/get-wishlist/{wishlist_id}$move", operation.RouterProperties[0].Path)
+	assert.Equal(t, "POST", operation.RouterProperties[0].HTTPMethod)
+}
+
+func TestParseRouterCommentNoDollarSignAtPathStartErr(t *testing.T) {
+	t.Parallel()
+
+	comment := `/@Router $customer/get-wishlist/{wishlist_id}$move [post]`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.Error(t, err)
+}
+
 func TestParseRouterCommentWithColonSign(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Describe the PR**
Add `$` to valid router paths for compatibility with HL7 FHIR standard. 

The FHIR standard uses $ to prefix operations against compliant endpoints. [Section 3.2.0.1 of the FHIR specification](https://www.hl7.org/fhir/operations.html#executing) gives a definition and an example. Allowing $ as a modifier would enable teams working in Go to output Swagger specifications for APIs that interact with FHIR endpoints and further the goal of greater healthcare data interoperability around the world.

**More information about HL7 FHIR standard**
HL7 is a multinational non-profit organization that defines interoperability and messaging standards for the healthcare industry. The following countries use an HL7 defined specification as the primary method for messaging between healthcare providers: United States, Canada, Mexico, Australia, New Zealand, India, Pakistan, United Kingdom, Finland, Sweden, Spain, Turkey and Switzerland. 

Historically, HL7 has facilitated information exchange through the sharing of documents. With the creation of the FHIR standard, HL7 aims to bring healthcare data movement in line with modern internet practices by introducing a REST based approach to exchange only relevant information instead of whole documents. 


**Relation issue**
This PR would resolve issue #1053 