### PR TITLE
fix: wrongly shared schema by fields

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1286,9 +1286,21 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 		}
 	}
 
-	err = ps.ComplementSchema(schema)
-	if err != nil {
-		return nil, nil, err
+	if IsRefSchema(schema) {
+		additionalSchema := *schema
+		err = ps.ComplementSchema(&additionalSchema)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !reflect.DeepEqual(schema, &additionalSchema) {
+			additionalSchema.Ref = spec.Ref{}
+			schema = spec.ComposedSchema(*schema, additionalSchema)
+		}
+	} else {
+		err = ps.ComplementSchema(schema)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	var tagRequired []string

--- a/parser.go
+++ b/parser.go
@@ -964,8 +964,13 @@ func (parser *Parser) getTypeSchema(typeName string, file *ast.File, ref bool) (
 		}
 	}
 
-	if ref && (len(schema.Schema.Type) > 0 && schema.Schema.Type[0] == OBJECT || len(schema.Enum) > 0) {
-		return parser.getRefTypeSchema(typeSpecDef, schema), nil
+	if ref {
+		if IsComplexSchema(schema.Schema) {
+			return parser.getRefTypeSchema(typeSpecDef, schema), nil
+		}
+		// if it is a simple schema, just return a copy
+		newSchema := *schema.Schema
+		return &newSchema, nil
 	}
 
 	return schema.Schema, nil

--- a/parser.go
+++ b/parser.go
@@ -1286,21 +1286,9 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 		}
 	}
 
-	if IsRefSchema(schema) {
-		additionalSchema := *schema
-		err = ps.ComplementSchema(&additionalSchema)
-		if err != nil {
-			return nil, nil, err
-		}
-		if !reflect.DeepEqual(schema, &additionalSchema) {
-			additionalSchema.Ref = spec.Ref{}
-			schema = spec.ComposedSchema(*schema, additionalSchema)
-		}
-	} else {
-		err = ps.ComplementSchema(schema)
-		if err != nil {
-			return nil, nil, err
-		}
+	err = ps.ComplementSchema(schema)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var tagRequired []string

--- a/schema.go
+++ b/schema.go
@@ -135,7 +135,7 @@ func ignoreNameOverride(name string) bool {
 	return len(name) != 0 && name[0] == IgnoreNameOverridePrefix
 }
 
-// IsComplexSchema whether a schema is complex and is supposed to be a ref schema
+// IsComplexSchema whether a schema is complex and should be a ref schema
 func IsComplexSchema(schema *spec.Schema) bool {
 	// a enum type should be complex
 	if len(schema.Enum) > 0 {
@@ -154,11 +154,6 @@ func IsComplexSchema(schema *spec.Schema) bool {
 		}
 	}
 	return false
-}
-
-// IsRefSchema whether a schema is a reference schema.
-func IsRefSchema(schema *spec.Schema) bool {
-	return schema.Ref.Ref.GetURL() != nil
 }
 
 // RefSchema build a reference schema.

--- a/schema.go
+++ b/schema.go
@@ -135,6 +135,27 @@ func ignoreNameOverride(name string) bool {
 	return len(name) != 0 && name[0] == IgnoreNameOverridePrefix
 }
 
+// IsComplexSchema whether a schema is complex and should be a ref schema
+func IsComplexSchema(schema *spec.Schema) bool {
+	// a enum type should be complex
+	if len(schema.Enum) > 0 {
+		return true
+	}
+
+	// a deep array type is complex, how to determine deep? here more than 2 ,for example: [][]object,[][][]int
+	if len(schema.Type) > 2 {
+		return true
+	}
+
+	//Object included, such as Object or []Object
+	for _, st := range schema.Type {
+		if st == OBJECT {
+			return true
+		}
+	}
+	return false
+}
+
 // RefSchema build a reference schema.
 func RefSchema(refType string) *spec.Schema {
 	return spec.RefSchema("#/definitions/" + refType)

--- a/schema.go
+++ b/schema.go
@@ -135,7 +135,7 @@ func ignoreNameOverride(name string) bool {
 	return len(name) != 0 && name[0] == IgnoreNameOverridePrefix
 }
 
-// IsComplexSchema whether a schema is complex and should be a ref schema
+// IsComplexSchema whether a schema is complex and is supposed to be a ref schema
 func IsComplexSchema(schema *spec.Schema) bool {
 	// a enum type should be complex
 	if len(schema.Enum) > 0 {
@@ -154,6 +154,11 @@ func IsComplexSchema(schema *spec.Schema) bool {
 		}
 	}
 	return false
+}
+
+// IsRefSchema whether a schema is a reference schema.
+func IsRefSchema(schema *spec.Schema) bool {
+	return schema.Ref.Ref.GetURL() != nil
 }
 
 // RefSchema build a reference schema.


### PR DESCRIPTION
**Describe the PR**
If there are more than two fields with the same redefined type which especially based on a primitive type, they will share a schema in fault. If one of them modified the schema, another will be affected.

 fix :  every field gets a copy of the schema unless the schema is a ref schema,  and then complete it with field properties.  


**Relation issue**
#1342 

