### PR TITLE
fix: don't skip ".." directory

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1567,7 +1567,7 @@ func walkWith(excludes map[string]struct{}, parseVendor bool) func(path string, 
 		if f.IsDir() {
 			if !parseVendor && f.Name() == "vendor" || // ignore "vendor"
 				f.Name() == "docs" || // exclude docs
-				len(f.Name()) > 1 && f.Name()[0] == '.' { // exclude all hidden folder
+				len(f.Name()) > 1 && f.Name()[0] == '.' && f.Name() != ".." { // exclude all hidden folder
 				return filepath.SkipDir
 			}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -3557,6 +3557,7 @@ func TestParser_Skip(t *testing.T) {
 	assert.NoError(t, parser.Skip("", &mockFS{FileName: "models", IsDirectory: true}))
 	assert.NoError(t, parser.Skip("", &mockFS{FileName: "admin", IsDirectory: true}))
 	assert.NoError(t, parser.Skip("", &mockFS{FileName: "release", IsDirectory: true}))
+	assert.NoError(t, parser.Skip("", &mockFS{FileName: "..", IsDirectory: true}))
 
 	parser = New(SetExcludedDirsAndFiles("admin/release,admin/models"))
 	assert.NoError(t, parser.Skip("admin", &mockFS{IsDirectory: true}))


### PR DESCRIPTION
`Parser.Skip()` treats `..` directory as hidden folder and return a `filepath.SkipDir`. If `..` is provided via `--dir` option, `swag` will miss some files.