### PR TITLE
Additional error message when parsing type definition

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1115,6 +1115,7 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 
 	definition, err := parser.parseTypeExpr(typeSpecDef.File, typeSpecDef.TypeSpec.Type, false)
 	if err != nil {
+		parser.debug.Printf("Error parsing type definition '%s': %s", typeName, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**Describe the PR**
Additional error message when parsing type definition

```
2023/03/06 18:51:36 Generating datalayer.UpdateInput
-> 2023/03/06 18:51:36 parse type error in 'datalayer.UpdateInput': cannot find type definition: special.Extratype
2023/03/06 18:51:36 Skipping 'datalayer.UpdateInput', recursion detected.
```

When type definition not found in  `pkgDefs.packages` it shows error like there is some recursion detected, but there is a incorrect/confusing path to the type `special.Extratype` used in imports section: 

Used import path: 
`"github.com/company/go-special"`

Expected import path:
`"github.com/company/special"`

This error message helps to find the specific type that is causing the "recursion"
