### PR TITLE
fix: split extensions param respecting open/close brackets

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -207,7 +207,9 @@ func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 	extensionsTag := ps.tag.Get(extensionsTag)
 	if extensionsTag != "" {
 		structField.extensions = map[string]interface{}{}
+		extensionsTag := strings.ReplaceAll(extensionsTag, `,,`, `{{escape-comma}}`)
 		for _, val := range strings.Split(extensionsTag, ",") {
+			val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
 			parts := strings.SplitN(val, "=", 2)
 			if len(parts) == 2 {
 				structField.extensions[parts[0]] = parts[1]

--- a/field_parser.go
+++ b/field_parser.go
@@ -146,6 +146,46 @@ type structField struct {
 	unique       bool
 }
 
+// splitNotWrapped slices s into all substrings separated by sep if sep is not
+// wrapped by brackets and returns a slice of the substrings between those separators.
+func splitNotWrapped(s string, sep rune) []string {
+	openCloseMap := map[rune]rune{
+		'(': ')',
+		'[': ']',
+		'{': '}',
+	}
+
+	result := make([]string, 0)
+	current := ""
+	var openCount = 0
+	var openChar rune
+	for _, char := range s {
+		if openChar == 0 && openCloseMap[char] != 0 {
+			openChar = char
+			openCount++
+			current += string(char)
+		} else if char == openChar {
+			openCount++
+			current = current + string(char)
+		} else if openCount > 0 && char == openCloseMap[openChar] {
+			openCount--
+			current += string(char)
+		} else if openCount == 0 && char == sep {
+			result = append(result, current)
+			openChar = 0
+			current = ""
+		} else {
+			current += string(char)
+		}
+	}
+
+	if current != "" {
+		result = append(result, current)
+	}
+
+	return result
+}
+
 func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 	types := ps.p.GetSchemaTypePath(schema, 2)
 	if len(types) == 0 {
@@ -207,9 +247,9 @@ func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 	extensionsTag := ps.tag.Get(extensionsTag)
 	if extensionsTag != "" {
 		structField.extensions = map[string]interface{}{}
-		extensionsTag := strings.ReplaceAll(extensionsTag, `,,`, `{{escape-comma}}`)
-		for _, val := range strings.Split(extensionsTag, ",") {
-			val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
+		//extensionsTag := strings.ReplaceAll(extensionsTag, `,,`, `{{escape-comma}}`)
+		for _, val := range splitNotWrapped(extensionsTag, ',') {
+			//val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
 			parts := strings.SplitN(val, "=", 2)
 			if len(parts) == 2 {
 				structField.extensions[parts[0]] = parts[1]

--- a/field_parser.go
+++ b/field_parser.go
@@ -247,9 +247,7 @@ func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 	extensionsTag := ps.tag.Get(extensionsTag)
 	if extensionsTag != "" {
 		structField.extensions = map[string]interface{}{}
-		//extensionsTag := strings.ReplaceAll(extensionsTag, `,,`, `{{escape-comma}}`)
 		for _, val := range splitNotWrapped(extensionsTag, ',') {
-			//val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
 			parts := strings.SplitN(val, "=", 2)
 			if len(parts) == 2 {
 				structField.extensions[parts[0]] = parts[1]

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -87,7 +87,7 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.Equal(t, true, schema.Extensions["x-nullable"])
 		assert.Equal(t, "def", schema.Extensions["x-abc"])
 		assert.Equal(t, false, schema.Extensions["x-omitempty"])
-		assert.Equal(t, "[0,, 9]", schema.Extensions["x-example"])
+		assert.Equal(t, "[0, 9]", schema.Extensions["x-example"])
 	})
 
 	t.Run("Enums tag", func(t *testing.T) {

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -80,7 +80,7 @@ func TestDefaultFieldParser(t *testing.T) {
 		err := newTagBaseFieldParser(
 			&Parser{},
 			&ast.Field{Tag: &ast.BasicLit{
-				Value: `json:"test" extensions:"x-nullable,x-abc=def,!x-omitempty,x-example=[0,, 9]"`,
+				Value: `json:"test" extensions:"x-nullable,x-abc=def,!x-omitempty,x-example=[0, 9],x-example2={çãíœ, (bar=(abc, def)), [0,9]}"`,
 			}},
 		).ComplementSchema(&schema)
 		assert.NoError(t, err)
@@ -88,6 +88,7 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.Equal(t, "def", schema.Extensions["x-abc"])
 		assert.Equal(t, false, schema.Extensions["x-omitempty"])
 		assert.Equal(t, "[0, 9]", schema.Extensions["x-example"])
+		assert.Equal(t, "{çãíœ, (bar=(abc, def)), [0,9]}", schema.Extensions["x-example2"])
 	})
 
 	t.Run("Enums tag", func(t *testing.T) {

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -72,7 +72,22 @@ func TestDefaultFieldParser(t *testing.T) {
 	})
 
 	t.Run("Extensions tag", func(t *testing.T) {
+		t.Parallel()
 
+		schema := spec.Schema{}
+		schema.Type = []string{"int"}
+		schema.Extensions = map[string]interface{}{}
+		err := newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" extensions:"x-nullable,x-abc=def,!x-omitempty,x-example=[0,, 9]"`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, true, schema.Extensions["x-nullable"])
+		assert.Equal(t, "def", schema.Extensions["x-abc"])
+		assert.Equal(t, false, schema.Extensions["x-omitempty"])
+		assert.Equal(t, "[0,, 9]", schema.Extensions["x-example"])
 	})
 
 	t.Run("Enums tag", func(t *testing.T) {

--- a/operation.go
+++ b/operation.go
@@ -495,8 +495,10 @@ func setEnumParam(param *spec.Parameter, attr, objectType, schemaType string) er
 }
 
 func setExtensionParam(param *spec.Parameter, attr string) error {
+	attr = strings.ReplaceAll(attr, `,,`, `{{escape-comma}}`)
 	param.Extensions = map[string]interface{}{}
 	for _, val := range strings.Split(attr, ",") {
+		val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
 		parts := strings.SplitN(val, "=", 2)
 		if len(parts) == 2 {
 			param.Extensions.Add(parts[0], parts[1])

--- a/operation.go
+++ b/operation.go
@@ -495,10 +495,8 @@ func setEnumParam(param *spec.Parameter, attr, objectType, schemaType string) er
 }
 
 func setExtensionParam(param *spec.Parameter, attr string) error {
-	attr = strings.ReplaceAll(attr, `,,`, `{{escape-comma}}`)
 	param.Extensions = map[string]interface{}{}
-	for _, val := range strings.Split(attr, ",") {
-		val = strings.ReplaceAll(val, `{{escape-comma}}`, ",")
+	for _, val := range splitNotWrapped(attr, ',') {
 		parts := strings.SplitN(val, "=", 2)
 		if len(parts) == 2 {
 			param.Extensions.Add(parts[0], parts[1])

--- a/parser_test.go
+++ b/parser_test.go
@@ -2957,7 +2957,7 @@ func TestParseParamCommentExtension(t *testing.T) {
 	src := `
 package main
 
-// @Param request query string true "query params" extensions(x-example=[0,, 9],x-foo=bar)
+// @Param request query string true "query params" extensions(x-example=[0, 9],x-foo=bar)
 // @Success 200
 // @Router /test [get]
 func Fun()  {


### PR DESCRIPTION
**Describe the PR**
split extensions param respecting open/close brackets
`// @Param range query string true "Range" default([0, 9]) extensions(x-example=[0,9])`

**Relation issue**
None.

**Additional context**
When using extensions param with text containing comma the extensions were getting splited wrong.

