### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -145,7 +145,7 @@ func initAction(ctx *cli.Context) error {
 	}
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	if ctx.Bool(quietFlag) {
-		logger = log.New(ioutil.Discard, "", log.LstdFlags)
+		logger = log.New(io.Discard, "", log.LstdFlags)
 	}
 
 	return gen.New().Build(&gen.Config{

--- a/format/format.go
+++ b/format/format.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,7 +90,7 @@ func (f *Format) excludeFile(path string) bool {
 }
 
 func (f *Format) format(path string) error {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -103,7 +102,7 @@ func (f *Format) format(path string) error {
 }
 
 func write(path string, contents []byte) error {
-	f, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return err
 	}

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -2,7 +2,6 @@ package format
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +43,7 @@ func TestFormat_DefaultExcludes(t *testing.T) {
 
 func TestFormat_ParseError(t *testing.T) {
 	fx := setup(t)
-	ioutil.WriteFile(filepath.Join(fx.basedir, "parse_error.go"), []byte(`package main
+	os.WriteFile(filepath.Join(fx.basedir, "parse_error.go"), []byte(`package main
 		func invalid() {`), 0644)
 	assert.Error(t, New().Build(&Config{SearchDir: fx.basedir}))
 }
@@ -82,7 +81,7 @@ func setup(t *testing.T) *fixture {
 		if err := os.MkdirAll(filepath.Dir(fullpath), 0755); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(fullpath, contents, 0644); err != nil {
+		if err := os.WriteFile(fullpath, contents, 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -90,7 +89,7 @@ func setup(t *testing.T) *fixture {
 }
 
 func (fx *fixture) isFormatted(file string) bool {
-	contents, err := ioutil.ReadFile(filepath.Join(fx.basedir, filepath.Clean(file)))
+	contents, err := os.ReadFile(filepath.Join(fx.basedir, filepath.Clean(file)))
 	if err != nil {
 		fx.t.Fatal(err)
 	}

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -95,7 +94,7 @@ func TestGen_BuildInstanceName(t *testing.T) {
 	goSourceFile := filepath.Join(config.OutputDir, "docs.go")
 
 	// Validate default registration name
-	expectedCode, err := ioutil.ReadFile(goSourceFile)
+	expectedCode, err := os.ReadFile(goSourceFile)
 	if err != nil {
 		require.NoError(t, err)
 	}
@@ -119,7 +118,7 @@ func TestGen_BuildInstanceName(t *testing.T) {
 	goSourceFile = filepath.Join(config.OutputDir, config.InstanceName+"_"+"docs.go")
 	assert.NoError(t, New().Build(config))
 
-	expectedCode, err = ioutil.ReadFile(goSourceFile)
+	expectedCode, err = os.ReadFile(goSourceFile)
 	if err != nil {
 		require.NoError(t, err)
 	}
@@ -254,7 +253,7 @@ func TestGen_BuildDescriptionWithQuotes(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	expectedJSON, err := ioutil.ReadFile(filepath.Join(config.SearchDir, "expected.json"))
+	expectedJSON, err := os.ReadFile(filepath.Join(config.SearchDir, "expected.json"))
 	if err != nil {
 		require.NoError(t, err)
 	}
@@ -694,7 +693,7 @@ func TestGen_parseOverrides(t *testing.T) {
 func TestGen_TypeOverridesFile(t *testing.T) {
 	customPath := "/foo/bar/baz"
 
-	tmp, err := ioutil.TempFile("", "")
+	tmp, err := os.CreateTemp("", "")
 	require.NoError(t, err)
 
 	defer os.Remove(tmp.Name())
@@ -824,11 +823,11 @@ func TestGen_ErrorAndInterface(t *testing.T) {
 	}
 
 	// check content
-	jsonOutput, err := ioutil.ReadFile(filepath.Join(config.OutputDir, "swagger.json"))
+	jsonOutput, err := os.ReadFile(filepath.Join(config.OutputDir, "swagger.json"))
 	if err != nil {
 		require.NoError(t, err)
 	}
-	expectedJSON, err := ioutil.ReadFile(filepath.Join(config.SearchDir, "expected.json"))
+	expectedJSON, err := os.ReadFile(filepath.Join(config.SearchDir, "expected.json"))
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/generics_test.go
+++ b/generics_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"go/ast"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +26,7 @@ func TestParseGenericsBasic(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/generics_basic"
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	p := New()
@@ -47,7 +47,7 @@ func TestParseGenericsArrays(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/generics_arrays"
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	p := New()
@@ -62,7 +62,7 @@ func TestParseGenericsNested(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/generics_nested"
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	p := New()
@@ -77,7 +77,7 @@ func TestParseGenericsProperty(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/generics_property"
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	p := New()
@@ -92,7 +92,7 @@ func TestParseGenericsNames(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/generics_names"
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	p := New()

--- a/operation.go
+++ b/operation.go
@@ -6,7 +6,6 @@ import (
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -270,7 +269,9 @@ func (operation *Operation) parseArrayParam(param *spec.Parameter, paramType, re
 
 // ParseParamComment parses params return []string of param properties
 // E.g. @Param	queryText		formData	      string	  true		        "The email for login"
-//              [param name]    [paramType] [data type]  [is mandatory?]   [Comment]
+//
+//	[param name]    [paramType] [data type]  [is mandatory?]   [Comment]
+//
 // E.g. @Param   some_id     path    int     true        "Some ID".
 func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.File) error {
 	matches := paramPattern.FindStringSubmatch(commentLine)
@@ -1197,17 +1198,17 @@ func createParameter(paramType, description, paramName, schemaType string, requi
 }
 
 func getCodeExampleForSummary(summaryName string, dirPath string) ([]byte, error) {
-	filesInfos, err := ioutil.ReadDir(dirPath)
+	dirEntries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, fileInfo := range filesInfos {
-		if fileInfo.IsDir() {
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
 			continue
 		}
 
-		fileName := fileInfo.Name()
+		fileName := entry.Name()
 
 		if !strings.Contains(fileName, ".json") {
 			continue
@@ -1216,7 +1217,7 @@ func getCodeExampleForSummary(summaryName string, dirPath string) ([]byte, error
 		if strings.Contains(fileName, summaryName) {
 			fullPath := filepath.Join(dirPath, fileName)
 
-			commentInfo, err := ioutil.ReadFile(fullPath)
+			commentInfo, err := os.ReadFile(fullPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read code example file %s error: %s ", fullPath, err)
 			}

--- a/parser.go
+++ b/parser.go
@@ -9,7 +9,6 @@ import (
 	"go/build"
 	goparser "go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -733,17 +732,17 @@ func isGeneralAPIComment(comments []string) bool {
 }
 
 func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
-	filesInfos, err := ioutil.ReadDir(dirPath)
+	dirEntries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, fileInfo := range filesInfos {
-		if fileInfo.IsDir() {
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
 			continue
 		}
 
-		fileName := fileInfo.Name()
+		fileName := entry.Name()
 
 		if !strings.Contains(fileName, ".md") {
 			continue
@@ -752,7 +751,7 @@ func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
 		if strings.Contains(fileName, tagName) {
 			fullPath := filepath.Join(dirPath, fileName)
 
-			commentInfo, err := ioutil.ReadFile(fullPath)
+			commentInfo, err := os.ReadFile(fullPath)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to read markdown file %s error: %s ", fullPath, err)
 			}
@@ -1488,7 +1487,7 @@ func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg) error {
 
 	srcDir := pkg.Raw.Dir
 
-	files, err := ioutil.ReadDir(srcDir) // only parsing files in the dir(don't contain sub dir files)
+	files, err := os.ReadDir(srcDir) // only parsing files in the dir(don't contain sub dir files)
 	if err != nil {
 		return err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -7,7 +7,6 @@ import (
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -864,7 +863,7 @@ func TestParser_ParseType(t *testing.T) {
 func TestParseSimpleApi1(t *testing.T) {
 	t.Parallel()
 
-	expected, err := ioutil.ReadFile("testdata/simple/expected.json")
+	expected, err := os.ReadFile("testdata/simple/expected.json")
 	assert.NoError(t, err)
 	searchDir := "testdata/simple"
 	p := New()
@@ -879,7 +878,7 @@ func TestParseSimpleApi1(t *testing.T) {
 func TestParseInterfaceAndError(t *testing.T) {
 	t.Parallel()
 
-	expected, err := ioutil.ReadFile("testdata/error/expected.json")
+	expected, err := os.ReadFile("testdata/error/expected.json")
 	assert.NoError(t, err)
 	searchDir := "testdata/error"
 	p := New()
@@ -2108,7 +2107,7 @@ func TestParseComposition(t *testing.T) {
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2125,7 +2124,7 @@ func TestParseImportAliases(t *testing.T) {
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2145,7 +2144,7 @@ func TestParseTypeOverrides(t *testing.T) {
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2162,7 +2161,7 @@ func TestParseNested(t *testing.T) {
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2208,7 +2207,7 @@ func TestParseConflictSchemaName(t *testing.T) {
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, string(expected), string(b))
 }
@@ -2222,7 +2221,7 @@ func TestParseExternalModels(t *testing.T) {
 	assert.NoError(t, err)
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
 	//ioutil.WriteFile("./testdata/external_models/main/expected.json",b,0777)
-	expected, err := ioutil.ReadFile(filepath.Join(searchDir, "expected.json"))
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 	assert.Equal(t, string(expected), string(b))
 }


### PR DESCRIPTION
**Describe the PR**
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). Since we have dropped support for Go 1.15 and lower (https://github.com/swaggo/swag/pull/1331), we can replace the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo`, this may improve performance in some cases as `os.ReadDir` is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir

**Relation issue**


**Additional context**
Add any other context about the problem here.
