### PR TITLE
Use form tags when available

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -68,16 +68,16 @@ func (ps *tagBaseFieldParser) ShouldSkip() bool {
 func (ps *tagBaseFieldParser) FieldName() (string, error) {
 	var name string
 
-	// use "form" tag over json tag
-	name = strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
-	if name != "" {
-		return name, nil
-	}
-
 	if ps.field.Tag != nil {
 		// json:"tag,hoge"
 		name = strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
 
+		if name != "" {
+			return name, nil
+		}
+
+		// use "form" tag over json tag
+		name = strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
 		if name != "" {
 			return name, nil
 		}

--- a/field_parser.go
+++ b/field_parser.go
@@ -67,6 +67,13 @@ func (ps *tagBaseFieldParser) ShouldSkip() bool {
 
 func (ps *tagBaseFieldParser) FieldName() (string, error) {
 	var name string
+
+	// use "form" tag over json tag
+	name = strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+	if name != "" {
+		return name, nil
+	}
+
 	if ps.field.Tag != nil {
 		// json:"tag,hoge"
 		name = strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])

--- a/operation.go
+++ b/operation.go
@@ -372,6 +372,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 }
 
 const (
+	formTag             = "form"
 	jsonTag             = "json"
 	bindingTag          = "binding"
 	defaultTag          = "default"


### PR DESCRIPTION
**Describe the PR**
swaggo doesn't look at the `form` tag on structs to determine field names, only the `json` tag. This update sets the field name in the swagger files to the `form` tag if it exists. This will match what gin binds to.


**Relation issue**
This issue was also raised here:
https://github.com/swaggo/swag/discussions/1411

**Additional context**
Add any other context about the problem here.
