### PR TITLE
feat: add --packagePrefix=P for only parse packages matched by prefix P

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -39,6 +39,7 @@ const (
 	templateDelimsFlag       = "templateDelims"
 	packageName              = "packageName"
 	collectionFormatFlag     = "collectionFormat"
+	packagePrefixFlag        = "packagePrefix"
 )
 
 var initFlags = []cli.Flag{
@@ -167,6 +168,11 @@ var initFlags = []cli.Flag{
 		Value:   "csv",
 		Usage:   "Set default collection format",
 	},
+	&cli.StringFlag{
+		Name:  packagePrefixFlag,
+		Value: "",
+		Usage: "Parse only packages whose import path match the given prefix, comma separated",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -235,6 +241,7 @@ func initAction(ctx *cli.Context) error {
 		PackageName:         ctx.String(packageName),
 		Debugger:            logger,
 		CollectionFormat:    collectionFormat,
+		PackagePrefix:       ctx.String(packagePrefixFlag),
 	})
 }
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -138,6 +138,9 @@ type Config struct {
 
 	// CollectionFormat set default collection format
 	CollectionFormat string
+
+	// Parse only packages whose import path match the given prefix, comma separated
+	PackagePrefix string
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json.
@@ -197,6 +200,7 @@ func (g *Gen) Build(config *Config) error {
 		swag.ParseUsingGoList(config.ParseGoList),
 		swag.SetTags(config.Tags),
 		swag.SetCollectionFormat(config.CollectionFormat),
+		swag.SetPackagePrefix(config.PackagePrefix),
 	)
 
 	p.PropNamingStrategy = config.PropNamingStrategy

--- a/golist.go
+++ b/golist.go
@@ -53,6 +53,10 @@ func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package, parseFl
 		return nil
 	}
 
+	if parser.skipPackageByPrefix(pkg.ImportPath) {
+		return nil // ignored by user-defined package path prefixes
+	}
+
 	srcDir := pkg.Dir
 	var err error
 	for i := range pkg.GoFiles {

--- a/parser_test.go
+++ b/parser_test.go
@@ -4048,3 +4048,25 @@ func TestParser_collectionFormat(t *testing.T) {
 		})
 	}
 }
+
+func TestParser_skipPackageByPrefix(t *testing.T) {
+	t.Parallel()
+
+	parser := New()
+
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag"))
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag/cmd"))
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag/gen"))
+
+	parser = New(SetPackagePrefix("github.com/swaggo/swag/cmd"))
+
+	assert.True(t, parser.skipPackageByPrefix("github.com/swaggo/swag"))
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag/cmd"))
+	assert.True(t, parser.skipPackageByPrefix("github.com/swaggo/swag/gen"))
+
+	parser = New(SetPackagePrefix("github.com/swaggo/swag/cmd,github.com/swaggo/swag/gen"))
+
+	assert.True(t, parser.skipPackageByPrefix("github.com/swaggo/swag"))
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag/cmd"))
+	assert.False(t, parser.skipPackageByPrefix("github.com/swaggo/swag/gen"))
+}


### PR DESCRIPTION
This PR adds a `--packagePrefix=P` option for only parse packages matched by prefix P.
This is useful when our swagger annotations are located in dependency. In the meantime there are some 3rd-party dependency (that we have no control) has some malform swagger annotations, we can use this option to exactly parse the package we need.

Close https://github.com/swaggo/swag/issues/904
