### PR TITLE
Update README_zh-CN.md

### DIFF
--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -120,7 +120,6 @@ OPTIONS:
 - [echo](http://github.com/swaggo/echo-swagger)
 - [buffalo](https://github.com/swaggo/buffalo-swagger)
 - [net/http](https://github.com/swaggo/http-swagger)
-- [net/http](https://github.com/swaggo/http-swagger)
 - [gorilla/mux](https://github.com/swaggo/http-swagger)
 - [go-chi/chi](https://github.com/swaggo/http-swagger)
 - [flamingo](https://github.com/i-love-flamingo/swagger)


### PR DESCRIPTION
remove repeat net/http

**Describe the PR**
I found the `net/http` is repeated in Chinese version.
