### PR TITLE
add retract to fix proxy cache caused by accidentally pushed tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,8 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )
+
+retract (
+	v1.9.0 // published accidentally
+	v1.16.0 // published accidentally
+)

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package swag
 
 // Version of swag.
-const Version = "v1.8.12"
+const Version = "v1.16.1"


### PR DESCRIPTION
**Describe the PR**
Add retract statement to fix proxy.golang.org cache

**Relation issue**
#1561 

**Additional context**
Accidentally pushed tags from wrong console window. The wrongfully pushed tags have already been deleted, but the goproxy cache already picked them up.
A new tag has already been published to fix fetching of the latest version for versions <v2.0.0

```To retract a version, a module author should add a retract directive to go.mod, then publish a new version containing that directive. The new version must be higher than other release or pre-release versions; that is, the @latest [version query](https://go.dev/ref/mod#version-queries) should resolve to the new version before retractions are considered. The go command loads and applies retractions from the version shown by go list -m -retracted $modpath@latest (where $modpath is the module path).```

https://go.dev/ref/mod#go-mod-file-retract
