### PR TITLE
Allow response object to be local instead of being a ref

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -968,7 +968,7 @@ func (operation *Operation) parseAPIObjectSchema(commentLine, schemaType, refTyp
 		}
 
 		return spec.ArrayProperty(schema), nil
-	case "struct":
+	case LOCAL:
 		return operation.parseObjectSchema(refType, astFile, false)
 	default:
 		return PrimitiveSchema(schemaType), nil

--- a/operation_test.go
+++ b/operation_test.go
@@ -315,7 +315,7 @@ func TestParseResponseCommentWithObjectType(t *testing.T) {
 func TestParseResponseWithLocalStruct(t *testing.T) {
 	t.Parallel()
 
-	comment := `@Success 200 struct Test`
+	comment := `@Success 200 local Test`
 	operation := NewOperation(nil)
 	FileName := "swag"
 	PackageName := "github.com/swagger/" + FileName

--- a/parser.go
+++ b/parser.go
@@ -925,7 +925,7 @@ func convertFromSpecificToPrimitive(typeName string) (string, error) {
 func (parser *Parser) getTypeSchema(typeName string, file *ast.File, ref bool) (*spec.Schema, error) {
 	if override, ok := parser.Overrides[typeName]; ok {
 		parser.debug.Printf("Override detected for %s: using %s instead", typeName, override)
-		return parseObjectSchema(parser, override, file)
+		return parseObjectSchema(parser, override, file, ref)
 	}
 
 	if IsInterfaceLike(typeName) {

--- a/schema.go
+++ b/schema.go
@@ -32,6 +32,8 @@ const (
 	ANY = "any"
 	// NIL represent a empty value.
 	NIL = "nil"
+	// LOCAL represent a local object value.
+	LOCAL = "local"
 
 	// IgnoreNameOverridePrefix Prepend to model to avoid renaming based on comment.
 	IgnoreNameOverridePrefix = '$'


### PR DESCRIPTION
**Describe the PR**
Add a new keyword to be used as response type (alongside object and array) making the response using directly the schema instead of a reference of the schema (only exposing an already existing feature).

**Relation issue**
https://github.com/swaggo/swag/issues/1413
