### PR TITLE
Add flag to generate documentation only for specifics tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ USAGE:
    swag init [command options] [arguments...]
 
 OPTIONS:
+   --quiet, -q                            Make the logger quiet. (default: false)
    --generalInfo value, -g value          Go file path in which 'swagger general API Info' is written (default: "main.go")
    --dir value, -d value                  Directories you want to parse,comma separated and general-info file must be in the first one (default: "./")
    --exclude value                        Exclude directories and files when searching, comma separated
@@ -97,10 +98,12 @@ OPTIONS:
    --codeExampleFiles value, --cef value  Parse folder containing code example files to use for the x-codeSamples extension, disabled by default
    --parseInternal                        Parse go files in internal packages, disabled by default (default: false)
    --generatedTime                        Generate timestamp at the top of docs.go, disabled by default (default: false)
-   --requiredByDefault                    Set validation required for all fields by default (default: false)
    --parseDepth value                     Dependency parse depth (default: 100)
+   --requiredByDefault                    Set validation required for all fields by default (default: false)
    --instanceName value                   This parameter can be used to name different swagger document instances. It is optional.
    --overridesFile value                  File to read global type overrides from. (default: ".swaggo")
+   --parseGoList                          Parse dependency via 'go list' (default: true)
+   --tags value, -t value                 A comma-separated list of tags to filter the APIs for which the documentation is generated.Special case if the tag is prefixed with the '!' character then the APIs with that tag will be excluded
    --help, -h                             show help (default: false)
 ```
 

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -33,6 +33,7 @@ const (
 	overridesFileFlag     = "overridesFile"
 	parseGoListFlag       = "parseGoList"
 	quietFlag             = "quiet"
+	includeTagsFlag       = "includeTags"
 )
 
 var initFlags = []cli.Flag{
@@ -128,6 +129,12 @@ var initFlags = []cli.Flag{
 		Value: true,
 		Usage: "Parse dependency via 'go list'",
 	},
+	&cli.StringFlag{
+		Name:    includeTagsFlag,
+		Aliases: []string{"it"},
+		Value:   "",
+		Usage:   "Include only tags mentioned when searching, comma separated",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -166,6 +173,7 @@ func initAction(ctx *cli.Context) error {
 		InstanceName:        ctx.String(instanceNameFlag),
 		OverridesFile:       ctx.String(overridesFileFlag),
 		ParseGoList:         ctx.Bool(parseGoListFlag),
+		IncludeTags:         ctx.String(includeTagsFlag),
 		Debugger:            logger,
 	})
 }

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -33,7 +33,7 @@ const (
 	overridesFileFlag     = "overridesFile"
 	parseGoListFlag       = "parseGoList"
 	quietFlag             = "quiet"
-	includeTagsFlag       = "includeTags"
+	tagsFlag              = "tags"
 )
 
 var initFlags = []cli.Flag{
@@ -130,10 +130,10 @@ var initFlags = []cli.Flag{
 		Usage: "Parse dependency via 'go list'",
 	},
 	&cli.StringFlag{
-		Name:    includeTagsFlag,
-		Aliases: []string{"it"},
+		Name:    tagsFlag,
+		Aliases: []string{"t"},
 		Value:   "",
-		Usage:   "Include only tags mentioned when searching, comma separated",
+		Usage:   "A comma-separated list of tags to filter the APIs for which the documentation is generated.Special case if the tag is prefixed with the '!' character then the APIs with that tag will be excluded",
 	},
 }
 
@@ -173,7 +173,7 @@ func initAction(ctx *cli.Context) error {
 		InstanceName:        ctx.String(instanceNameFlag),
 		OverridesFile:       ctx.String(overridesFileFlag),
 		ParseGoList:         ctx.Bool(parseGoListFlag),
-		IncludeTags:         ctx.String(includeTagsFlag),
+		Tags:                ctx.String(tagsFlag),
 		Debugger:            logger,
 	})
 }

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -122,7 +122,7 @@ type Config struct {
 	ParseGoList bool
 
 	// include only tags mentioned when searching, comma separated
-	IncludeTags string
+	Tags string
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json.
@@ -169,7 +169,7 @@ func (g *Gen) Build(config *Config) error {
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),
 		swag.ParseUsingGoList(config.ParseGoList),
-		swag.SetIncludeTags(config.IncludeTags),
+		swag.SetTags(config.Tags),
 	)
 
 	p.PropNamingStrategy = config.PropNamingStrategy

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -120,6 +120,9 @@ type Config struct {
 
 	// ParseGoList whether swag use go list to parse dependency
 	ParseGoList bool
+
+	// include only tags mentioned when searching, comma separated
+	IncludeTags string
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json.
@@ -166,6 +169,7 @@ func (g *Gen) Build(config *Config) error {
 		swag.SetStrict(config.Strict),
 		swag.SetOverrides(overrides),
 		swag.ParseUsingGoList(config.ParseGoList),
+		swag.SetIncludeTags(config.IncludeTags),
 	)
 
 	p.PropNamingStrategy = config.PropNamingStrategy


### PR DESCRIPTION
**Describe the PR**
Added CLI flag to generate the doc for them if specified.
It helps when you want to generate multiple pieces of documentation(e.g. one for devs and a separate one for customers)

**Relation issue**
None

**Additional context**
ToDo:
- [x] Add a flag to the parser
- [x] Add tests