### PR TITLE
chore:remove unnecessary check

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -1,9 +1,7 @@
 package format
 
 import (
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/swaggo/swag"
 )
@@ -26,10 +24,6 @@ type Config struct {
 }
 
 func (f *Fmt) Build(config *Config) error {
-	if _, err := os.Stat(config.SearchDir); os.IsNotExist(err) {
-		return fmt.Errorf("dir: %s is not exist", config.SearchDir)
-	}
-
 	log.Println("Formating code.... ")
 	formater := swag.NewFormater()
 	if err := formater.FormatAPI(config.SearchDir, config.Excludes, config.MainFile); err != nil {


### PR DESCRIPTION
**Describe the PR**
This will remove the check for existence of the `SearchDir` on `swag fmt` which is breaking the comma separated list feature from `swag fmt -d cmd/hello,./`, fore example.

**Relation issue**

**Additional context**
The check is being made after splitting the list on the comma character, later, in the `FormatAPI` call.
