### PR TITLE
If @Success tag's return value equals null, prevent null pointer exceptions.

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -918,6 +918,10 @@ func parseCombinedObjectSchema(parser *Parser, refType string, astFile *ast.File
 				return nil, err
 			}
 
+			if schema == nil {
+				schema = PrimitiveSchema(OBJECT)
+			}
+
 			props[keyVal[0]] = *schema
 		}
 	}


### PR DESCRIPTION
**Describe the PR**
When the return value defined by the @Success tag is equal to the null value, make fixes to prevent a null pointer exception from occurring.

**Relation issue**
https://github.com/swaggo/swag/issues/1653

**Additional context**
Since null could not be specified in swagger, an object was specified.