### PR TITLE
fix: Generic Fields does not handle Arrays in the .swaggo file

### DIFF
--- a/generics_test.go
+++ b/generics_test.go
@@ -31,8 +31,9 @@ func TestParseGenericsBasic(t *testing.T) {
 
 	p := New()
 	p.Overrides = map[string]string{
-		"types.Field[string]":              "string",
-		"types.DoubleField[string,string]": "string",
+		"types.Field[string]":               "string",
+		"types.DoubleField[string,string]":  "[]string",
+		"types.TrippleField[string,string]": "[][]string",
 	}
 
 	err = p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)

--- a/testdata/generics_basic/.swaggo
+++ b/testdata/generics_basic/.swaggo
@@ -1,2 +1,3 @@
 replace types.Field[string] string
-replace types.DoubleField[string,string] string
+replace types.DoubleField[string,string] []string
+replace types.TrippleField[string,string] [][]string

--- a/testdata/generics_basic/expected.json
+++ b/testdata/generics_basic/expected.json
@@ -181,8 +181,20 @@
         "types.Hello": {
             "type": "object",
             "properties": {
+                "myNewArrayField": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "myNewField": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "myStringField1": {
                     "type": "string"

--- a/testdata/generics_basic/types/string.go
+++ b/testdata/generics_basic/types/string.go
@@ -9,8 +9,14 @@ type DoubleField[T1 any, T2 any] struct {
 	Value2 T2
 }
 
+type TrippleField[T1 any, T2 any] struct {
+	Value1 T1
+	Value2 T2
+}
+
 type Hello struct {
-	MyStringField1 Field[*string]               `json:"myStringField1"`
-	MyStringField2 Field[string]                `json:"myStringField2"`
-	MyArrayField   DoubleField[*string, string] `json:"myNewField"`
+	MyStringField1    Field[*string]                `json:"myStringField1"`
+	MyStringField2    Field[string]                 `json:"myStringField2"`
+	MyArrayField      DoubleField[*string, string]  `json:"myNewField"`
+	MyArrayDepthField TrippleField[*string, string] `json:"myNewArrayField"`
 }


### PR DESCRIPTION
**Describe the PR**
Fixes Bug described in https://github.com/swaggo/swag/issues/1318 and https://github.com/swaggo/swag/issues/1320

**Relation issue**
- https://github.com/swaggo/swag/issues/1318
- https://github.com/swaggo/swag/issues/1320

**Additional context**
Since I did not find any suitable tests, I integrated them into the generics tests.
Tested with Go 1.15, 1.16, 1.17, 1.18 and 1.19.
