### PR TITLE
V2: Support produce comment

### DIFF
--- a/operationv3.go
+++ b/operationv3.go
@@ -209,7 +209,7 @@ func (o *OperationV3) ParseProduceComment(commentLine string) error {
 	return nil
 }
 
-// ParseParamComment produces the previously parsed produce comment.
+// ProcessProduceComment processes the previously parsed produce comment.
 func (o *OperationV3) ProcessProduceComment() error {
 	const errMessage = "could not process produce comment"
 

--- a/parserv3.go
+++ b/parserv3.go
@@ -442,7 +442,15 @@ func (p *Parser) ParseRouterAPIInfoV3(fileInfo *AstFileInfo) error {
 					return fmt.Errorf("ParseComment error in file %s :%+v", fileInfo.Path, err)
 				}
 			}
-			err := processRouterOperationV3(p, operation)
+
+			// workaround until we replace the produce comment with a new @Success syntax
+			// We first need to setup all responses before we can set the mimetypes
+			err := operation.ProcessProduceComment()
+			if err != nil {
+				return err
+			}
+
+			err = processRouterOperationV3(p, operation)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Describe the PR**
Add basic support for the produce comment.
The implementation is based on some assumptions and is only been done to be able to parse swaggo v1 comments.

**Relation issue**
#1550 

**Additional context**
We should update the ```//@Success``` comment in the future to incorporate the changes and additional fields of open api v3.1.0.
The support of the produce comment is more of a workaround right now. 

Looking at the structure of the V3 data, i'd recommend either additional comment types or expanding the ```//@Success```.
![image](https://user-images.githubusercontent.com/9110370/231927484-5ce51dcf-9077-441e-bdbc-ee4492bb96ca.png)

