### PR TITLE
Update repository URL for Fiber Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ OPTIONS:
 - [buffalo](https://github.com/swaggo/buffalo-swagger)
 - [net/http](https://github.com/swaggo/http-swagger)
 - [flamingo](https://github.com/i-love-flamingo/swagger)
-- [fiber](https://github.com/arsmn/fiber-swagger)
+- [fiber](https://github.com/gofiber/swagger)
 - [atreugo](https://github.com/Nerzal/atreugo-swagger)
 
 ## How to use it with Gin


### PR DESCRIPTION
**Describe the PR**
Update repository URL for Fiber Swagger (the repository was moved there).

The repository https://github.com/arsmn/fiber-swagger is deprecated.
