### PR TITLE
docs(readme): fix param brace

### DIFF
--- a/README_pt.md
+++ b/README_pt.md
@@ -418,7 +418,7 @@ Quando uma pequena sequência na sua documentação é insuficiente, ou precisa 
 | success | resposta de sucesso que separou por espaços. `return code or default`,`{param type}`,`data type`,`comment` |.
 | failure | Resposta de falha que separou por espaços. `return code or default`,`{param type}`,`data type`,`comment` |
 | response | Igual ao `sucesso` e `falha` |
-| header | Cabeçalho em resposta que separou por espaços. `código de retorno`,`{{tipo de parâmetro}`,`tipo de dados`,`comentário` |.
+| header | Cabeçalho em resposta que separou por espaços. `código de retorno`,`{tipo de parâmetro}`,`tipo de dados`,`comentário` |.
 | router | Definição do caminho que separou por espaços. caminho",`path`,`[httpMethod]` |[httpMethod]` |
 | x-name | A chave de extensão, deve ser iniciada por x- e tomar apenas o valor json.                                                           |
 | x-codeSample | Optional Markdown use. tomar `file` como parâmetro. Isto irá então procurar um ficheiro nomeado como o resumo na pasta dada.                                      |


### PR DESCRIPTION
**Describe the PR**
Updates the curly braces for _PT ReadMe, as there's an extra start brac ```{``` for the param

**Relation issue**
This causes GitHub Pages using ```Jekyll``` to fail for applications that use this as a vendor package

```
Liquid Exception: Liquid syntax error (line 421): Variable '{{tipo de parâmetro}' was not properly terminated with regexp: /\}\}/ in Source/Server/vendor/[github.com/swaggo/swag/README_pt.md](http://github.com/swaggo/swag/README_pt.md)
```
