### PR TITLE
fix using tab (\t) as separator for custom type names

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -3249,6 +3249,30 @@ func Fun()  {
 	assert.Equal(t, "#/definitions/Teacher", ref.String())
 }
 
+func TestParseTabFormattedRenamedStructDefinition(t *testing.T) {
+	t.Parallel()
+
+	src := "package main\n" +
+		"\n" +
+		"type Child struct {\n" +
+		"\tName string\n" +
+		"}\t//\t@name\tPupil\n" +
+		"\n" +
+		"// @Success 200 {object} Pupil\n" +
+		"func Fun()  { }"
+
+	p := New()
+	_ = p.packages.ParseFile("api", "api/api.go", src, ParseAll)
+	_, err := p.packages.ParseTypes()
+	assert.NoError(t, err)
+
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
+	assert.NoError(t, err)
+
+	_, ok := p.swagger.Definitions["Pupil"]
+	assert.True(t, ok)
+}
+
 func TestParseFunctionScopedStructDefinition(t *testing.T) {
 	t.Parallel()
 

--- a/types.go
+++ b/types.go
@@ -3,6 +3,7 @@ package swag
 import (
 	"go/ast"
 	"go/token"
+	"regexp"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -47,9 +48,15 @@ func (t *TypeSpecDef) TypeName() string {
 		return t.TypeSpec.Name.Name[1:]
 	} else if t.TypeSpec.Comment != nil {
 		// get alias from comment '// @name '
+		const regexCaseInsensitive = "(?i)"
+		reTypeName, err := regexp.Compile(regexCaseInsensitive + `^@name\s+(\S+)`)
+		if err != nil {
+			panic(err)
+		}
 		for _, comment := range t.TypeSpec.Comment.List {
-			texts := strings.Split(strings.TrimSpace(strings.TrimLeft(comment.Text, "/")), " ")
-			if len(texts) > 1 && strings.ToLower(texts[0]) == "@name" {
+			trimmedComment := strings.TrimSpace(strings.TrimLeft(comment.Text, "/"))
+			texts := reTypeName.FindStringSubmatch(trimmedComment)
+			if len(texts) > 1 {
 				return texts[1]
 			}
 		}


### PR DESCRIPTION
**Describe the PR**

A bug fix.

### What happened

* using swag version v1.8.12
* did run `swag fmt ...` and custom type names got reformatted
* did run `swag init ...` - Problem: types for custom names not found anymore

Hint: the `swag fmt` reformats the comment, using a tab (\t) as a separator between `@name` and the type name.

### Expectation

After running `swag fmt`, the parser still finds all types.

### Solution

I did rework the parser using some little regEx to use any kind of whitespace.
An additional test is provided as well.

----

**Relation issue**
Issue #1150 seems somewhat related, but I don't care what the `fmt` command does, rather the problem, the parser can't find custom types.

**Additional context**

I did run `go run github.com/swaggo/swag/cmd/swag@latest fmt` yesterday, on a larger code base and afterward all custom type names could not be found anymore. The parser did complain can't finding the type. 