### PR TITLE
Add `error` as a Primitive Type

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -81,7 +81,7 @@ func TransToValidSchemeType(typeName string) string {
 		return NUMBER
 	case "bool":
 		return BOOLEAN
-	case "string":
+	case "string", "error":
 		return STRING
 	}
 
@@ -107,7 +107,8 @@ func IsGolangPrimitiveType(typeName string) bool {
 		"float64",
 		"bool",
 		"string",
-		"any":
+		"any",
+		"error":
 		return true
 	}
 

--- a/schema_test.go
+++ b/schema_test.go
@@ -30,6 +30,7 @@ func TestTransToValidSchemeType(t *testing.T) {
 	assert.Equal(t, TransToValidSchemeType("float32"), NUMBER)
 	assert.Equal(t, TransToValidSchemeType("bool"), BOOLEAN)
 	assert.Equal(t, TransToValidSchemeType("string"), STRING)
+	assert.Equal(t, TransToValidSchemeType("error"), STRING)
 
 	// should accept any type, due to user defined types
 	other := "oops"


### PR DESCRIPTION
**Describe the PR**

- When the handler is returning a custom error struct type, and it contains the built-in `error` interface like below, the error `:cannot find type definition: error` would occur.

```go
type ErrorResponse struct {
	Message string `json:"message"`
	Cause   error  `json:"cause"`
}
```

- I am thinking, since the `error` interface is also a built-in type, ~and when it marshals to JSON using the interface (instead of any underneath implementation), it should be translated to a string~.
- Please let me know if/where I should add more tests!

-----

**Relation Issue**

https://github.com/swaggo/swag/issues/1171
