### PR TITLE
add cli flag --pdl to determine whether parse operations in dependency

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -198,6 +199,19 @@ func initAction(ctx *cli.Context) error {
 		return fmt.Errorf("not supported %s collectionFormat", ctx.String(collectionFormat))
 	}
 
+	var pdv = 0
+	pds := ctx.String(parseDependencyFlag)
+	bv, err := strconv.ParseBool(pds)
+	if err == nil {
+		if bv {
+			pdv = 1
+		}
+	} else {
+		iv, err := strconv.ParseInt(pds, 10, 64)
+		if err == nil {
+			pdv = int(iv)
+		}
+	}
 	return gen.New().Build(&gen.Config{
 		SearchDir:           ctx.String(searchDirFlag),
 		Excludes:            ctx.String(excludeFlag),
@@ -207,7 +221,7 @@ func initAction(ctx *cli.Context) error {
 		OutputDir:           ctx.String(outputFlag),
 		OutputTypes:         outputTypes,
 		ParseVendor:         ctx.Bool(parseVendorFlag),
-		ParseDependency:     ctx.Bool(parseDependencyFlag),
+		ParseDependency:     pdv,
 		MarkdownFilesDir:    ctx.String(markdownFilesFlag),
 		ParseInternal:       ctx.Bool(parseInternalFlag),
 		GeneratedTime:       ctx.Bool(generatedTimeFlag),

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -16,29 +15,30 @@ import (
 )
 
 const (
-	searchDirFlag         = "dir"
-	excludeFlag           = "exclude"
-	generalInfoFlag       = "generalInfo"
-	propertyStrategyFlag  = "propertyStrategy"
-	outputFlag            = "output"
-	outputTypesFlag       = "outputTypes"
-	parseVendorFlag       = "parseVendor"
-	parseDependencyFlag   = "parseDependency"
-	markdownFilesFlag     = "markdownFiles"
-	codeExampleFilesFlag  = "codeExampleFiles"
-	parseInternalFlag     = "parseInternal"
-	generatedTimeFlag     = "generatedTime"
-	requiredByDefaultFlag = "requiredByDefault"
-	parseDepthFlag        = "parseDepth"
-	instanceNameFlag      = "instanceName"
-	overridesFileFlag     = "overridesFile"
-	parseGoListFlag       = "parseGoList"
-	quietFlag             = "quiet"
-	tagsFlag              = "tags"
-	parseExtensionFlag    = "parseExtension"
-	templateDelimsFlag    = "templateDelims"
-	packageName           = "packageName"
-	collectionFormatFlag  = "collectionFormat"
+	searchDirFlag            = "dir"
+	excludeFlag              = "exclude"
+	generalInfoFlag          = "generalInfo"
+	propertyStrategyFlag     = "propertyStrategy"
+	outputFlag               = "output"
+	outputTypesFlag          = "outputTypes"
+	parseVendorFlag          = "parseVendor"
+	parseDependencyFlag      = "parseDependency"
+	parseDependencyLevelFlag = "parseDependencyLevel"
+	markdownFilesFlag        = "markdownFiles"
+	codeExampleFilesFlag     = "codeExampleFiles"
+	parseInternalFlag        = "parseInternal"
+	generatedTimeFlag        = "generatedTime"
+	requiredByDefaultFlag    = "requiredByDefault"
+	parseDepthFlag           = "parseDepth"
+	instanceNameFlag         = "instanceName"
+	overridesFileFlag        = "overridesFile"
+	parseGoListFlag          = "parseGoList"
+	quietFlag                = "quiet"
+	tagsFlag                 = "tags"
+	parseExtensionFlag       = "parseExtension"
+	templateDelimsFlag       = "templateDelims"
+	packageName              = "packageName"
+	collectionFormatFlag     = "collectionFormat"
 )
 
 var initFlags = []cli.Flag{
@@ -84,6 +84,11 @@ var initFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  parseVendorFlag,
 		Usage: "Parse go files in 'vendor' folder, disabled by default",
+	},
+	&cli.IntFlag{
+		Name:    parseDependencyLevelFlag,
+		Aliases: []string{"pdl"},
+		Usage:   "Parse go files inside dependency folder, disabled by default",
 	},
 	&cli.BoolFlag{
 		Name:    parseDependencyFlag,
@@ -199,17 +204,10 @@ func initAction(ctx *cli.Context) error {
 		return fmt.Errorf("not supported %s collectionFormat", ctx.String(collectionFormat))
 	}
 
-	var pdv = 0
-	pds := ctx.String(parseDependencyFlag)
-	bv, err := strconv.ParseBool(pds)
-	if err == nil {
-		if bv {
+	var pdv = ctx.Int(parseDependencyLevelFlag)
+	if pdv == 0 {
+		if ctx.Bool(parseDependencyFlag) {
 			pdv = 1
-		}
-	} else {
-		iv, err := strconv.ParseInt(pds, 10, 64)
-		if err == nil {
-			pdv = int(iv)
 		}
 	}
 	return gen.New().Build(&gen.Config{

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -88,7 +88,7 @@ var initFlags = []cli.Flag{
 	&cli.IntFlag{
 		Name:    parseDependencyLevelFlag,
 		Aliases: []string{"pdl"},
-		Usage:   "Parse go files inside dependency folder, disabled by default",
+		Usage:   "Parse go files inside dependency folder, 0 disabled, 1 only parse models, 2 only parse operations, 3 parse all",
 	},
 	&cli.BoolFlag{
 		Name:    parseDependencyFlag,

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -103,7 +103,7 @@ type Config struct {
 	// ParseVendor whether swag should be parse vendor folder
 	ParseVendor bool
 
-	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 operations, 2 models, 3 all
+	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 models, 2 operations, 3 all
 	ParseDependency int
 
 	// ParseInternal whether swag should parse internal packages

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -103,8 +103,8 @@ type Config struct {
 	// ParseVendor whether swag should be parse vendor folder
 	ParseVendor bool
 
-	// ParseDependencies whether swag should be parse outside dependency folder
-	ParseDependency bool
+	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 operations, 2 models, 3 all
+	ParseDependency int
 
 	// ParseInternal whether swag should parse internal packages
 	ParseInternal bool

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -661,7 +661,7 @@ func TestGen_cgoImports(t *testing.T) {
 		OutputDir:          "../testdata/simple_cgo/docs",
 		OutputTypes:        outputTypes,
 		PropNamingStrategy: "",
-		ParseDependency:    true,
+		ParseDependency:    1,
 	}
 
 	assert.NoError(t, New().Build(config))

--- a/generics_test.go
+++ b/generics_test.go
@@ -127,7 +127,7 @@ func TestParseGenericsPackageAlias(t *testing.T) {
 	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
 	assert.NoError(t, err)
 
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err = p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 	b, err := json.MarshalIndent(p.swagger, "", "    ")

--- a/golist.go
+++ b/golist.go
@@ -47,7 +47,7 @@ func listPackages(ctx context.Context, dir string, env []string, args ...string)
 	return pkgs, nil
 }
 
-func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
+func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package, parseFlag ParseFlag) error {
 	ignoreInternal := pkg.Goroot && !parser.ParseInternal
 	if ignoreInternal { // ignored internal
 		return nil
@@ -56,7 +56,7 @@ func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
 	srcDir := pkg.Dir
 	var err error
 	for i := range pkg.GoFiles {
-		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.GoFiles[i]), nil, ParseModels)
+		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.GoFiles[i]), nil, parseFlag)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package) error {
 
 	// parse .go source files that import "C"
 	for i := range pkg.CgoFiles {
-		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.CgoFiles[i]), nil, ParseModels)
+		err = parser.parseFile(pkg.ImportPath, filepath.Join(srcDir, pkg.CgoFiles[i]), nil, parseFlag)
 		if err != nil {
 			return err
 		}

--- a/golist_test.go
+++ b/golist_test.go
@@ -105,7 +105,7 @@ func TestGetAllGoFileInfoFromDepsByList(t *testing.T) {
 				p.ParseInternal = false
 			}
 			c.buildPackage.Dir = filepath.Join(pwd, c.buildPackage.Dir)
-			err := p.getAllGoFileInfoFromDepsByList(c.buildPackage)
+			err := p.getAllGoFileInfoFromDepsByList(c.buildPackage, ParseModels)
 			if c.except != nil {
 				assert.NotNil(t, err)
 			} else {

--- a/packages.go
+++ b/packages.go
@@ -19,7 +19,7 @@ type PackagesDefinitions struct {
 	files             map[*ast.File]*AstFileInfo
 	packages          map[string]*PackageDefinitions
 	uniqueDefinitions map[string]*TypeSpecDef
-	parseDependency   bool
+	parseDependency   ParseFlag
 	debug             Debugger
 }
 
@@ -324,7 +324,7 @@ func (pkgDefs *PackagesDefinitions) EvaluateConstValueByName(file *ast.File, pkg
 			}
 		}
 	}
-	if pkgDefs.parseDependency {
+	if pkgDefs.parseDependency > 0 {
 		for _, pkgPath := range externalPkgPaths {
 			if err := pkgDefs.loadExternalPackage(pkgPath); err == nil {
 				if pkg, ok := pkgDefs.packages[pkgPath]; ok {
@@ -513,7 +513,7 @@ func (pkgDefs *PackagesDefinitions) findTypeSpecFromPackagePaths(matchedPkgPaths
 		}
 	}
 
-	if pkgDefs.parseDependency {
+	if pkgDefs.parseDependency > 0 {
 		for _, pkgPath := range externalPkgPaths {
 			if err := pkgDefs.loadExternalPackage(pkgPath); err == nil {
 				typeDef = pkgDefs.findTypeSpec(pkgPath, name)

--- a/parser.go
+++ b/parser.go
@@ -74,10 +74,10 @@ type ParseFlag int
 const (
 	// ParseNone parse nothing
 	ParseNone ParseFlag = 0x00
-	// ParseOperations parse operations
-	ParseOperations = 0x01
 	// ParseModels parse models
-	ParseModels = 0x02
+	ParseModels = 0x01
+	// ParseOperations parse operations
+	ParseOperations = 0x02
 	// ParseAll parse operations and models
 	ParseAll = ParseOperations | ParseModels
 )
@@ -126,8 +126,8 @@ type Parser struct {
 	// ParseVendor parse vendor folder
 	ParseVendor bool
 
-	// ParseDependencies whether swag should be parse outside dependency folder
-	ParseDependency bool
+	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 operations, 2 models, 3 all
+	ParseDependency ParseFlag
 
 	// ParseInternal whether swag should parse internal packages
 	ParseInternal bool
@@ -237,11 +237,11 @@ func New(options ...func(*Parser)) *Parser {
 }
 
 // SetParseDependency sets whether to parse the dependent packages.
-func SetParseDependency(parseDependency bool) func(*Parser) {
+func SetParseDependency(parseDependency int) func(*Parser) {
 	return func(p *Parser) {
-		p.ParseDependency = parseDependency
+		p.ParseDependency = ParseFlag(parseDependency)
 		if p.packages != nil {
-			p.packages.parseDependency = parseDependency
+			p.packages.parseDependency = p.ParseDependency
 		}
 	}
 }
@@ -365,7 +365,7 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 	}
 
 	// Use 'go list' command instead of depth.Resolve()
-	if parser.ParseDependency {
+	if parser.ParseDependency > 0 {
 		if parser.parseGoList {
 			pkgs, err := listPackages(context.Background(), filepath.Dir(absMainAPIFilePath), nil, "-deps")
 			if err != nil {
@@ -374,7 +374,7 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 
 			length := len(pkgs)
 			for i := 0; i < length; i++ {
-				err := parser.getAllGoFileInfoFromDepsByList(pkgs[i])
+				err := parser.getAllGoFileInfoFromDepsByList(pkgs[i], parser.ParseDependency)
 				if err != nil {
 					return err
 				}
@@ -394,7 +394,7 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 				return fmt.Errorf("pkg %s cannot find all dependencies, %s", pkgName, err)
 			}
 			for i := 0; i < len(t.Root.Deps); i++ {
-				err := parser.getAllGoFileInfoFromDeps(&t.Root.Deps[i])
+				err := parser.getAllGoFileInfoFromDeps(&t.Root.Deps[i], parser.ParseDependency)
 				if err != nil {
 					return err
 				}
@@ -1586,7 +1586,7 @@ func (parser *Parser) getAllGoFileInfo(packageDir, searchDir string) error {
 	})
 }
 
-func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg) error {
+func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg, parseFlag ParseFlag) error {
 	ignoreInternal := pkg.Internal && !parser.ParseInternal
 	if ignoreInternal || !pkg.Resolved { // ignored internal and not resolved dependencies
 		return nil
@@ -1610,13 +1610,13 @@ func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg) error {
 		}
 
 		path := filepath.Join(srcDir, f.Name())
-		if err := parser.parseFile(pkg.Name, path, nil, ParseModels); err != nil {
+		if err := parser.parseFile(pkg.Name, path, nil, parseFlag); err != nil {
 			return err
 		}
 	}
 
 	for i := 0; i < len(pkg.Deps); i++ {
-		if err := parser.getAllGoFileInfoFromDeps(&pkg.Deps[i]); err != nil {
+		if err := parser.getAllGoFileInfoFromDeps(&pkg.Deps[i], parseFlag); err != nil {
 			return err
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -126,7 +126,7 @@ type Parser struct {
 	// ParseVendor parse vendor folder
 	ParseVendor bool
 
-	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 operations, 2 models, 3 all
+	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 models, 2 operations, 3 all
 	ParseDependency ParseFlag
 
 	// ParseInternal whether swag should parse internal packages

--- a/parser_test.go
+++ b/parser_test.go
@@ -2161,7 +2161,7 @@ func TestParseNested(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/nested"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 
@@ -2176,7 +2176,7 @@ func TestParseDuplicated(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/duplicated"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.Errorf(t, err, "duplicated @id declarations successfully found")
 }
@@ -2185,7 +2185,7 @@ func TestParseDuplicatedOtherMethods(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/duplicated2"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.Errorf(t, err, "duplicated @id declarations successfully found")
 }
@@ -2194,7 +2194,7 @@ func TestParseDuplicatedFunctionScoped(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/duplicated_function_scoped"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.Errorf(t, err, "duplicated @id declarations successfully found")
 }
@@ -2203,7 +2203,7 @@ func TestParseConflictSchemaName(t *testing.T) {
 	t.Parallel()
 
 	searchDir := "testdata/conflict_name"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2215,7 +2215,7 @@ func TestParseConflictSchemaName(t *testing.T) {
 func TestParseExternalModels(t *testing.T) {
 	searchDir := "testdata/external_models/main"
 	mainAPIFile := "main.go"
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
 	assert.NoError(t, err)
 	b, _ := json.MarshalIndent(p.swagger, "", "    ")
@@ -2227,7 +2227,7 @@ func TestParseExternalModels(t *testing.T) {
 
 func TestParseGoList(t *testing.T) {
 	mainAPIFile := "main.go"
-	p := New(ParseUsingGoList(true), SetParseDependency(true))
+	p := New(ParseUsingGoList(true), SetParseDependency(1))
 	go111moduleEnv := os.Getenv("GO111MODULE")
 
 	cases := []struct {
@@ -2439,7 +2439,7 @@ type ResponseWrapper struct {
       }
    }
 }`
-	parser := New(SetParseDependency(true))
+	parser := New(SetParseDependency(1))
 
 	_ = parser.packages.ParseFile("api", "api/api.go", src, ParseAll)
 
@@ -3073,7 +3073,7 @@ func TestParseOutsideDependencies(t *testing.T) {
 	searchDir := "testdata/pare_outside_dependencies"
 	mainAPIFile := "cmd/main.go"
 
-	p := New(SetParseDependency(true))
+	p := New(SetParseDependency(1))
 	if err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth); err != nil {
 		t.Error("Failed to parse api: " + err.Error())
 	}


### PR DESCRIPTION
**Describe the PR**
Add cli flag --pdl to determine whether parse operations in dependency
```
swag init --pd            // for backward compatibility, only parse models indepedency
swag init --pdl 3        // 0 disabled, 1 only parse models, 2 only parse operations, 3 parse all
```


**Relation issue**
#1451
