### PR TITLE
Imporve performance when generating spec with external dependencies

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -29,6 +29,7 @@ const (
 	parseDepthFlag       = "parseDepth"
 	instanceNameFlag     = "instanceName"
 	overridesFileFlag    = "overridesFile"
+	parseGoListFlag      = "parseGoList"
 )
 
 var initFlags = []cli.Flag{
@@ -110,6 +111,11 @@ var initFlags = []cli.Flag{
 		Value: gen.DefaultOverridesFile,
 		Usage: "File to read global type overrides from.",
 	},
+	&cli.BoolFlag{
+		Name:  parseGoListFlag,
+		Value: true,
+		Usage: "Parse dependency via 'go list'",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -142,6 +148,7 @@ func initAction(ctx *cli.Context) error {
 		ParseDepth:          ctx.Int(parseDepthFlag),
 		InstanceName:        ctx.String(instanceNameFlag),
 		OverridesFile:       ctx.String(overridesFileFlag),
+		ParseGoList:         ctx.Bool(parseGoListFlag),
 	})
 }
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -105,6 +105,9 @@ type Config struct {
 
 	// OverridesFile defines global type overrides.
 	OverridesFile string
+
+	// ParseGoList whether swag use go list to parse dependency
+	ParseGoList bool
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json.
@@ -152,6 +155,7 @@ func (g *Gen) Build(config *Config) error {
 	p.ParseVendor = config.ParseVendor
 	p.ParseDependency = config.ParseDependency
 	p.ParseInternal = config.ParseInternal
+	p.ParseGoList = config.ParseGoList
 
 	if err := p.ParseAPIMultiSearchDir(searchDirs, config.MainAPIFile, config.ParseDepth); err != nil {
 		return err

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -149,13 +149,13 @@ func (g *Gen) Build(config *Config) error {
 		swag.SetCodeExamplesDirectory(config.CodeExampleFilesDir),
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),
+		swag.ParseUsingGoList(config.ParseGoList),
 	)
 
 	p.PropNamingStrategy = config.PropNamingStrategy
 	p.ParseVendor = config.ParseVendor
 	p.ParseDependency = config.ParseDependency
 	p.ParseInternal = config.ParseInternal
-	p.ParseGoList = config.ParseGoList
 
 	if err := p.ParseAPIMultiSearchDir(searchDirs, config.MainAPIFile, config.ParseDepth); err != nil {
 		return err

--- a/golist.go
+++ b/golist.go
@@ -53,11 +53,6 @@ func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
 		return nil
 	}
 
-	// Skip cgo
-	if pkg.Name == "C" {
-		return nil
-	}
-
 	srcDir := pkg.Dir
 	var err error
 	for i := range pkg.GoFiles {
@@ -67,8 +62,9 @@ func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
 		}
 	}
 
-	for i := range pkg.CFiles {
-		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.CFiles[i]), nil)
+	// parse .go source files that import "C"
+	for i := range pkg.CgoFiles {
+		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.CgoFiles[i]), nil)
 		if err != nil {
 			return err
 		}

--- a/golist.go
+++ b/golist.go
@@ -1,0 +1,75 @@
+package swag
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/build"
+	"os/exec"
+	"path/filepath"
+)
+
+func listPackages(ctx context.Context, dir string, env []string, args ...string) (pkgs []*build.Package, finalErr error) {
+	goArgs := append([]string{"list", "-json", "-e"}, args...)
+	cmd := exec.CommandContext(ctx, "go", goArgs...)
+	cmd.Env = env
+	cmd.Dir = dir
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	defer func() {
+		if stderrBuf.Len() > 0 {
+			finalErr = fmt.Errorf("%v\n%s", finalErr, stderrBuf.Bytes())
+		}
+	}()
+
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	dec := json.NewDecoder(stdout)
+	for dec.More() {
+		var pkg build.Package
+		if err := dec.Decode(&pkg); err != nil {
+			return nil, err
+		}
+		pkgs = append(pkgs, &pkg)
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return pkgs, nil
+}
+
+func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
+	ignoreInternal := pkg.Goroot && !parser.ParseInternal
+	if ignoreInternal { // ignored internal
+		return nil
+	}
+
+	// Skip cgo
+	if pkg.Name == "C" {
+		return nil
+	}
+
+	srcDir := pkg.Dir
+	for i := range pkg.GoFiles {
+		path := filepath.Join(srcDir, pkg.GoFiles[i])
+		if err := parser.parseFile(pkg.ImportPath, path, nil); err != nil {
+			return err
+		}
+	}
+
+	for i := range pkg.CFiles {
+		path := filepath.Join(srcDir, pkg.CFiles[i])
+		if err := parser.parseFile(pkg.ImportPath, path, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/golist_test.go
+++ b/golist_test.go
@@ -1,0 +1,116 @@
+package swag
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go/build"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListPackages(t *testing.T) {
+
+	cases := []struct {
+		name      string
+		args      []string
+		searchDir string
+		except    error
+	}{
+		{
+			name:      "errorArgs",
+			args:      []string{"-abc"},
+			searchDir: "testdata/golist",
+			except:    fmt.Errorf("exit status 2"),
+		},
+		{
+			name:      "normal",
+			args:      []string{"-deps"},
+			searchDir: "testdata/golist",
+			except:    nil,
+		},
+		{
+			name:      "list error",
+			args:      []string{"-deps"},
+			searchDir: "testdata/golist_not_exist",
+			except:    errors.New("searchDir not exist"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := listPackages(context.TODO(), c.searchDir, nil, c.args...)
+			if c.except != nil {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestGetAllGoFileInfoFromDepsByList(t *testing.T) {
+	p := New(ParseUsingGoList(true))
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+	cases := []struct {
+		name           string
+		buildPackage   *build.Package
+		ignoreInternal bool
+		except         error
+	}{
+		{
+			name: "normal",
+			buildPackage: &build.Package{
+				Name:       "main",
+				ImportPath: "github.com/swaggo/swag/testdata/golist",
+				Dir:        "testdata/golist",
+				GoFiles:    []string{"main.go"},
+				CgoFiles:   []string{"api/api.go"},
+			},
+			except: nil,
+		},
+		{
+			name: "ignore internal",
+			buildPackage: &build.Package{
+				Goroot: true,
+			},
+			ignoreInternal: true,
+			except:         nil,
+		},
+		{
+			name: "gofiles error",
+			buildPackage: &build.Package{
+				Dir:     "testdata/golist_not_exist",
+				GoFiles: []string{"main.go"},
+			},
+			except: errors.New("file not exist"),
+		},
+		{
+			name: "cgofiles error",
+			buildPackage: &build.Package{
+				Dir:      "testdata/golist_not_exist",
+				CgoFiles: []string{"main.go"},
+			},
+			except: errors.New("file not exist"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.ignoreInternal {
+				p.ParseInternal = false
+			}
+			c.buildPackage.Dir = filepath.Join(pwd, c.buildPackage.Dir)
+			err := p.getAllGoFileInfoFromDepsByList(c.buildPackage)
+			if c.except != nil {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}

--- a/packages.go
+++ b/packages.go
@@ -6,6 +6,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -78,6 +79,11 @@ func (pkgDefs *PackagesDefinitions) CollectAstFile(packageDir, path string, astF
 func rangeFiles(files map[*ast.File]*AstFileInfo, handle func(filename string, file *ast.File) error) error {
 	sortedFiles := make([]*AstFileInfo, 0, len(files))
 	for _, info := range files {
+		// ignore package path prefix with 'vendor' or $GOROOT,
+		// because the router info of api will not be included these files.
+		if strings.HasPrefix(info.PackagePath, "vendor") || strings.HasPrefix(info.Path, runtime.GOROOT()) {
+			continue
+		}
 		sortedFiles = append(sortedFiles, info)
 	}
 

--- a/packages_test.go
+++ b/packages_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/token"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,6 +151,20 @@ func TestPackage_rangeFiles(t *testing.T) {
 			File:        &ast.File{Name: &ast.Ident{Name: "api.go"}},
 			Path:        "testdata/simple/api/api.go",
 			PackagePath: "api",
+		},
+		{
+			Name: &ast.Ident{Name: "foo.go"},
+		}: {
+			File:        &ast.File{Name: &ast.Ident{Name: "foo.go"}},
+			Path:        "vendor/foo/foo.go",
+			PackagePath: "vendor/foo",
+		},
+		{
+			Name: &ast.Ident{Name: "bar.go"},
+		}: {
+			File:        &ast.File{Name: &ast.Ident{Name: "bar.go"}},
+			Path:        filepath.Join(runtime.GOROOT(), "bar.go"),
+			PackagePath: "bar",
 		},
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -142,8 +142,8 @@ type Parser struct {
 	// Overrides allows global replacements of types. A blank replacement will be skipped.
 	Overrides map[string]string
 
-	// ParseGoList whether swag use go list to parse dependency
-	ParseGoList bool
+	// parseGoList whether swag use go list to parse dependency
+	parseGoList bool
 }
 
 // FieldParserFactory create FieldParser.
@@ -265,6 +265,13 @@ func SetOverrides(overrides map[string]string) func(parser *Parser) {
 	}
 }
 
+// ParseUsingGoList sets whether swag use go list to parse dependency
+func ParseUsingGoList(enabled bool) func(parser *Parser) {
+	return func(p *Parser) {
+		p.parseGoList = enabled
+	}
+}
+
 // ParseAPI parses general api info for given searchDir and mainAPIFile.
 func (parser *Parser) ParseAPI(searchDir string, mainAPIFile string, parseDepth int) error {
 	return parser.ParseAPIMultiSearchDir([]string{searchDir}, mainAPIFile, parseDepth)
@@ -291,9 +298,9 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 		return err
 	}
 
+	// Use 'go list' command instead of depth.Resolve()
 	if parser.ParseDependency {
-		// Use 'go list' command instead of depth.Resolve()
-		if parser.ParseGoList {
+		if parser.parseGoList {
 			pkgs, err := listPackages(context.Background(), filepath.Dir(absMainAPIFilePath), nil, "-deps")
 			if err != nil {
 				return fmt.Errorf("pkg %s cannot find all dependencies, %s", filepath.Dir(absMainAPIFilePath), err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -2164,7 +2164,7 @@ func TestParseGoList(t *testing.T) {
 	mainAPIFile := "main.go"
 	p := New()
 	p.ParseDependency = true
-	p.ParseGoList = true
+	p.parseGoList = true
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -2159,6 +2159,16 @@ func TestParseExternalModels(t *testing.T) {
 	assert.Equal(t, string(expected), string(b))
 }
 
+func TestParseGoList(t *testing.T) {
+	searchDir := "testdata/golist"
+	mainAPIFile := "main.go"
+	p := New()
+	p.ParseDependency = true
+	p.ParseGoList = true
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	assert.NoError(t, err)
+}
+
 func TestParser_ParseStructArrayObject(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/golist/api/api.go
+++ b/testdata/golist/api/api.go
@@ -4,9 +4,35 @@ package api
 #include "foo.h"
 */
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 func PrintInt(i, j int) {
 	res := C.add(C.int(i), C.int(j))
 	fmt.Println(res)
+}
+
+type Foo struct {
+	ID        int      `json:"id"`
+	Name      string   `json:"name"`
+	PhotoUrls []string `json:"photoUrls"`
+	Status    string   `json:"status"`
+}
+
+// GetFoo example
+// @Summary Get foo
+// @Description get foo
+// @ID foo
+// @Accept  json
+// @Produce  json
+// @Param   some_id      query   int     true  "Some ID"
+// @Param	some_foo	 formData Foo true "Foo"
+// @Success 200 {string} string	"ok"
+// @Failure 400 {object} web.APIError "We need ID!!"
+// @Failure 404 {object} web.APIError "Can not find ID"
+// @Router /testapi/foo [get]
+func GetFoo(w http.ResponseWriter, r *http.Request) {
+	// write your code
 }

--- a/testdata/golist/api/api.go
+++ b/testdata/golist/api/api.go
@@ -1,0 +1,12 @@
+package api
+
+/*
+#include "foo.h"
+*/
+import "C"
+import "fmt"
+
+func PrintInt(i, j int) {
+	res := C.add(C.int(i), C.int(j))
+	fmt.Println(res)
+}

--- a/testdata/golist/api/foo.c
+++ b/testdata/golist/api/foo.c
@@ -1,0 +1,3 @@
+int add(int a, int b) {
+    return a + b;
+}

--- a/testdata/golist/api/foo.h
+++ b/testdata/golist/api/foo.h
@@ -1,0 +1,1 @@
+int add(int, int);

--- a/testdata/golist/main.go
+++ b/testdata/golist/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/example/basic/api"
+	goapi "github.com/swaggo/swag/testdata/golist/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server Petstore server.
+// @termsOfService http://swagger.io/terms/
+
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host petstore.swagger.io
+// @BasePath /v2
+func main() {
+	goapi.PrintInt(10, 5)
+	http.HandleFunc("/testapi/get-string-by-int/", api.GetStringByInt)
+	http.HandleFunc("//testapi/get-struct-array-by-string/", api.GetStructArrayByString)
+	http.HandleFunc("/testapi/upload", api.Upload)
+	http.ListenAndServe(":8080", nil)
+}

--- a/testdata/golist_disablemodule/api/api.go
+++ b/testdata/golist_disablemodule/api/api.go
@@ -1,0 +1,14 @@
+package api
+
+/*
+#include "foo.h"
+*/
+import "C"
+import (
+	"fmt"
+)
+
+func PrintInt(i, j int) {
+	res := C.add(C.int(i), C.int(j))
+	fmt.Println(res)
+}

--- a/testdata/golist_disablemodule/api/foo.c
+++ b/testdata/golist_disablemodule/api/foo.c
@@ -1,0 +1,3 @@
+int add(int a, int b) {
+    return a + b;
+}

--- a/testdata/golist_disablemodule/api/foo.h
+++ b/testdata/golist_disablemodule/api/foo.h
@@ -1,0 +1,1 @@
+int add(int, int);

--- a/testdata/golist_disablemodule/main.go
+++ b/testdata/golist_disablemodule/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/swaggo/swag/example/basic/api"
-	goapi "github.com/swaggo/swag/testdata/golist/api"
+	internalapi "github.com/swaggo/swag/testdata/golist_disablemodule/api"
 )
 
 // @title Swagger Example API
@@ -23,14 +23,12 @@ import (
 // @in header
 // @name Authorization
 
-// @query.collection.format multi
 // @host petstore.swagger.io
 // @BasePath /v2
 func main() {
-	goapi.PrintInt(10, 5)
+	internalapi.PrintInt(0, 1)
 	http.HandleFunc("/testapi/get-string-by-int/", api.GetStringByInt)
 	http.HandleFunc("/testapi/get-struct-array-by-string/", api.GetStructArrayByString)
 	http.HandleFunc("/testapi/upload", api.Upload)
-	http.HandleFunc("/testapi/foo", goapi.GetFoo)
 	http.ListenAndServe(":8080", nil)
 }

--- a/testdata/golist_invalid/main.go
+++ b/testdata/golist_invalid/main.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/swaggo/swag/example/basic/api"
-	goapi "github.com/swaggo/swag/testdata/golist/api"
+	"github.com/swaggo/swag/testdata/invalid_external_pkg/invalid"
 )
 
 // @title Swagger Example API
@@ -23,14 +23,10 @@ import (
 // @in header
 // @name Authorization
 
-// @query.collection.format multi
 // @host petstore.swagger.io
 // @BasePath /v2
 func main() {
-	goapi.PrintInt(10, 5)
-	http.HandleFunc("/testapi/get-string-by-int/", api.GetStringByInt)
-	http.HandleFunc("/testapi/get-struct-array-by-string/", api.GetStructArrayByString)
+	invalid.Foo()
 	http.HandleFunc("/testapi/upload", api.Upload)
-	http.HandleFunc("/testapi/foo", goapi.GetFoo)
 	http.ListenAndServe(":8080", nil)
 }

--- a/testdata/invalid_external_pkg/invalid/normal.go
+++ b/testdata/invalid_external_pkg/invalid/normal.go
@@ -1,0 +1,5 @@
+package invalid
+
+func Foo() {
+
+}

--- a/testdata/invalid_external_pkg/main.go
+++ b/testdata/invalid_external_pkg/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
**Describe the PR**

Directly use `go list` command instead of `depth`, because `depth` use go standard library `build.Import`  and call the `build.Import` too many times, it will spent too many times when the large dependencies.

Because `swag` only needs to know which files are dependent, and does not need to get the level of dependencies, all dependencies can be directly through `go list` command, and `swag` not need to go through deep loop again, but if use `depth`, `swag` still need to loop too many times, so i refactor the swag get ast files code.

**Relation issue**

Fixes: https://github.com/swaggo/swag/issues/1032

**Additional context**

Added the `--parseGoList` flag, the default value is true default. If someone does not want to enable it, it can be set to false when init, if it's set to false, `swag` still use `depth` for dependency parser.
