### PR TITLE
feature: add file data type to document

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 - number (float32)
 - boolean (bool)
 - user defined struct
+- file
 
 ## Security
 | annotation | description | parameters | example |


### PR DESCRIPTION
**Describe the PR**
add data type:  file

**Relation issue**
None

**Additional context**
For a http request, if we use `multipart/form-data` as content-type, we can use file as a param. 
swag can do this, but this part is missing in the document.