### PR TITLE
fix: Generics not detected if name does not contain a pkg name

### DIFF
--- a/testdata/generics_basic/api/api.go
+++ b/testdata/generics_basic/api/api.go
@@ -7,6 +7,17 @@ import (
 	"github.com/swaggo/swag/testdata/generics_basic/web"
 )
 
+type Response[T any, X any] struct {
+	Data T
+	Meta X
+
+	Status string
+}
+
+type StringStruct struct {
+	Data string
+}
+
 // @Summary Add a new pet to the store
 // @Description get string by ID
 // @Accept  json
@@ -16,6 +27,8 @@ import (
 // @Success 201 {object} web.GenericResponse[types.Hello]
 // @Success 202 {object} web.GenericResponse[types.Field[string]]
 // @Success 203 {object} web.GenericResponse[types.Field[int]]
+// @Success 204 {object} Response[string, types.Field[int]]
+// @Success 205 {object} Response[StringStruct, types.Field[int]]
 // @Success 222 {object} web.GenericResponseMulti[types.Post, types.Post]
 // @Failure 400 {object} web.APIError "We need ID!!"
 // @Failure 404 {object} web.APIError "Can not find ID"

--- a/testdata/generics_basic/expected.json
+++ b/testdata/generics_basic/expected.json
@@ -147,6 +147,18 @@
                             "$ref": "#/definitions/web.GenericResponse-types_Field_int"
                         }
                     },
+                    "204": {
+                        "description": "No Content",
+                        "schema": {
+                            "$ref": "#/definitions/api.Response-string-types_Field_int"
+                        }
+                    },
+                    "205": {
+                        "description": "Reset Content",
+                        "schema": {
+                            "$ref": "#/definitions/api.Response-api_StringStruct-types_Field_int"
+                        }
+                    },
                     "222": {
                         "description": "",
                         "schema": {
@@ -170,6 +182,42 @@
         }
     },
     "definitions": {
+        "api.Response-api_StringStruct-types_Field_int": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/api.StringStruct"
+                },
+                "meta": {
+                    "$ref": "#/definitions/types.Field-int"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.Response-string-types_Field_int": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                },
+                "meta": {
+                    "$ref": "#/definitions/types.Field-int"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.StringStruct": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                }
+            }
+        },
         "types.Field-int": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
**Describe the PR**
Fixes bug described in https://github.com/swaggo/swag/issues/1319

- Generic detection moved to own method
- prepend pkg name if not provided

**Relation issue**
https://github.com/swaggo/swag/issues/1319

**Additional context**
Tested with Go 1.15, 1.16, 1.17, 1.18 and 1.19.
