### PR TITLE
support x-go-type for Overrides 支持为override 类型指定其原始的go type

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -2133,6 +2133,13 @@ func TestParseImportAliases(t *testing.T) {
 	assert.Equal(t, string(expected), string(b))
 }
 
+func TestAddExtXGoType(t *testing.T) {
+	p := New()
+	assert.NotPanics(t, func() {
+		p.addExtXGoType(nil, "hello")
+	})
+
+}
 func TestParseTypeOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/global_override/expected.json
+++ b/testdata/global_override/expected.json
@@ -45,7 +45,13 @@
             "type": "object",
             "properties": {
                 "application": {
-                    "type": "string"
+                    "type": "string",
+                    "x-go-type": {
+                        "import": {
+                            "package": "github.com/swaggo/swag/testdata/global_override/types"
+                        },
+                        "type": "Application"
+                    }
                 },
                 "application2": {
                     "$ref": "#/definitions/othertypes.Application"
@@ -53,7 +59,13 @@
                 "application_array": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "x-go-type": {
+                            "import": {
+                                "package": "github.com/swaggo/swag/testdata/global_override/types"
+                            },
+                            "type": "Application"
+                        }
                     }
                 },
                 "application_time": {


### PR DESCRIPTION
    

**Describe the PR**
When Override detected, supporting add "x-go-type" extension for that field.

```
            "field": {
                    "type": "string",
                    "x-go-type": {
                        "import": {
                            "package": "github.com/swaggo/swag/testdata/global_override/types"
                        },
                        "type": "Application"
                    }
```
**Relation issue**
none.

**Additional context**

```
type JsonTimestamp time.Time 
func (jt JsonTimestamp) MarshalJSON() ([]byte, error) {
	if time.Time(jt).IsZero() {
		return []byte("0"), nil
	}
	ts := time.Time(jt).Unix()
	if ts < 0 {
		ts = 0
	}

	return []byte(strconv.FormatInt(ts, 10)), nil
}

  type DemoReq struct {
	CreateTime jsonx.JsonTimestamp `form:"create_time" json:"create_time"  example:"1650796560"`                                   
}


```
 .swaggo:
```
 replace gitlab.luojilab.com/zeroteam/common/jsonx.JsonTimestamp integer
```
expected:
```
        "models.DemoReq": {
            "type": "object",
            "properties": {
                "create_time": {
                    "type": "integer",
                    "x-go-type": {
                        "import": {
                            "package": "gitlab.luojilab.com/zeroteam/common/jsonx"
                        },
                        "type": "JsonTimestamp"
                    }
                }
            }
        },
```
but got:
```
        "models.DemoReq": {
            "type": "object",
            "properties": {
                "create_time": {
                    "type": "integer"              
                }
            }
        },
```


I want  to generate client code with `https://github.com/go-swagger/go-swagger` 

```
 swagger generate client -f /tmp/docs/swagger.json  -t ~/go/src/hello
```
with this PR I would got 
```
type DemoReq struct {
	CreateTime jsonx.JsonTimestamp `json:"create_time"`
}
```
Without it :
```
type DemoReq struct {
	CreateTime int `json:"create_time"`
}
```

