### PR TITLE
docs: add PT and EN examples for Go generic types

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Swag converts Go annotations to Swagger Documentation 2.0. We've created a varie
 	- [How to use security annotations](#how-to-use-security-annotations)
 	- [Add a description for enum items](#add-a-description-for-enum-items)
 	- [Generate only specific docs file types](#generate-only-specific-docs-file-types)
+    - [How to use Go generic types](#how-to-use-generics)
 - [About the Project](#about-the-project)
 
 ## Getting started
@@ -908,6 +909,19 @@ By default `swag` command generates Swagger specification in three different fil
 - swagger.yaml
 
 If you would like to limit a set of file types which should be generated you can use `--outputTypes` (short `-ot`) flag. Default value is `go,json,yaml` - output types separated with comma. To limit output only to `go` and `yaml` files, you would write `go,yaml`. With complete command that would be `swag init --outputTypes go,yaml`.
+
+### How to use Generics
+
+```go
+// @Success 200 {object} web.GenericNestedResponse[types.Post]
+// @Success 204 {object} web.GenericNestedResponse[types.Post, Types.AnotherOne]
+// @Success 201 {object} web.GenericNestedResponse[web.GenericInnerType[types.Post]]
+func GetPosts(w http.ResponseWriter, r *http.Request) {
+	_ = web.GenericNestedResponse[types.Post]{}
+}
+```
+See [this file](https://github.com/swaggo/swag/blob/master/testdata/generics_nested/api/api.go) for more details 
+and other examples.
 
 ### Change the default Go Template action delimiters
 [#980](https://github.com/swaggo/swag/issues/980)

--- a/README_pt.md
+++ b/README_pt.md
@@ -43,6 +43,7 @@ Swag converte anotações Go para Documentação Swagger 2.0. Criámos uma varie
 	- [Como utilizar as anotações de segurança](#como-utilizar-as-anotações-de-segurança)
 	- [Adicionar uma descrição para enumerar artigos](#add-a-description-for-enum-items)
 	- [Gerar apenas tipos de ficheiros de documentos específicos](#generate-only-specific-docs-file-file-types)
+    - [Como usar tipos genéricos](#como-usar-tipos-genéricos)
 - [Sobre o projecto](#sobre-o-projecto)
 
 ## Começando
@@ -904,6 +905,18 @@ Por defeito, o comando `swag` gera especificação Swagger em três tipos difere
 - swagger.yaml
 
 Se desejar limitar um conjunto de tipos de ficheiros que devem ser gerados pode utilizar a bandeira `--outputTypes` (short `-ot`). O valor por defeito é `go,json,yaml` - tipos de saída separados por vírgula. Para limitar a saída apenas a ficheiros `go` e `yaml`, escrever-se-ia `go,yaml'. Com comando completo que seria `swag init --outputTypes go,yaml`.
+
+### Como usar tipos genéricos
+
+```go
+// @Success 200 {object} web.GenericNestedResponse[types.Post]
+// @Success 204 {object} web.GenericNestedResponse[types.Post, Types.AnotherOne]
+// @Success 201 {object} web.GenericNestedResponse[web.GenericInnerType[types.Post]]
+func GetPosts(w http.ResponseWriter, r *http.Request) {
+	_ = web.GenericNestedResponse[types.Post]{}
+}
+```
+Para mais detalhes e outros exemplos, veja [esse arquivo](https://github.com/swaggo/swag/blob/master/testdata/generics_nested/api/api.go)
 
 ### Alterar os delimitadores de acção padrão Go Template
 [#980](https://github.com/swaggo/swag/issues/980)


### PR DESCRIPTION
**Describe the PR**
Add Portuguese and English documentation about usage of the parser with Go generic types

**Relation issue**
#1655 

**Additional context**
The examples were already being used as [test data](https://github.com/swaggo/swag/blob/master/testdata/generics_nested/api/api.go) but none added to the main README.md
