### PR TITLE
fix: don't error on empty comment line in matchExtension

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -843,10 +843,12 @@ func matchExtension(extensionToMatch string, comments []*ast.Comment) (match boo
 		for _, comment := range comments {
 			commentLine := strings.TrimSpace(strings.TrimLeft(comment.Text, "/"))
 			fields := FieldsByAnySpace(commentLine, 2)
-			lowerAttribute := strings.ToLower(fields[0])
+			if len(fields) > 0 {
+				lowerAttribute := strings.ToLower(fields[0])
 
-			if lowerAttribute == fmt.Sprintf("@x-%s", strings.ToLower(extensionToMatch)) {
-				return true
+				if lowerAttribute == fmt.Sprintf("@x-%s", strings.ToLower(extensionToMatch)) {
+					return true
+				}
 			}
 		}
 		return false

--- a/parser_test.go
+++ b/parser_test.go
@@ -3895,17 +3895,17 @@ func TestParser_parseExtension(t *testing.T) {
 		{
 			name:          "when no flag is set, everything is exported",
 			parser:        New(),
-			expectedPaths: map[string]bool{"/without-extension": true, "/with-another-extension": true, "/with-correct-extension": true},
+			expectedPaths: map[string]bool{"/without-extension": true, "/with-another-extension": true, "/with-correct-extension": true, "/with-empty-comment-line": true},
 		},
 		{
 			name:          "when nonexistent flag is set, nothing is exported",
 			parser:        New(SetParseExtension("nonexistent-extension-filter")),
-			expectedPaths: map[string]bool{"/without-extension": false, "/with-another-extension": false, "/with-correct-extension": false},
+			expectedPaths: map[string]bool{"/without-extension": false, "/with-another-extension": false, "/with-correct-extension": false, "/with-empty-comment-line": false},
 		},
 		{
 			name:          "when correct flag is set, only that Path is exported",
 			parser:        New(SetParseExtension("google-backend")),
-			expectedPaths: map[string]bool{"/without-extension": false, "/with-another-extension": false, "/with-correct-extension": true},
+			expectedPaths: map[string]bool{"/without-extension": false, "/with-another-extension": false, "/with-correct-extension": true, "/with-empty-comment-line": false},
 		},
 	}
 

--- a/testdata/parseExtension/parseExtension.go
+++ b/testdata/parseExtension/parseExtension.go
@@ -10,3 +10,7 @@ func Fun2() {}
 // @Router /with-correct-extension [get]
 // @x-google-backend {"address": "http://backend"}
 func Fun3() {}
+
+// @Router /with-empty-comment-line [get]
+//
+func FunEmptyCommentLine() {}


### PR DESCRIPTION
**Describe the PR**
parseExtension will break on empty comment lines `//`

**Relation issue**
https://github.com/swaggo/swag/pull/1219

**Additional context**
My previous test cases weren't covering empty comment lines and in that case `fields[0]` breaks.
Added fix and tests.

More than open for further suggestions/improvements if there are any
