### PR TITLE
Fix generics issue #1345 

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -237,6 +237,7 @@ func (pkgDefs *PackagesDefinitions) resolveGenericType(file *ast.File, expr ast.
 
 		for _, field := range astExpr.Fields.List {
 			newField := &ast.Field{
+				Type:    field.Type,
 				Doc:     field.Doc,
 				Names:   field.Names,
 				Tag:     field.Tag,
@@ -244,15 +245,12 @@ func (pkgDefs *PackagesDefinitions) resolveGenericType(file *ast.File, expr ast.
 			}
 
 			newField.Type = pkgDefs.resolveGenericType(file, field.Type, genericParamTypeDefs, parseDependency)
-			if newField.Type == nil {
-				newField.Type = field.Type
-			}
 
 			newStructTypeDef.Fields.List = append(newStructTypeDef.Fields.List, newField)
 		}
 		return newStructTypeDef
 	}
-	return nil
+	return expr
 }
 
 func getExtendedGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {

--- a/generics.go
+++ b/generics.go
@@ -144,7 +144,7 @@ func (pkgDefs *PackagesDefinitions) parametrizeGenericType(file *ast.File, origi
 
 	parametrizedTypeSpec.TypeSpec.Name = ident
 
-	newType := resolveGenericType(original.TypeSpec.Type, genericParamTypeDefs)
+	newType := pkgDefs.resolveGenericType(original.File, original.TypeSpec.Type, genericParamTypeDefs, parseDependency)
 
 	genericDefinitionsMutex.Lock()
 	defer genericDefinitionsMutex.Unlock()
@@ -197,21 +197,36 @@ func splitStructName(fullGenericForm string) (string, []string) {
 	return genericTypeName, genericParams
 }
 
-func resolveGenericType(expr ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) ast.Expr {
+func (pkgDefs *PackagesDefinitions) resolveGenericType(file *ast.File, expr ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec, parseDependency bool) ast.Expr {
 	switch astExpr := expr.(type) {
 	case *ast.Ident:
 		if genTypeSpec, ok := genericParamTypeDefs[astExpr.Name]; ok {
-			if genTypeSpec.ArrayDepth > 0 {
-				genTypeSpec.ArrayDepth--
-				return &ast.ArrayType{Elt: resolveGenericType(expr, genericParamTypeDefs)}
+			retType := genTypeSpec.Type()
+			for i := 0; i < genTypeSpec.ArrayDepth; i++ {
+				retType = &ast.ArrayType{Elt: retType}
 			}
-			return genTypeSpec.Type()
+			return retType
 		}
+		return expr
 	case *ast.ArrayType:
 		return &ast.ArrayType{
-			Elt:    resolveGenericType(astExpr.Elt, genericParamTypeDefs),
+			Elt:    pkgDefs.resolveGenericType(file, astExpr.Elt, genericParamTypeDefs, parseDependency),
 			Len:    astExpr.Len,
 			Lbrack: astExpr.Lbrack,
+		}
+	case *ast.StarExpr:
+		return &ast.StarExpr{
+			Star: astExpr.Star,
+			X:    pkgDefs.resolveGenericType(file, astExpr.X, genericParamTypeDefs, parseDependency),
+		}
+	case *ast.IndexExpr, *ast.IndexListExpr:
+		fullGenericName, err := getGenericFieldType(file, expr, genericParamTypeDefs)
+		if err != nil {
+			panic(err)
+		}
+		typeDef := pkgDefs.findGenericTypeSpec(fullGenericName, file, parseDependency)
+		if typeDef != nil {
+			return typeDef.TypeSpec.Type
 		}
 	case *ast.StructType:
 		newStructTypeDef := &ast.StructType{
@@ -231,7 +246,7 @@ func resolveGenericType(expr ast.Expr, genericParamTypeDefs map[string]*genericT
 				Comment: field.Comment,
 			}
 
-			newField.Type = resolveGenericType(field.Type, genericParamTypeDefs)
+			newField.Type = pkgDefs.resolveGenericType(file, field.Type, genericParamTypeDefs, parseDependency)
 			if newField.Type == nil {
 				newField.Type = field.Type
 			}
@@ -243,32 +258,42 @@ func resolveGenericType(expr ast.Expr, genericParamTypeDefs map[string]*genericT
 	return nil
 }
 
-func getExtendedGenericFieldType(file *ast.File, field ast.Expr) (string, error) {
+func getExtendedGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {
 	switch fieldType := field.(type) {
 	case *ast.ArrayType:
-		fieldName, err := getExtendedGenericFieldType(file, fieldType.Elt)
+		fieldName, err := getExtendedGenericFieldType(file, fieldType.Elt, genericParamTypeDefs)
 		return "[]" + fieldName, err
 	case *ast.StarExpr:
-		return getExtendedGenericFieldType(file, fieldType.X)
+		return getExtendedGenericFieldType(file, fieldType.X, genericParamTypeDefs)
+	case *ast.Ident:
+		if genericParamTypeDefs != nil {
+			if typeSpec, ok := genericParamTypeDefs[fieldType.Name]; ok {
+				if typeSpec.TypeSpec == nil && IsGolangPrimitiveType(typeSpec.Name) {
+					return typeSpec.Name, nil
+				}
+				return typeSpec.TypeSpec.FullName(), nil
+			}
+		}
+		return getFieldType(file, field)
 	default:
 		return getFieldType(file, field)
 	}
 }
 
-func getGenericFieldType(file *ast.File, field ast.Expr) (string, error) {
+func getGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {
 	var fullName string
 	var baseName string
 	var err error
 	switch fieldType := field.(type) {
 	case *ast.IndexListExpr:
-		baseName, err = getGenericTypeName(file, fieldType.X)
+		baseName, err = getGenericTypeName(file, fieldType.X, genericParamTypeDefs)
 		if err != nil {
 			return "", err
 		}
 		fullName = baseName + "["
 
 		for _, index := range fieldType.Indices {
-			fieldName, err := getExtendedGenericFieldType(file, index)
+			fieldName, err := getExtendedGenericFieldType(file, index, genericParamTypeDefs)
 			if err != nil {
 				return "", err
 			}
@@ -278,12 +303,12 @@ func getGenericFieldType(file *ast.File, field ast.Expr) (string, error) {
 
 		fullName = strings.TrimRight(fullName, ",") + "]"
 	case *ast.IndexExpr:
-		baseName, err = getGenericTypeName(file, fieldType.X)
+		baseName, err = getGenericTypeName(file, fieldType.X, genericParamTypeDefs)
 		if err != nil {
 			return "", err
 		}
 
-		indexName, err := getExtendedGenericFieldType(file, fieldType.Index)
+		indexName, err := getExtendedGenericFieldType(file, fieldType.Index, genericParamTypeDefs)
 		if err != nil {
 			return "", err
 		}
@@ -306,28 +331,36 @@ func getGenericFieldType(file *ast.File, field ast.Expr) (string, error) {
 	return strings.TrimLeft(fmt.Sprintf("%s.%s", packageName, fullName), "."), nil
 }
 
-func getGenericTypeName(file *ast.File, field ast.Expr) (string, error) {
-	switch indexType := field.(type) {
+func getGenericTypeName(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {
+	switch fieldType := field.(type) {
 	case *ast.Ident:
-		if indexType.Obj == nil {
-			return getFieldType(file, field)
+		if fieldType.Obj == nil {
+			if genericParamTypeDefs != nil {
+				if typeSpec, ok := genericParamTypeDefs[fieldType.Name]; ok {
+					if typeSpec.TypeSpec == nil && IsGolangPrimitiveType(typeSpec.Name) {
+						return typeSpec.Name, nil
+					}
+					return typeSpec.TypeSpec.FullName(), nil
+				}
+			}
+			return fieldType.Name, nil
 		}
 
 		tSpec := &TypeSpecDef{
 			File:     file,
-			TypeSpec: indexType.Obj.Decl.(*ast.TypeSpec),
+			TypeSpec: fieldType.Obj.Decl.(*ast.TypeSpec),
 			PkgPath:  file.Name.Name,
 		}
 		return tSpec.FullName(), nil
 	case *ast.ArrayType:
 		tSpec := &TypeSpecDef{
 			File:     file,
-			TypeSpec: indexType.Elt.(*ast.Ident).Obj.Decl.(*ast.TypeSpec),
+			TypeSpec: fieldType.Elt.(*ast.Ident).Obj.Decl.(*ast.TypeSpec),
 			PkgPath:  file.Name.Name,
 		}
 		return tSpec.FullName(), nil
 	case *ast.SelectorExpr:
-		return fmt.Sprintf("%s.%s", indexType.X.(*ast.Ident).Name, indexType.Sel.Name), nil
+		return fmt.Sprintf("%s.%s", fieldType.X.(*ast.Ident).Name, fieldType.Sel.Name), nil
 	}
 	return "", fmt.Errorf("unknown type %#v", field)
 }
@@ -344,7 +377,7 @@ func (parser *Parser) parseGenericTypeExpr(file *ast.File, typeExpr ast.Expr) (*
 	case *ast.MapType:
 	case *ast.FuncType:
 	case *ast.IndexExpr:
-		name, err := getExtendedGenericFieldType(file, expr)
+		name, err := getExtendedGenericFieldType(file, expr, nil)
 		if err == nil {
 			if schema, err := parser.getTypeSchema(name, file, false); err == nil {
 				return spec.MapProperty(schema), nil

--- a/generics.go
+++ b/generics.go
@@ -220,10 +220,7 @@ func (pkgDefs *PackagesDefinitions) resolveGenericType(file *ast.File, expr ast.
 			X:    pkgDefs.resolveGenericType(file, astExpr.X, genericParamTypeDefs, parseDependency),
 		}
 	case *ast.IndexExpr, *ast.IndexListExpr:
-		fullGenericName, err := getGenericFieldType(file, expr, genericParamTypeDefs)
-		if err != nil {
-			panic(err)
-		}
+		fullGenericName, _ := getGenericFieldType(file, expr, genericParamTypeDefs)
 		typeDef := pkgDefs.findGenericTypeSpec(fullGenericName, file, parseDependency)
 		if typeDef != nil {
 			return typeDef.TypeSpec.Type
@@ -292,7 +289,7 @@ func getGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs ma
 	var err error
 	switch fieldType := field.(type) {
 	case *ast.IndexListExpr:
-		baseName, err = getGenericTypeName(file, fieldType.X, genericParamTypeDefs)
+		baseName, err = getGenericTypeName(file, fieldType.X)
 		if err != nil {
 			return "", err
 		}
@@ -309,7 +306,7 @@ func getGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs ma
 
 		fullName = strings.TrimRight(fullName, ",") + "]"
 	case *ast.IndexExpr:
-		baseName, err = getGenericTypeName(file, fieldType.X, genericParamTypeDefs)
+		baseName, err = getGenericTypeName(file, fieldType.X)
 		if err != nil {
 			return "", err
 		}
@@ -337,15 +334,9 @@ func getGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs ma
 	return strings.TrimLeft(fmt.Sprintf("%s.%s", packageName, fullName), "."), nil
 }
 
-func getGenericTypeName(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {
+func getGenericTypeName(file *ast.File, field ast.Expr) (string, error) {
 	switch fieldType := field.(type) {
 	case *ast.Ident:
-		if genericParamTypeDefs != nil {
-			if typeSpec, ok := genericParamTypeDefs[fieldType.Name]; ok {
-				return typeSpec.Name, nil
-			}
-		}
-
 		if fieldType.Obj == nil {
 			return fieldType.Name, nil
 		}

--- a/generics.go
+++ b/generics.go
@@ -207,7 +207,6 @@ func (pkgDefs *PackagesDefinitions) resolveGenericType(file *ast.File, expr ast.
 			}
 			return retType
 		}
-		return expr
 	case *ast.ArrayType:
 		return &ast.ArrayType{
 			Elt:    pkgDefs.resolveGenericType(file, astExpr.Elt, genericParamTypeDefs, parseDependency),

--- a/generics.go
+++ b/generics.go
@@ -372,7 +372,7 @@ func (parser *Parser) parseGenericTypeExpr(file *ast.File, typeExpr ast.Expr) (*
 		name, err := getExtendedGenericFieldType(file, expr, nil)
 		if err == nil {
 			if schema, err := parser.getTypeSchema(name, file, false); err == nil {
-				return spec.MapProperty(schema), nil
+				return schema, nil
 			}
 		}
 

--- a/generics_other.go
+++ b/generics_other.go
@@ -17,7 +17,7 @@ func (pkgDefs *PackagesDefinitions) parametrizeGenericType(file *ast.File, origi
 	return original
 }
 
-func getGenericFieldType(file *ast.File, field ast.Expr) (string, error) {
+func getGenericFieldType(file *ast.File, field ast.Expr, genericParamTypeDefs map[string]*genericTypeSpec) (string, error) {
 	return "", fmt.Errorf("unknown field type %#v", field)
 }
 

--- a/generics_other.go
+++ b/generics_other.go
@@ -9,6 +9,12 @@ import (
 	"go/ast"
 )
 
+type genericTypeSpec struct {
+	ArrayDepth int
+	TypeSpec   *TypeSpecDef
+	Name       string
+}
+
 func typeSpecFullName(typeSpecDef *TypeSpecDef) string {
 	return typeSpecDef.FullName()
 }

--- a/generics_test.go
+++ b/generics_test.go
@@ -296,6 +296,7 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err := getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}},
+		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test.Field", field)
@@ -303,6 +304,7 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.ArrayType{Elt: &ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}}},
+		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test.Field", field)
@@ -310,6 +312,7 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.SelectorExpr{X: &ast.Ident{Name: "field"}, Sel: &ast.Ident{Name: "Name"}},
+		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "field.Name", field)
@@ -317,6 +320,7 @@ func TestGetGenericTypeName(t *testing.T) {
 	_, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.BadExpr{},
+		nil,
 	)
 	assert.Error(t, err)
 }

--- a/generics_test.go
+++ b/generics_test.go
@@ -296,7 +296,6 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err := getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}},
-		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test.Field", field)
@@ -304,7 +303,6 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.ArrayType{Elt: &ast.Ident{Name: "types", Obj: &ast.Object{Decl: &ast.TypeSpec{Name: &ast.Ident{Name: "Field"}}}}},
-		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "test.Field", field)
@@ -312,7 +310,6 @@ func TestGetGenericTypeName(t *testing.T) {
 	field, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.SelectorExpr{X: &ast.Ident{Name: "field"}, Sel: &ast.Ident{Name: "Name"}},
-		nil,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, "field.Name", field)
@@ -320,7 +317,6 @@ func TestGetGenericTypeName(t *testing.T) {
 	_, err = getGenericTypeName(
 		&ast.File{Name: &ast.Ident{Name: "test"}},
 		&ast.BadExpr{},
-		nil,
 	)
 	assert.Error(t, err)
 }

--- a/parser.go
+++ b/parser.go
@@ -1331,7 +1331,7 @@ func getFieldType(file *ast.File, field ast.Expr) (string, error) {
 
 		return fullName, nil
 	default:
-		return getGenericFieldType(file, field)
+		return getGenericFieldType(file, field, nil)
 	}
 }
 

--- a/testdata/generics_property/api/api.go
+++ b/testdata/generics_property/api/api.go
@@ -22,6 +22,8 @@ type CreateMovie struct {
 	Producer       types.Field[*Person]
 	Audience       Audience[Person]
 	AudienceNames  Audience[string]
+	Detail1        types.Field[types.Field[Person]]
+	Detail2        types.Field[types.Field[string]]
 }
 
 type Person struct {

--- a/testdata/generics_property/expected.json
+++ b/testdata/generics_property/expected.json
@@ -120,6 +120,12 @@
                 "cameraPeople": {
                     "$ref": "#/definitions/types.Field-array_api_Person"
                 },
+                "detail1": {
+                    "$ref": "#/definitions/types.Field-types_Field_api_Person"
+                },
+                "detail2": {
+                    "$ref": "#/definitions/types.Field-types_Field_string"
+                },
                 "directors": {
                     "$ref": "#/definitions/types.Field-array_api_Person"
                 },
@@ -284,6 +290,62 @@
                     "properties": {
                         "subValue1": {
                             "type": "string"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "types.Field-types_Field_api_Person": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/types.Field-api_Person"
+                },
+                "value2": {
+                    "$ref": "#/definitions/types.Field-api_Person"
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Field-api_Person"
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "$ref": "#/definitions/types.Field-api_Person"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "types.Field-types_Field_string": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/types.Field-string"
+                },
+                "value2": {
+                    "$ref": "#/definitions/types.Field-string"
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Field-string"
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "$ref": "#/definitions/types.Field-string"
                         },
                         "subValue2": {
                             "type": "string"

--- a/testdata/generics_property/expected.json
+++ b/testdata/generics_property/expected.json
@@ -167,6 +167,26 @@
             "properties": {
                 "value": {
                     "$ref": "#/definitions/api.Person"
+                },
+                "value2": {
+                    "$ref": "#/definitions/api.Person"
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Person"
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "$ref": "#/definitions/api.Person"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -177,6 +197,32 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/api.Person"
+                    }
+                },
+                "value2": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.Person"
+                    }
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/api.Person"
+                        }
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "$ref": "#/definitions/api.Person"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -189,6 +235,32 @@
                     "items": {
                         "$ref": "#/definitions/types.Post"
                     }
+                },
+                "value2": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/types.Post"
+                    }
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/types.Post"
+                        }
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "$ref": "#/definitions/types.Post"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },
@@ -197,6 +269,26 @@
             "properties": {
                 "value": {
                     "type": "string"
+                },
+                "value2": {
+                    "type": "string"
+                },
+                "value3": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "value4": {
+                    "type": "object",
+                    "properties": {
+                        "subValue1": {
+                            "type": "string"
+                        },
+                        "subValue2": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/testdata/generics_property/types/post.go
+++ b/testdata/generics_property/types/post.go
@@ -1,7 +1,15 @@
 package types
 
+type SubField1[T any, T2 any] struct {
+	SubValue1 T
+	SubValue2 T2
+}
+
 type Field[T any] struct {
-	Value T
+	Value  T
+	Value2 *T
+	Value3 []T
+	Value4 SubField1[T, string]
 }
 
 type APIBase struct {


### PR DESCRIPTION
**Describe the PR**
fix generic bug:  a struct field with complex generic type.

for example:
```
type MyFieldStruct[T1 any, T2 any] struct {
        Data1   T1
        Data2   T2
}

type Nested[T any] struct{
        Value T
}

type MyStruct[T any] struct{
        Field1 *T
        Field2 []T
        Field3 MyFieldStruct[T, string]
        field4  Nested[Nested[string]]
}
```

**Relation issue**
#1345 