### PR TITLE
test: remove redundant `filepath.Clean` call

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -102,7 +102,7 @@ func setup(t *testing.T) *fixture {
 }
 
 func (fx *fixture) isFormatted(file string) bool {
-	contents, err := os.ReadFile(filepath.Join(fx.basedir, filepath.Clean(file)))
+	contents, err := os.ReadFile(filepath.Join(fx.basedir, file))
 	if err != nil {
 		fx.t.Fatal(err)
 	}


### PR DESCRIPTION
**Describe the PR**
`filepath.Join` already calls `filepath.Clean` on it's arguments. So, it's unnecessary to call `filepath.Clean` on the second argument.

**Relation issue**

**Additional context**
