### PR TITLE
Refactor some things for the needs of github.com/go-chai/chai

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -40,6 +40,18 @@ func New() *Gen {
 	}
 }
 
+type GenConfig struct {
+	// OutputDir represents the output directory for all the generated files
+	OutputDir string
+
+	// InstanceName is used to get distinct names for different swagger documents in the
+	// same project. The default value is "swagger".
+	InstanceName string
+
+	// GeneratedTime whether swag should generate the timestamp at the top of docs.go
+	GeneratedTime bool
+}
+
 // Config presents Gen configurations.
 type Config struct {
 	// SearchDir the swag would be parse,comma separated if multiple
@@ -91,10 +103,6 @@ type Config struct {
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json
 func (g *Gen) Build(config *Config) error {
-	if config.InstanceName == "" {
-		config.InstanceName = swag.Name
-	}
-
 	searchDirs := strings.Split(config.SearchDir, ",")
 	for _, searchDir := range searchDirs {
 		if _, err := os.Stat(searchDir); os.IsNotExist(err) {
@@ -135,7 +143,23 @@ func (g *Gen) Build(config *Config) error {
 	if err := p.ParseAPIMultiSearchDir(searchDirs, config.MainAPIFile, config.ParseDepth); err != nil {
 		return err
 	}
-	swagger := p.GetSwagger()
+
+	return g.Generate(p.GetSwagger(), &GenConfig{
+		OutputDir:     config.OutputDir,
+		InstanceName:  config.InstanceName,
+		GeneratedTime: config.GeneratedTime,
+	})
+}
+
+// Generate outputs a swagger spec
+func (g *Gen) Generate(swagger *spec.Swagger, config *GenConfig) error {
+	if config.InstanceName == "" {
+		config.InstanceName = swag.Name
+	}
+
+	if config.OutputDir == "" {
+		config.OutputDir = "docs/"
+	}
 
 	b, err := g.jsonIndent(swagger)
 	if err != nil {
@@ -251,7 +275,7 @@ func parseOverrides(r io.Reader) (map[string]string, error) {
 	return overrides, nil
 }
 
-func (g *Gen) writeGoDoc(packageName string, output io.Writer, swagger *spec.Swagger, config *Config) error {
+func (g *Gen) writeGoDoc(packageName string, output io.Writer, swagger *spec.Swagger, config *GenConfig) error {
 	generator, err := template.New("swagger_info").Funcs(template.FuncMap{
 		"printDoc": func(v string) string {
 			// Add schemes

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -361,7 +361,7 @@ func TestGen_writeGoDoc(t *testing.T) {
 	swapTemplate := packageTemplate
 
 	packageTemplate = `{{{`
-	err := gen.writeGoDoc("docs", nil, nil, &Config{})
+	err := gen.writeGoDoc("docs", nil, nil, &GenConfig{})
 	assert.Error(t, err)
 
 	packageTemplate = `{{.Data}}`
@@ -371,7 +371,7 @@ func TestGen_writeGoDoc(t *testing.T) {
 			Info: &spec.Info{},
 		},
 	}
-	err = gen.writeGoDoc("docs", &mockWriter{}, swagger, &Config{})
+	err = gen.writeGoDoc("docs", &mockWriter{}, swagger, &GenConfig{})
 	assert.Error(t, err)
 
 	packageTemplate = `{{ if .GeneratedTime }}Fake Time{{ end }}`
@@ -380,14 +380,14 @@ func TestGen_writeGoDoc(t *testing.T) {
 			hook: func(data []byte) {
 				assert.Equal(t, "Fake Time", string(data))
 			},
-		}, swagger, &Config{GeneratedTime: true})
+		}, swagger, &GenConfig{GeneratedTime: true})
 	assert.NoError(t, err)
 	err = gen.writeGoDoc("docs",
 		&mockWriter{
 			hook: func(data []byte) {
 				assert.Equal(t, "", string(data))
 			},
-		}, swagger, &Config{GeneratedTime: false})
+		}, swagger, &GenConfig{GeneratedTime: false})
 	assert.NoError(t, err)
 
 	packageTemplate = swapTemplate

--- a/operation.go
+++ b/operation.go
@@ -810,6 +810,10 @@ func (operation *Operation) parseCombinedObjectSchema(refType string, astFile *a
 	}), nil
 }
 
+func (operation *Operation) ParseAPIObjectSchema(schemaType, refType string, astFile *ast.File) (*spec.Schema, error) {
+	return operation.parseObjectSchema(refType, astFile)
+}
+
 func (operation *Operation) parseAPIObjectSchema(schemaType, refType string, astFile *ast.File) (*spec.Schema, error) {
 	switch schemaType {
 	case OBJECT:


### PR DESCRIPTION
**Describe the PR**

I am working on https://github.com/go-chai/chai - an extension for the chi router that provides support for type safe http handlers via generics. This allows it to also provide swagger spec generation that automatically detects the request/response types, http methods and route paths. Chai uses swaggo/swag annotations for the parts of the swagger spec that cannot be automatically inferred.

I am using swaggo/swag as a library but some of the functions that I needed were unexported and others I needed to modify a bit. I forked swag and made the changes I needed there, but I'd rather not have to maintain that fork and put the changes back into swag itself.

I am opening this PR as a more of a place for discussion for which parts can be merged into swag.
