### PR TITLE
Included package infos related to the model

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1131,6 +1131,15 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 		fillDefinitionDescription(definition, typeSpecDef.File, typeSpecDef)
 	}
 
+	definition.ExtraProps = map[string]interface{}{
+		"x-pkg": map[string]string{
+			"package":   typeSpecDef.PkgPath,
+			"name":      typeSpecDef.Name(),
+			"type-name": typeSpecDef.TypeName(),
+			"full-path": typeSpecDef.FullPath(),
+		},
+	}
+
 	if len(typeSpecDef.Enums) > 0 {
 		var varnames []string
 		var enumComments = make(map[string]string)


### PR DESCRIPTION
**Describe the PR**
The current generator does not include any package information. 
I had to create a restApi client that only imports the models without creating new ones.

**Additional context**
It only includes the params shown below

```json
"fiber.Args": {
    "type": "object",
    "x-pkg": {
        "full-path": "github.com/gofiber/fiber/v2.Args",
        "name": "Args",
        "package": "github.com/gofiber/fiber/v2",
        "type-name": "fiber.Args"
    }
},
```