### PR TITLE
support form tag

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -71,13 +71,12 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 	if ps.field.Tag != nil {
 		// json:"tag,hoge"
 		name = strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
-
 		if name != "" {
 			return name, nil
 		}
 
 		// use "form" tag over json tag
-		name = strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+		name = ps.FormName()
 		if name != "" {
 			return name, nil
 		}
@@ -95,6 +94,13 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 	default:
 		return toLowerCamelCase(ps.field.Names[0].Name), nil
 	}
+}
+
+func (ps *tagBaseFieldParser) FormName() string {
+	if ps.field.Tag != nil {
+		return strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+	}
+	return ""
 }
 
 func toSnakeCase(in string) string {

--- a/operation.go
+++ b/operation.go
@@ -310,14 +310,21 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 					continue
 				}
 
+				var formName = name
+				if item.Schema.Extensions != nil {
+					if nameVal, ok := item.Schema.Extensions[formTag]; ok {
+						formName = nameVal.(string)
+					}
+				}
+
 				switch {
 				case prop.Type[0] == ARRAY && prop.Items.Schema != nil &&
 					len(prop.Items.Schema.Type) > 0 && IsSimplePrimitiveType(prop.Items.Schema.Type[0]):
 
-					param = createParameter(paramType, prop.Description, name, prop.Type[0], prop.Items.Schema.Type[0], findInSlice(schema.Required, name), enums, operation.parser.collectionFormatInQuery)
+					param = createParameter(paramType, prop.Description, formName, prop.Type[0], prop.Items.Schema.Type[0], findInSlice(schema.Required, name), enums, operation.parser.collectionFormatInQuery)
 
 				case IsSimplePrimitiveType(prop.Type[0]):
-					param = createParameter(paramType, prop.Description, name, PRIMITIVE, prop.Type[0], findInSlice(schema.Required, name), enums, operation.parser.collectionFormatInQuery)
+					param = createParameter(paramType, prop.Description, formName, PRIMITIVE, prop.Type[0], findInSlice(schema.Required, name), enums, operation.parser.collectionFormatInQuery)
 				default:
 					operation.parser.debug.Printf("skip field [%s] in %s is not supported type for %s", name, refType, paramType)
 

--- a/parser.go
+++ b/parser.go
@@ -179,6 +179,7 @@ type FieldParserFactory func(ps *Parser, field *ast.Field) FieldParser
 type FieldParser interface {
 	ShouldSkip() bool
 	FieldName() (string, error)
+	FormName() string
 	CustomSchema() (*spec.Schema, error)
 	ComplementSchema(schema *spec.Schema) error
 	IsRequired() (bool, error)
@@ -1386,6 +1387,13 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 
 	if required {
 		tagRequired = append(tagRequired, fieldName)
+	}
+
+	if formName := ps.FormName(); len(formName) > 0 {
+		if schema.Extensions == nil {
+			schema.Extensions = make(spec.Extensions)
+		}
+		schema.Extensions[formTag] = formName
 	}
 
 	return map[string]spec.Schema{fieldName: *schema}, tagRequired, nil


### PR DESCRIPTION
**Describe the PR**
This is a completed way to support form tag.
As the extensions of schema only marshal keys with prefix `x-` into json, so I just add the form tag name with key `form` into the schema extensions, and look it up when parsing @param.
And this way also doesn't affect the final output docs.

**Relation issue**
#1422 

