### PR TITLE
feat: global security

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -715,6 +715,11 @@ func (operation *Operation) ParseRouterComment(commentLine string) error {
 
 // ParseSecurityComment parses comment for given `security` comment string.
 func (operation *Operation) ParseSecurityComment(commentLine string) error {
+	if len(commentLine) == 0 {
+		operation.Security = []map[string][]string{}
+		return nil
+	}
+
 	var (
 		securityMap    = make(map[string][]string)
 		securitySource = commentLine[strings.Index(commentLine, "@Security")+1:]

--- a/parser_test.go
+++ b/parser_test.go
@@ -2157,6 +2157,21 @@ func TestParseTypeOverrides(t *testing.T) {
 	assert.Equal(t, string(expected), string(b))
 }
 
+func TestGlobalSecurity(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/global_security"
+	p := New()
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	assert.NoError(t, err)
+
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	assert.NoError(t, err)
+
+	b, _ := json.MarshalIndent(p.swagger, "", "  ")
+	assert.Equal(t, string(expected), string(b))
+}
+
 func TestParseNested(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/global_security/api/api.go
+++ b/testdata/global_security/api/api.go
@@ -4,19 +4,31 @@ import (
 	"net/http"
 )
 
-// @Summary Get application
-// @Description test get application
+// @Summary default security
 // @Success 200
 // @Router /testapi/application [get]
-func GetApplication(w http.ResponseWriter, r *http.Request) {
-	//write your code
-}
+func GetApplication(w http.ResponseWriter, r *http.Request) {}
 
-// Summary Get no security
-// @Description override global security
+// @Summary no security
 // @Security
 // @Success 200
 // @Router /testapi/nosec [get]
-func GetNoSec(w http.ResponseWriter, r *http.Request) {
-	//write your code
-}
+func GetNoSec(w http.ResponseWriter, r *http.Request) {}
+
+// @Summary basic security
+// @Security BasicAuth
+// @Success 200
+// @Router /testapi/basic [get]
+func GetBasic(w http.ResponseWriter, r *http.Request) {}
+
+// @Summary oauth2 write
+// @Security OAuth2Application[write]
+// @Success 200
+// @Router /testapi/oauth/write [get]
+func GetOAuthWrite(w http.ResponseWriter, r *http.Request) {}
+
+// @Summary oauth2 admin
+// @Security OAuth2Application[admin]
+// @Success 200
+// @Router /testapi/oauth/admin [get]
+func GetOAuthAdmin(w http.ResponseWriter, r *http.Request) {}

--- a/testdata/global_security/api/api.go
+++ b/testdata/global_security/api/api.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"net/http"
+)
+
+// @Summary Get application
+// @Description test get application
+// @Success 200
+// @Router /testapi/application [get]
+func GetApplication(w http.ResponseWriter, r *http.Request) {
+	//write your code
+}
+
+// Summary Get no security
+// @Description override global security
+// @Security
+// @Success 200
+// @Router /testapi/nosec [get]
+func GetNoSec(w http.ResponseWriter, r *http.Request) {
+	//write your code
+}

--- a/testdata/global_security/expected.json
+++ b/testdata/global_security/expected.json
@@ -1,0 +1,44 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Swagger Example API",
+    "contact": {},
+    "version": "1.0"
+  },
+  "paths": {
+    "/testapi/application": {
+      "get": {
+        "description": "test get application",
+        "summary": "Get application",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/testapi/nosec": {
+      "get": {
+        "security": [],
+        "description": "override global security",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "APIKeyAuth": {
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "APIKeyAuth": []
+    }
+  ]
+}

--- a/testdata/global_security/expected.json
+++ b/testdata/global_security/expected.json
@@ -8,8 +8,22 @@
   "paths": {
     "/testapi/application": {
       "get": {
-        "description": "test get application",
-        "summary": "Get application",
+        "summary": "default security",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/testapi/basic": {
+      "get": {
+        "security": [
+          {
+            "BasicAuth": []
+          }
+        ],
+        "summary": "basic security",
         "responses": {
           "200": {
             "description": "OK"
@@ -20,7 +34,41 @@
     "/testapi/nosec": {
       "get": {
         "security": [],
-        "description": "override global security",
+        "summary": "no security",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/testapi/oauth/admin": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Application": [
+              "admin"
+            ]
+          }
+        ],
+        "summary": "oauth2 admin",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/testapi/oauth/write": {
+      "get": {
+        "security": [
+          {
+            "OAuth2Application": [
+              "write"
+            ]
+          }
+        ],
+        "summary": "oauth2 write",
         "responses": {
           "200": {
             "description": "OK"
@@ -34,11 +82,24 @@
       "type": "apiKey",
       "name": "Authorization",
       "in": "header"
+    },
+    "BasicAuth": {
+      "type": "basic"
+    },
+    "OAuth2Application": {
+      "type": "oauth2",
+      "flow": "application",
+      "tokenUrl": "https://example.com/oauth/token",
+      "scopes": {
+        "admin": " Grants read and write access to administrative information",
+        "write": " Grants write access"
+      }
     }
   },
   "security": [
     {
-      "APIKeyAuth": []
+      "APIKeyAuth": [],
+      "OAuth2Application": []
     }
   ]
 }

--- a/testdata/global_security/main.go
+++ b/testdata/global_security/main.go
@@ -1,0 +1,20 @@
+package global_security
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/global_security/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+
+// @securityDefinitions.apikey APIKeyAuth
+// @in header
+// @name Authorization
+
+// @security APIKeyAuth
+func main() {
+	http.HandleFunc("/testapi/application", api.GetApplication)
+	http.ListenAndServe(":8080", nil)
+}

--- a/testdata/global_security/main.go
+++ b/testdata/global_security/main.go
@@ -1,11 +1,5 @@
 package global_security
 
-import (
-	"net/http"
-
-	"github.com/swaggo/swag/testdata/global_security/api"
-)
-
 // @title Swagger Example API
 // @version 1.0
 
@@ -13,8 +7,12 @@ import (
 // @in header
 // @name Authorization
 
-// @security APIKeyAuth
-func main() {
-	http.HandleFunc("/testapi/application", api.GetApplication)
-	http.ListenAndServe(":8080", nil)
-}
+// @securityDefinitions.basic  BasicAuth
+
+// @securityDefinitions.oauth2.application OAuth2Application
+// @tokenUrl https://example.com/oauth/token
+// @scope.write Grants write access
+// @scope.admin Grants read and write access to administrative information
+
+// @security APIKeyAuth || OAuth2Application
+func main() {}


### PR DESCRIPTION
**Describe the PR**
Add support global `@Security` tag. If need to disable security for an operation, an empty security tag is used.

**Relation issue**
#1453 

**Additional context**

