### PR TITLE
fix: Nested generic fields not fully working, if generic type is from…

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -167,6 +167,10 @@ func (pkgDefs *PackagesDefinitions) parametrizeStruct(original *TypeSpecDef, ful
 // splitStructName splits a generic struct name in his parts
 func splitStructName(fullGenericForm string) (string, []string) {
 	// split only at the first '[' and remove the last ']'
+	if fullGenericForm[len(fullGenericForm)-1] != ']' {
+		return "", nil
+	}
+
 	genericParams := strings.SplitN(strings.TrimSpace(fullGenericForm)[:len(fullGenericForm)-1], "[", 2)
 	if len(genericParams) == 1 {
 		return "", nil

--- a/generics_test.go
+++ b/generics_test.go
@@ -93,6 +93,87 @@ func TestParseGenericsNames(t *testing.T) {
 	assert.Equal(t, string(expected), string(b))
 }
 
+func TestParametrizeStruct(t *testing.T) {
+	pd := PackagesDefinitions{
+		packages: make(map[string]*PackageDefinitions),
+	}
+	// valid
+	typeSpec := pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}, {Names: []*ast.Ident{{Name: "T2"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string, []string]", false)
+	assert.Equal(t, "$test.Field-string-array_string", typeSpec.Name())
+
+	// definition contains one type params, but two type params are provided
+	typeSpec = pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string, string]", false)
+	assert.Nil(t, typeSpec)
+
+	// definition contains two type params, but only one is used
+	typeSpec = pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}, {Names: []*ast.Ident{{Name: "T2"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string]", false)
+	assert.Nil(t, typeSpec)
+
+	// name is not a valid type name
+	typeSpec = pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}, {Names: []*ast.Ident{{Name: "T2"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string", false)
+	assert.Nil(t, typeSpec)
+
+	typeSpec = pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}, {Names: []*ast.Ident{{Name: "T2"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string, [string]", false)
+	assert.Nil(t, typeSpec)
+
+	typeSpec = pd.parametrizeStruct(&TypeSpecDef{
+		TypeSpec: &ast.TypeSpec{
+			Name:       &ast.Ident{Name: "Field"},
+			TypeParams: &ast.FieldList{List: []*ast.Field{{Names: []*ast.Ident{{Name: "T"}}}, {Names: []*ast.Ident{{Name: "T2"}}}}},
+			Type:       &ast.StructType{Struct: 100, Fields: &ast.FieldList{Opening: 101, Closing: 102}},
+		}}, "test.Field[string, ]string]", false)
+	assert.Nil(t, typeSpec)
+}
+
+func TestSplitStructNames(t *testing.T) {
+	t.Parallel()
+
+	field, params := splitStructName("test.Field")
+	assert.Empty(t, field)
+	assert.Nil(t, params)
+
+	field, params = splitStructName("test.Field]")
+	assert.Empty(t, field)
+	assert.Nil(t, params)
+
+	field, params = splitStructName("test.Field[string")
+	assert.Empty(t, field)
+	assert.Nil(t, params)
+
+	field, params = splitStructName("test.Field[string]")
+	assert.Equal(t, "test.Field", field)
+	assert.Equal(t, []string{"string"}, params)
+
+	field, params = splitStructName("test.Field[string, []string]")
+	assert.Equal(t, "test.Field", field)
+	assert.Equal(t, []string{"string", "[]string"}, params)
+}
+
 func TestGetGenericFieldType(t *testing.T) {
 	field, err := getFieldType(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
@@ -123,6 +204,34 @@ func TestGetGenericFieldType(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test.Field[string,int]", field)
+
+	field, err = getFieldType(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.IndexListExpr{
+			X:       &ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}},
+			Indices: []ast.Expr{&ast.Ident{Name: "string"}, &ast.ArrayType{Elt: &ast.Ident{Name: "int"}}},
+		},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "test.Field[string,[]int]", field)
+
+	field, err = getFieldType(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.IndexListExpr{
+			X:       &ast.BadExpr{},
+			Indices: []ast.Expr{&ast.Ident{Name: "string"}, &ast.Ident{Name: "int"}},
+		},
+	)
+	assert.Error(t, err)
+
+	field, err = getFieldType(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.IndexListExpr{
+			X:       &ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}},
+			Indices: []ast.Expr{&ast.Ident{Name: "string"}, &ast.ArrayType{Elt: &ast.BadExpr{}}},
+		},
+	)
+	assert.Error(t, err)
 
 	field, err = getFieldType(
 		&ast.File{Name: &ast.Ident{Name: "test"}},

--- a/generics_test.go
+++ b/generics_test.go
@@ -148,4 +148,40 @@ func TestGetGenericFieldType(t *testing.T) {
 		&ast.IndexExpr{X: &ast.Ident{Name: "Field"}, Index: &ast.BadExpr{}},
 	)
 	assert.Error(t, err)
+
+	field, err = getFieldType(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.IndexExpr{X: &ast.SelectorExpr{X: &ast.Ident{Name: "field"}, Sel: &ast.Ident{Name: "Name"}}, Index: &ast.Ident{Name: "string"}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "field.Name[string]", field)
+}
+
+func TestGetGenericTypeName(t *testing.T) {
+	field, err := getGenericTypeName(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "test.Field", field)
+
+	field, err = getGenericTypeName(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.ArrayType{Elt: &ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "test.Field", field)
+
+	field, err = getGenericTypeName(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.SelectorExpr{X: &ast.Ident{Name: "field"}, Sel: &ast.Ident{Name: "Name"}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "field.Name", field)
+
+	_, err = getGenericTypeName(
+		&ast.File{Name: &ast.Ident{Name: "test"}},
+		&ast.BadExpr{},
+	)
+	assert.Error(t, err)
 }

--- a/testdata/generics_property/api/api.go
+++ b/testdata/generics_property/api/api.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"github.com/swaggo/swag/testdata/generics_property/web"
 	"net/http"
 )
+
+type NestedResponse struct {
+	web.GenericResponse[[]string, *uint8]
+}
 
 // @Summary List Posts
 // @Description Get All of the Posts
@@ -12,6 +17,7 @@ import (
 // @Success 200 {object} web.PostResponse "ok"
 // @Success 201 {object} web.PostResponses "ok"
 // @Success 202 {object} web.StringResponse "ok"
+// @Success 203 {object} NestedResponse "ok"
 // @Router /posts [get]
 func GetPosts(w http.ResponseWriter, r *http.Request) {
 }

--- a/testdata/generics_property/expected.json
+++ b/testdata/generics_property/expected.json
@@ -39,11 +39,6 @@
                         "type": "integer",
                         "name": "rows",
                         "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "name": "search",
-                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -64,12 +59,32 @@
                         "schema": {
                             "$ref": "#/definitions/web.StringResponse"
                         }
+                    },
+                    "203": {
+                        "description": "ok",
+                        "schema": {
+                            "$ref": "#/definitions/api.NestedResponse"
+                        }
                     }
                 }
             }
         }
     },
     "definitions": {
+        "api.NestedResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "items2": {
+                    "type": "integer"
+                }
+            }
+        },
         "types.Field-string": {
             "type": "object",
             "properties": {

--- a/testdata/generics_property/web/handler.go
+++ b/testdata/generics_property/web/handler.go
@@ -28,7 +28,7 @@ func (String) Where(ps ...PostSelector) String {
 
 type PostPager struct {
 	Pager[String, PostSelector]
-	Search string `json:"search" form:"search"`
+	Search types.Field[string] `json:"search" form:"search"`
 }
 
 type PostResponse struct {


### PR DESCRIPTION
**Describe the PR**
Fixes the bug described in https://github.com/swaggo/swag/issues/1304
- full name generation changed and support for SelectorExpr added
- prepend package only, if type name does not contain package

**Relation issue**
https://github.com/swaggo/swag/issues/1304

**Additional context**
All changes are backward compatible and have been tested with Go 1.15, 1.16, 1.17, 1.18 and 1.19.
