### PR TITLE
feat: allow empty example strings for struct fields

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -182,8 +182,8 @@ func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 	jsonTag := ps.tag.Get(jsonTag)
 	// json:"name,string" or json:",string"
 
-	exampleTag := ps.tag.Get(exampleTag)
-	if exampleTag != "" {
+	exampleTag, ok := ps.tag.Lookup(exampleTag)
+	if ok {
 		structField.exampleValue = exampleTag
 		if !strings.Contains(jsonTag, ",string") {
 			example, err := defineTypeOfExample(structField.schemaType, structField.arrayType, exampleTag)

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -24,6 +24,17 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.Equal(t, "one", schema.Example)
 
 		schema = spec.Schema{}
+		schema.Type = []string{"string"}
+		err = newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" example:""`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, "", schema.Example)
+
+		schema = spec.Schema{}
 		schema.Type = []string{"float"}
 		err = newTagBaseFieldParser(
 			&Parser{},


### PR DESCRIPTION
**Describe the PR**
allow empty example strings for struct fields 

**Relation issue**
#1102

**Additional context**
None.
