### PR TITLE
fix: fixed definition parsing for alias types

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -792,7 +792,7 @@ func (p *Parser) parseTypeExprV3(file *ast.File, typeExpr ast.Expr, ref bool) (*
 
 	// type Foo Baz
 	case *ast.Ident:
-		result, err := p.getTypeSchemaV3(expr.Name, file, true)
+		result, err := p.getTypeSchemaV3(expr.Name, file, ref)
 		if err != nil {
 			return nil, errors.Wrap(err, errMessage)
 		}

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -1,8 +1,10 @@
 package swag
 
 import (
+	"encoding/json"
 	"go/ast"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -397,4 +399,23 @@ func TestParserParseServers(t *testing.T) {
 	assert.Equal(t, "https://petstore.com/v3", servers[1].Spec.URL)
 	assert.Equal(t, "Production Petstore server.", servers[1].Spec.Description)
 
+}
+
+func TestParseTypeAlias(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/v3/type_alias_definition"
+
+	p := New(GenerateOpenAPI3Doc(true))
+
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	require.NoError(t, err)
+
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	require.NoError(t, err)
+
+	result, err := json.Marshal(p.openAPI)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(result))
 }

--- a/testdata/v3/type_alias_definition/api/api.go
+++ b/testdata/v3/type_alias_definition/api/api.go
@@ -1,0 +1,10 @@
+package api
+
+import "net/http"
+
+// @Router /test [GET]
+// @Produce json
+// @Success 200 {object} types.Response "Success"
+func Handle(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/testdata/v3/type_alias_definition/expected.json
+++ b/testdata/v3/type_alias_definition/expected.json
@@ -1,0 +1,110 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Swagger Example API",
+    "version": "1.0"
+  },
+  "externalDocs": {
+    "description": "",
+    "url": ""
+  },
+  "components": {
+    "schemas": {
+      "types.NestedStruct": {
+        "type": "object",
+        "properties": {
+          "int": {
+            "type": "integer"
+          }
+        }
+      },
+      "types.Struct": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "type": "string"
+          },
+          "nestedStruct": {
+            "$ref": "#/components/schemas/types.NestedStruct"
+          }
+        }
+      },
+      "types.StructAlias": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "type": "string"
+          },
+          "nestedStruct": {
+            "$ref": "#/components/schemas/types.NestedStruct"
+          }
+        }
+      },
+      "types.StructSubtype": {
+        "type": "object",
+        "properties": {
+          "string": {
+            "type": "string"
+          },
+          "nestedStruct": {
+            "$ref": "#/components/schemas/types.NestedStruct"
+          }
+        }
+      },
+      "types.OtherStructAlias": {
+        "type": "object",
+        "properties": {
+          "float": {
+            "type": "number"
+          }
+        }
+      },
+      "types.OtherStructSubtype": {
+        "type": "object",
+        "properties": {
+          "float": {
+            "type": "number"
+          }
+        }
+      },
+      "types.Response": {
+        "type": "object",
+        "properties": {
+          "struct": {
+            "$ref": "#/components/schemas/types.Struct"
+          },
+          "structAlias": {
+            "$ref": "#/components/schemas/types.StructAlias"
+          },
+          "structSubtype": {
+            "$ref": "#/components/schemas/types.StructSubtype"
+          },
+          "otherStructAlias": {
+            "$ref": "#/components/schemas/types.OtherStructAlias"
+          },
+          "otherStructSubtype": {
+            "$ref": "#/components/schemas/types.OtherStructSubtype"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/types.Response"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/v3/type_alias_definition/main.go
+++ b/testdata/v3/type_alias_definition/main.go
@@ -1,0 +1,4 @@
+package main
+
+// @title Swagger Example API
+// @version 1.0

--- a/testdata/v3/type_alias_definition/othertypes/types.go
+++ b/testdata/v3/type_alias_definition/othertypes/types.go
@@ -1,0 +1,5 @@
+package othertypes
+
+type Struct struct {
+	Float float64
+}

--- a/testdata/v3/type_alias_definition/types/types.go
+++ b/testdata/v3/type_alias_definition/types/types.go
@@ -1,0 +1,26 @@
+package types
+
+import "github.com/swaggo/swag/v2/testdata/v3/type_alias_definition/othertypes"
+
+type Struct struct {
+	String       string       `json:"string"`
+	NestedStruct NestedStruct `json:"nestedStruct"`
+}
+
+type NestedStruct struct {
+	Int int `json:"int"`
+}
+
+type StructAlias = Struct
+type OtherStructAlias = othertypes.Struct
+
+type StructSubtype Struct
+type OtherStructSubtype othertypes.Struct
+
+type Response struct {
+	Struct             `json:"struct"`
+	StructAlias        `json:"structAlias"`
+	OtherStructAlias   `json:"otherStructAlias"`
+	StructSubtype      `json:"structSubtype"`
+	OtherStructSubtype `json:"otherStructSubtype"`
+}


### PR DESCRIPTION
**Describe the PR**
The fix for OpenAPI v3 definition parsing of go alias types 

**Relation issue**
https://github.com/swaggo/swag/issues/1590

**Additional context**
-
