### PR TITLE
fix: string cutset method usage

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -372,9 +372,9 @@ func (pkgDefs *PackagesDefinitions) collectConstEnums(parsedSchemas map[*TypeSpe
 			}
 			if constVar.Comment != nil && len(constVar.Comment.List) > 0 {
 				enumValue.Comment = constVar.Comment.List[0].Text
-				enumValue.Comment = strings.TrimLeft(enumValue.Comment, "//")
-				enumValue.Comment = strings.TrimLeft(enumValue.Comment, "/*")
-				enumValue.Comment = strings.TrimRight(enumValue.Comment, "*/")
+				enumValue.Comment = strings.TrimPrefix(enumValue.Comment, "//")
+				enumValue.Comment = strings.TrimPrefix(enumValue.Comment, "/*")
+				enumValue.Comment = strings.TrimSuffix(enumValue.Comment, "*/")
 				enumValue.Comment = strings.TrimSpace(enumValue.Comment)
 			}
 			typeDef.Enums = append(typeDef.Enums, enumValue)


### PR DESCRIPTION
**Describe the PR**
Here we are going to trim `//`, `/*` at the comment before and `*/` last, should use `TrimPrefix` and `TrimSuffix` instead of `TrimLeft` and `TrimRight`.

**Relation issue**
None
