### PR TITLE
fix(version): update version to 2

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package swag
 
 // Version of swag.
-const Version = "v1.8.12"
+const Version = "v2.0.0-beta"


### PR DESCRIPTION
**Describe the PR**
update the version

I found out that running `swag --version` returns 1.8 which is weird