### PR TITLE
fix: temp dir to be the same as SerchDir to avoid invalid cross-device link (#1203)

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -103,7 +103,7 @@ func (f *Format) format(path string) error {
 }
 
 func write(path string, contents []byte) error {
-	f, err := ioutil.TempFile(filepath.Split(path))
+	f, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Describe the PR**

Fix temp file logic t avoid invalid cross-device link 

**Relation issue**
https://github.com/swaggo/swag/issues/1203

**Additional context**

**Cause**

This  error  occurs when os.Rename between different partitions

https://groups.google.com/g/golang-dev/c/5w7Jmg_iCJQ

In other words, TMPDIR and PWD  are different partitions.

When  `ioutil.TempFile(dir, pattern string)` 's first parameter is empty string, TempFile are created on TMPDIR.

> If dir is the empty string, TempFile uses the default directory for temporary files (see os.TempDir).
https://pkg.go.dev/io/ioutil#TempFile

**Solution**
Fix `filepath.Split()` to `filepath.Dir() and Base()`.     
`filepath.Split` may return an empty string.

```go
package main

import (
	"fmt"
	"path/filepath"
)

func main() {
	paths := []string{
		"/home/swaggo/main.go",
		"main.go",
	}

	fmt.Println("filepath.Split")
	for _, p := range paths {
		dir, file := filepath.Split(p)
		fmt.Printf("input: %q\n\tdir: %q\n\tfile: %q\n", p, dir, file)
	}
	fmt.Println("filepath.Dir, Base")
	for _, p := range paths {
		dir := filepath.Dir(p)
		file := filepath.Base(p)
		fmt.Printf("input: %q\n\tdir: %q\n\tfile: %q\n", p, dir, file)
	}
}
```

```sh
filepath.Split
input: "/home/swaggo/main.go"
	dir: "/home/swaggo/"
	file: "main.go"
input: "main.go"
	dir: ""
	file: "main.go"
filepath.Dir, Base
input: "/home/swaggo/main.go"
	dir: "/home/swaggo"
	file: "main.go"
input: "main.go"
	dir: "."
	file: "main.go"
```

**Check**

```sh
> pwd
/add_disk/swag
> go install github.com/swaggo/swag/cmd/swag@latest
> swag fmt main.go
2022/06/25 01:12:20 fmt: rename /tmp/main.go3296877051 main.go: invalid cross-device link
> make install
....
> swag fmt main.go
> 
```
