### PR TITLE
Added file data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 - integer (int, uint, uint32, uint64)
 - number (float32)
 - boolean (bool)
+- file (param data type when uploading)
 - user defined struct
 
 ## Security


### PR DESCRIPTION
The file data type will add the file input to the swagger ui when making a form data request with a file

**Describe the PR**
e.g. add cool parser.

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**
Add any other context about the problem here.
