### PR TITLE
chore: parse escaped double colon (\\:) example struct tag

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1442,11 +1441,7 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 		result := map[string]interface{}{}
 
 		for _, value := range values {
-			mapData, err := splitByUnescapedDoubleColon(value)
-
-			if err != nil {
-				return nil, err
-			}
+			mapData := strings.SplitN(value, ":", 2)
 
 			if len(mapData) == 2 {
 				v, err := defineTypeOfExample(arrayType, "", mapData[1])
@@ -1593,32 +1588,6 @@ func walkWith(excludes map[string]struct{}, parseVendor bool) func(path string, 
 
 		return nil
 	}
-}
-
-// SplitByUnescapedDoubleColon splits a string on every double colon (:) that is not escaped (\\)
-func splitByUnescapedDoubleColon(value string) ([]string, error) {
-	// Since Golang regexp does not support negative lookaheads, we make two capture groups,
-	// one with what comes before the ":" and another one with everything after. We iterate
-	// on the string until there are no more ":" matches
-	re, _ := regexp.Compile("^([^\\\\]+?):(.*?)$")
-	mapData := make([]string, 0)
-
-	splitString := value
-
-	for {
-		slices := re.FindStringSubmatch(splitString)
-
-		if slices == nil || len(slices) < 2 {
-			break
-		}
-
-		mapData = append(mapData, slices[1])
-		splitString = slices[2]
-	}
-
-	mapData = append(mapData, strings.ReplaceAll(splitString, "\\:", ":"))
-
-	return mapData, nil
 }
 
 // GetSwagger returns *spec.Swagger which is the root document object for the API specification.

--- a/parser_test.go
+++ b/parser_test.go
@@ -3650,6 +3650,49 @@ func TestDefineTypeOfExample(t *testing.T) {
 	})
 }
 
+func TestSplitByUnescapedDoubleColon(t *testing.T) {
+	t.Run("No double colon", func(t *testing.T) {
+		t.Parallel()
+
+		example, err := splitByUnescapedDoubleColon("example")
+		assert.NoError(t, err)
+		assert.Len(t, example, 1)
+		assert.Equal(t, example[0], "example")
+
+		example, err = splitByUnescapedDoubleColon("")
+		assert.NoError(t, err)
+		assert.Len(t, example, 1)
+		assert.Equal(t, example[0], "")
+	})
+
+	t.Run("Unescaped double colon", func(t *testing.T) {
+		t.Parallel()
+
+		example, err := splitByUnescapedDoubleColon("key_one:one")
+		assert.NoError(t, err)
+		assert.Len(t, example, 2)
+		assert.Equal(t, example[0], "key_one")
+		assert.Equal(t, example[1], "one")
+
+		example, err = splitByUnescapedDoubleColon("key_one:one:key_two:two")
+		assert.NoError(t, err)
+		assert.Len(t, example, 4)
+		assert.Equal(t, example[0], "key_one")
+		assert.Equal(t, example[1], "one")
+		assert.Equal(t, example[2], "key_two")
+		assert.Equal(t, example[3], "two")
+	})
+
+	t.Run("Escaped double colon", func(t *testing.T) {
+		t.Parallel()
+
+		example, err := splitByUnescapedDoubleColon("key_one\\:one")
+		assert.NoError(t, err)
+		assert.Len(t, example, 1)
+		assert.Equal(t, example[0], "key_one:one")
+	})
+}
+
 type mockFS struct {
 	os.FileInfo
 	FileName    string

--- a/parser_test.go
+++ b/parser_test.go
@@ -3650,49 +3650,6 @@ func TestDefineTypeOfExample(t *testing.T) {
 	})
 }
 
-func TestSplitByUnescapedDoubleColon(t *testing.T) {
-	t.Run("No double colon", func(t *testing.T) {
-		t.Parallel()
-
-		example, err := splitByUnescapedDoubleColon("example")
-		assert.NoError(t, err)
-		assert.Len(t, example, 1)
-		assert.Equal(t, example[0], "example")
-
-		example, err = splitByUnescapedDoubleColon("")
-		assert.NoError(t, err)
-		assert.Len(t, example, 1)
-		assert.Equal(t, example[0], "")
-	})
-
-	t.Run("Unescaped double colon", func(t *testing.T) {
-		t.Parallel()
-
-		example, err := splitByUnescapedDoubleColon("key_one:one")
-		assert.NoError(t, err)
-		assert.Len(t, example, 2)
-		assert.Equal(t, example[0], "key_one")
-		assert.Equal(t, example[1], "one")
-
-		example, err = splitByUnescapedDoubleColon("key_one:one:key_two:two")
-		assert.NoError(t, err)
-		assert.Len(t, example, 4)
-		assert.Equal(t, example[0], "key_one")
-		assert.Equal(t, example[1], "one")
-		assert.Equal(t, example[2], "key_two")
-		assert.Equal(t, example[3], "two")
-	})
-
-	t.Run("Escaped double colon", func(t *testing.T) {
-		t.Parallel()
-
-		example, err := splitByUnescapedDoubleColon("key_one\\:one")
-		assert.NoError(t, err)
-		assert.Len(t, example, 1)
-		assert.Equal(t, example[0], "key_one:one")
-	})
-}
-
 type mockFS struct {
 	os.FileInfo
 	FileName    string


### PR DESCRIPTION
**Describe the PR**
Replaces the regular string splitting by a ":" made during the "example" tag parsing so that it will not split escaped double colons, allowing string examples containing a double colon to be escaped using double backlashes.

**Relation issue**
https://github.com/swaggo/swag/issues/1401

**Additional context**
Since the core `regexp` library cannot suport negative lookaheads, I had to combine a regular expression with a loop to capture all the ocurrences and append them to an array.
