### PR TITLE
enhancement: record token.FileSet for every file

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -211,6 +211,8 @@ func New(options ...func(*Parser)) *Parser {
 		option(parser)
 	}
 
+	parser.packages.debug = parser.debug
+
 	return parser
 }
 
@@ -276,7 +278,6 @@ func SetDebugger(logger Debugger) func(parser *Parser) {
 		if logger != nil {
 			p.debug = logger
 		}
-
 	}
 }
 
@@ -377,7 +378,7 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 		return err
 	}
 
-	err = rangeFiles(parser.packages.files, parser.ParseRouterAPIInfo)
+	err = parser.packages.RangeFiles(parser.ParseRouterAPIInfo)
 	if err != nil {
 		return err
 	}
@@ -969,7 +970,6 @@ func (parser *Parser) getTypeSchema(typeName string, file *ast.File, ref bool) (
 			if err == ErrRecursiveParseStruct && ref {
 				return parser.getRefTypeSchema(typeSpecDef, schema), nil
 			}
-
 			return nil, err
 		}
 	}
@@ -1520,18 +1520,7 @@ func (parser *Parser) parseFile(packageDir, path string, src interface{}) error 
 		return nil
 	}
 
-	// positions are relative to FileSet
-	astFile, err := goparser.ParseFile(token.NewFileSet(), path, src, goparser.ParseComments)
-	if err != nil {
-		return fmt.Errorf("ParseFile error:%+v", err)
-	}
-
-	err = parser.packages.CollectAstFile(packageDir, path, astFile)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return parser.packages.ParseFile(packageDir, path, src)
 }
 
 func (parser *Parser) checkOperationIDUniqueness() error {

--- a/parser_test.go
+++ b/parser_test.go
@@ -814,16 +814,13 @@ func Fun()  {
     }
 }`
 
-		f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-		assert.NoError(t, err)
-
 		p := New()
-		_ = p.packages.CollectAstFile("api", "api/api.go", f)
+		_ = p.packages.ParseFile("api", "api/api.go", src)
 
-		_, err = p.packages.ParseTypes()
+		_, err := p.packages.ParseTypes()
 		assert.NoError(t, err)
 
-		err = p.ParseRouterAPIInfo("", f)
+		err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 		assert.NoError(t, err)
 
 		b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2374,15 +2371,13 @@ func Test(){
       }
    }
 }`
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
 
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	_, err = p.packages.ParseTypes()
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	out, err := json.MarshalIndent(p.swagger.Definitions, "", "   ")
@@ -2438,18 +2433,14 @@ type ResponseWrapper struct {
 }`
 	parser := New(SetParseDependency(true))
 
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-	_ = parser.packages.CollectAstFile("api", "api/api.go", f)
+	_ = parser.packages.ParseFile("api", "api/api.go", src)
 
-	f2, err := goparser.ParseFile(token.NewFileSet(), "", restsrc, goparser.ParseComments)
-	assert.NoError(t, err)
-	_ = parser.packages.CollectAstFile("rest", "rest/rest.go", f2)
+	_ = parser.packages.ParseFile("rest", "rest/rest.go", restsrc)
 
-	_, err = parser.packages.ParseTypes()
+	_, err := parser.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = parser.ParseRouterAPIInfo("", f)
+	err = parser.packages.RangeFiles(parser.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	out, err := json.MarshalIndent(parser.swagger.Definitions, "", "   ")
@@ -2502,16 +2493,12 @@ func Test(){
       }
    }
 }`
-
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	_, err = p.packages.ParseTypes()
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	out, err := json.MarshalIndent(p.swagger.Definitions, "", "   ")
@@ -2630,16 +2617,13 @@ func Test(){
       }
    }
 }`
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
+	_ = p.packages.ParseFile("api", "api/api.go", src)
 
-	_, err = p.packages.ParseTypes()
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	out, err := json.MarshalIndent(p.swagger.Definitions, "", "   ")
@@ -3134,16 +3118,14 @@ func Fun()  {
     }
 }`
 
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
+	err := p.packages.ParseFile("api", "api/api.go", src)
+	assert.NoError(t, err)
 
 	_, err = p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -3191,16 +3173,13 @@ func Fun()  {
     }
 }`
 
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
+	_ = p.packages.ParseFile("api", "api/api.go", src)
 
-	_, err = p.packages.ParseTypes()
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -3229,15 +3208,13 @@ func Fun()  {
 
 }
 `
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
 
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	_, err = p.packages.ParseTypes()
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
@@ -3274,15 +3251,12 @@ func Fun()  {
 	}
 }
 `
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	_, err = p.packages.ParseTypes()
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	_, ok := p.swagger.Definitions["main.Fun.response"]
@@ -3361,16 +3335,13 @@ func Fun()  {
     }
 }`
 
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
+	_ = p.packages.ParseFile("api", "api/api.go", src)
 
-	_, err = p.packages.ParseTypes()
+	_, err := p.packages.ParseTypes()
 	assert.NoError(t, err)
 
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -3388,16 +3359,13 @@ func Fun()  {
 
 }
 `
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	pkgs := NewPackagesDefinitions()
 
-	// unset the .files and .packages and check that they're re-initialized by CollectAstFile
+	// unset the .files and .packages and check that they're re-initialized by collectAstFile
 	pkgs.packages = nil
 	pkgs.files = nil
 
-	_ = pkgs.CollectAstFile("api", "api/api.go", f)
+	_ = pkgs.ParseFile("api", "api/api.go", src)
 	assert.NotNil(t, pkgs.packages)
 	assert.NotNil(t, pkgs.files)
 }
@@ -3413,18 +3381,23 @@ func Fun()  {
 
 }
 `
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
 
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	assert.NotNil(t, p.packages.files[f])
-
-	astFileInfo := p.packages.files[f]
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	assert.Equal(t, 1, len(p.packages.files))
+	var path string
+	var file *ast.File
+	for path, file = range p.packages.packages["api"].Files {
+		break
+	}
+	assert.NotNil(t, file)
+	assert.NotNil(t, p.packages.files[file])
 
 	// if we collect the same again nothing should happen
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
-	assert.Equal(t, astFileInfo, p.packages.files[f])
+	_ = p.packages.ParseFile("api", "api/api.go", src)
+	assert.Equal(t, 1, len(p.packages.files))
+	assert.Equal(t, file, p.packages.packages["api"].Files[path])
+	assert.NotNil(t, p.packages.files[file])
 }
 
 func TestParseJSONFieldString(t *testing.T) {
@@ -3552,13 +3525,11 @@ func Fun()  {
 
 }
 `
-	f, err := goparser.ParseFile(token.NewFileSet(), "", src, goparser.ParseComments)
-	assert.NoError(t, err)
-
 	p := New()
-	_ = p.packages.CollectAstFile("api", "api/api.go", f)
+	err := p.packages.ParseFile("api", "api/api.go", src)
+	assert.NoError(t, err)
 	_, _ = p.packages.ParseTypes()
-	err = p.ParseRouterAPIInfo("", f)
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
 	assert.NoError(t, err)
 
 	teacher, ok := p.swagger.Definitions["Teacher"]

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package swag
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -80,6 +81,9 @@ func (t *TypeSpecDef) FullPath() string {
 
 // AstFileInfo information of an ast.File.
 type AstFileInfo struct {
+	//FileSet the FileSet object which is used to parse this go source file
+	FileSet *token.FileSet
+
 	// File ast.File
 	File *ast.File
 


### PR DESCRIPTION
**Describe the PR**
sometimes, we want to know where the error is when parsing go files, so record token.FileSet for every file so that the position of parsing error can be acquired and output to log

**Relation issue**
#1392
