### PR TITLE
fix: failing assert in enums test on 32bit

### DIFF
--- a/enums_test.go
+++ b/enums_test.go
@@ -2,6 +2,7 @@ package swag
 
 import (
 	"encoding/json"
+	"math/bits"
 	"os"
 	"path/filepath"
 	"testing"
@@ -21,7 +22,7 @@ func TestParseGlobalEnums(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(expected), string(b))
 	constsPath := "github.com/swaggo/swag/testdata/enums/consts"
-	assert.Equal(t, 64, p.packages.packages[constsPath].ConstTable["uintSize"].Value)
+	assert.Equal(t, bits.UintSize, p.packages.packages[constsPath].ConstTable["uintSize"].Value)
 	assert.Equal(t, int32(62), p.packages.packages[constsPath].ConstTable["maxBase"].Value)
 	assert.Equal(t, 8, p.packages.packages[constsPath].ConstTable["shlByLen"].Value)
 	assert.Equal(t, 255, p.packages.packages[constsPath].ConstTable["hexnum"].Value)


### PR DESCRIPTION
**Describe the PR**
This PR makes `enums_test.go` pass on 32-bit architectures.

**Relation issue**
#1633
