### PR TITLE
chore: drop support go 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.13.x', '1.14.x', '1.15.x', '1.16.x', '1.17.x' ]
+        go: [ '1.14.x', '1.15.x', '1.16.x', '1.17.x' ]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ go get -u github.com/swaggo/swag/cmd/swag
 # 1.16 or newer
 $ go install github.com/swaggo/swag/cmd/swag@latest
 ```
-To build from source you need [Go](https://golang.org/dl/) (1.13 or newer).
+To build from source you need [Go](https://golang.org/dl/) (1.14 or newer).
 
 Or download a pre-compiled binary from the [release page](https://github.com/swaggo/swag/releases).
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -53,7 +53,7 @@ $ go get -u github.com/swaggo/swag/cmd/swag
 $ go install github.com/swaggo/swag/cmd/swag@latest
 ```
 
-从源码开始构建的话，需要有Go环境（1.13及以上版本）。
+从源码开始构建的话，需要有Go环境（1.14及以上版本）。
 
 或者从github的release页面下载预编译好的二进制文件。
 


### PR DESCRIPTION
**Describe the PR**
Drop support for GO 1.13

**Relation issue**
None

**Additional context**
The pipeline is taking too long to run all 1.13-1.17 Linux and macOS tests.
