### PR TITLE
feat: get swagger instance from register

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -39,6 +39,15 @@ func Register(name string, swagger Swagger) {
 	swags[name] = swagger
 }
 
+// GetSwagger returns the swagger instance for given name.
+// If not found, returns nil.
+func GetSwagger(name string) Swagger {
+	swaggerMu.RLock()
+	defer swaggerMu.RUnlock()
+
+	return swags[name]
+}
+
 // ReadDoc reads swagger document. An optional name parameter can be passed to read a specific document.
 // The default name is "swagger".
 func ReadDoc(optionalName ...string) (string, error) {

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -219,3 +219,14 @@ func TestCalledTwicelRegister(t *testing.T) {
 func setup() {
 	swags = nil
 }
+
+func TestGetSwagger(t *testing.T) {
+	setup()
+	instance := &s{}
+	Register(Name, instance)
+	swagger := GetSwagger(Name)
+	assert.Equal(t, instance, swagger)
+
+	swagger = GetSwagger("invalid")
+	assert.Nil(t, swagger)
+}


### PR DESCRIPTION
**Describe the PR**
Problem starts if our swagger instance generated by CI and registered.
In main program if we want to modify some parameters inside of that instance is it not possible because code not in there.

Getting swagger instance with name from register it is easy to work with it, without need any workaround.

Swagger is an interface so we should do some casting but we know the our code and it should be this type.

```go
if s, ok := swag.GetSwagger("swagger").(*swag.Spec); s != nil && ok {
	s.Version = "1.0.0"
	s.Title = "Test"
}
```

**Relation issue**
#1240 
