### PR TITLE
support json tags in embedded structs

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -43,7 +43,7 @@ func newTagBaseFieldParser(p *Parser, field *ast.Field) FieldParser {
 
 func (ps *tagBaseFieldParser) ShouldSkip() bool {
 	// Skip non-exported fields.
-	if !ast.IsExported(ps.field.Names[0].Name) {
+	if ps.field.Names != nil && !ast.IsExported(ps.field.Names[0].Name) {
 		return true
 	}
 
@@ -74,6 +74,10 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 		if name != "" {
 			return name, nil
 		}
+	}
+
+	if ps.field.Names == nil {
+		return "", nil
 	}
 
 	switch ps.p.PropNamingStrategy {

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -215,16 +215,16 @@
               }
             }
           },
-          "404": {
-            "description": "Can not find ID",
-            "schema": {
-              "$ref": "#/definitions/web.APIError"
-            }
-          },
           "403": {
             "description": "cross",
             "schema": {
               "$ref": "#/definitions/cross.Cross"
+            }
+          },
+          "404": {
+            "description": "Can not find ID",
+            "schema": {
+              "$ref": "#/definitions/web.APIError"
             }
           }
         }
@@ -722,12 +722,6 @@
         "Data": {
           "type": "integer"
         },
-        "Err": {
-          "type": "integer"
-        },
-        "Status": {
-          "type": "boolean"
-        },
         "cross": {
           "$ref": "#/definitions/cross.Cross"
         },
@@ -736,6 +730,20 @@
           "items": {
             "$ref": "#/definitions/cross.Cross"
           }
+        },
+        "rev_value_base": {
+          "$ref": "#/definitions/web.RevValueBase"
+        }
+      }
+    },
+    "web.RevValueBase": {
+      "type": "object",
+      "properties": {
+        "Err": {
+          "type": "integer"
+        },
+        "Status": {
+          "type": "boolean"
         }
       }
     },


### PR DESCRIPTION
**Describe the PR**
This change makes it so json tags on embedded structs are honored.

One example of this:
```go

type RevValueBase struct {
	Status bool `json:"Status"`

	Err int32 `json:"Err,omitempty"`
}
type RevValue struct {
	RevValueBase `json:"rev_value_base"`
}
```

Previously, `RevValueBase` was inlined into `RevValue`. With this change, it matches the behavior of the core json package and the embedded struct becomes a field.
```json
"rev_value_base": {
    "$ref": "#/definitions/web.RevValueBase"
}
```

It should be noted that this changes the schema generation of embedded structs. However, since it was impossible to unmarshal embedded structs previously, I don't believe this is could cause breakage unless people implemented custom de-serialization.

**Relation issue**
Fixes #886
