### PR TITLE
Optimize docker container usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o swag cmd/swag/
 ######## Start a new stage from scratch #######
 FROM scratch
 
-WORKDIR /root/
+WORKDIR /code/
 
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/swag /bin/swag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 
 # Start from the latest golang base image
-FROM golang:1.18.3-alpine as builder
+FROM golang:1.20-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ FROM scratch
 WORKDIR /root/
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=builder /app/swag .
+COPY --from=builder /app/swag /root/swag

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,5 @@ WORKDIR /root/
 
 # Copy the Pre-built binary file from the previous stage
 COPY --from=builder /app/swag /root/swag
+
+ENTRYPOINT ["/root/swag"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ FROM scratch
 WORKDIR /root/
 
 # Copy the Pre-built binary file from the previous stage
-COPY --from=builder /app/swag /root/swag
+COPY --from=builder /app/swag /bin/swag
 
-ENTRYPOINT ["/root/swag"]
+ENTRYPOINT ["/bin/swag"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build from source you need [Go](https://golang.org/dl/) (1.17 or newer).
 
 Alternatively you can run the docker image:
 ```sh
-docker run --rm -v $(pwd):/code -w /code ghcr.io/swaggo/swag:latest
+docker run --rm -v $(pwd):/code ghcr.io/swaggo/swag:latest
 ```
 
 Or download a pre-compiled binary from the [release page](https://github.com/swaggo/swag/releases).

--- a/README.md
+++ b/README.md
@@ -51,11 +51,16 @@ Swag converts Go annotations to Swagger Documentation 2.0. We've created a varie
 
 1. Add comments to your API source code, See [Declarative Comments Format](#declarative-comments-format).
 
-2. Download swag by using:
+2. Install swag by using:
 ```sh
 go install github.com/swaggo/swag/cmd/swag@latest
 ```
 To build from source you need [Go](https://golang.org/dl/) (1.17 or newer).
+
+Alternatively you can run the docker image:
+```sh
+docker run --rm -v $(pwd):/code -w /code ghcr.io/swaggo/swag:latest
+```
 
 Or download a pre-compiled binary from the [release page](https://github.com/swaggo/swag/releases).
 


### PR DESCRIPTION
Currently the docker container has to be invoked with
```sh
docker run --rm -v $(pwd):/code -w /code ghcr.io/swaggo/swag:v1.16.2 /root/swag
```
which means users have to know that the binary is placed under `/root/swag`. If they don´t know this and just try
```sh
docker run --rm -v $(pwd):/code ghcr.io/swaggo/swag:v1.16.2
```
they will get the error
```sh
docker: Error response from daemon: No command specified.
```
if they then try
```sh
docker run --rm -v $(pwd):/code ghcr.io/swaggo/swag:v1.16.2 swag
```
it won´t work either
```sh
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "swago": executable file not found in $PATH
: unknown.
```
This PR adds an `ENTRYPOINT` meaning the first command will just work. It also moves the binary to `/bin` since having the binary in the same directory as the default `WORKDIR` is suboptimal since users need to mount their code into the container. If the binary is not stored in the `WORKDIR`, then users can simply mount their code to that directory without having to specify a different one with `-w`.