### PR TITLE
style: remove duplicate space

### DIFF
--- a/gen/gen.go
+++ b/gen/gen.go
@@ -235,7 +235,7 @@ func (g *Gen) writeDocSwagger(config *Config, swagger *spec.Swagger) error {
 		return err
 	}
 
-	g.debug.Printf("create docs.go at  %+v", docFileName)
+	g.debug.Printf("create docs.go at %+v", docFileName)
 
 	return nil
 }
@@ -259,7 +259,7 @@ func (g *Gen) writeJSONSwagger(config *Config, swagger *spec.Swagger) error {
 		return err
 	}
 
-	g.debug.Printf("create swagger.json at  %+v", jsonFileName)
+	g.debug.Printf("create swagger.json at %+v", jsonFileName)
 
 	return nil
 }
@@ -288,7 +288,7 @@ func (g *Gen) writeYAMLSwagger(config *Config, swagger *spec.Swagger) error {
 		return err
 	}
 
-	g.debug.Printf("create swagger.yaml at  %+v", yamlFileName)
+	g.debug.Printf("create swagger.yaml at %+v", yamlFileName)
 
 	return nil
 }


### PR DESCRIPTION
Remove duplicate space in

```log
2023/01/05 17:51:16 create docs.go at  docs/docs.go
2023/01/05 17:51:16 create swagger.json at  docs/swagger.json
2023/01/05 17:51:16 create swagger.yaml at  docs/swagger.yaml
```