### PR TITLE
Set env CGO_ENABLED=0  for goreleaser to avoid dynamic linking

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,8 @@ build:
   ignore:
     - goos: darwin
       goarch: arm64
+  env:
+    - CGO_ENABLED=0
 archives:
   -
     replacements:


### PR DESCRIPTION
Binaries that are being built by the goreleaser don't have the CGO_ENABLED=0 env set which means they are dynamically linked to 
/lib64/ld-linux-x86-64.so.2  (or whichever version of ld-linux)
In some versions of distros, there are different versions ld-linux which makes the swag not start properly. 
In my case, I wanted to download the release binary into intermediate docker based on alpine to generate API documentation and it was always failing with "file not found" error.
NOTE: This change was not tested - I don't have the whole setup to test the goreleaser
sources:
https://jvns.ca/blog/2021/11/17/debugging-a-weird--file-not-found--error/
https://goreleaser.com/customization/build/

**Describe the PR**
Add CGO_ENABLED=0 into .goreleaser

**Relation issue**


**Additional context**

