### PR TITLE
if the top type name is any or interface{}, don't use allOf

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -894,6 +894,11 @@ func parseCombinedObjectSchema(parser *Parser, refType string, astFile *ast.File
 		return schema, nil
 	}
 
+	if schema.Ref.GetURL() == nil && len(schema.Type) > 0 && schema.Type[0] == OBJECT && len(schema.Properties) == 0 && schema.AdditionalProperties == nil {
+		schema.Properties = props
+		return schema, nil
+	}
+
 	return spec.ComposedSchema(*schema, spec.Schema{
 		SchemaProps: spec.SchemaProps{
 			Type:       []string{OBJECT},

--- a/operation_test.go
+++ b/operation_test.go
@@ -2273,6 +2273,10 @@ func TestParseObjectSchema(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, schema, PrimitiveSchema(OBJECT))
 
+	schema, err = operation.parseObjectSchema("any{data=string}", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, schema, PrimitiveSchema(OBJECT).SetProperty("data", *PrimitiveSchema("string")))
+
 	schema, err = operation.parseObjectSchema("int", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, schema, PrimitiveSchema(INTEGER))


### PR DESCRIPTION
**Describe the PR**
If the top type name in response is any or interface{}, don't use allOf. This will make it more readable.

**Relation issue**
#1413 
