### PR TITLE
:bug: array form filed name should not contains bracket which led to invalid fieldname in ts codegen

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -98,7 +98,7 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 
 func (ps *tagBaseFieldParser) FormName() string {
 	if ps.field.Tag != nil {
-		return strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+		return strings.TrimRight(strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0]), "[]")
 	}
 	return ""
 }

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -668,4 +668,26 @@ func TestValidTags(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, schema.Enum)
 	})
+
+	t.Run("Form Filed Name", func(t *testing.T) {
+		t.Parallel()
+
+		filedname, err := newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `form:"test[]"`,
+			}},
+		).FieldName()
+		assert.NoError(t, err)
+		assert.Equal(t, "test", filedname)
+
+		filedname, err = newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `form:"test"`,
+			}},
+		).FieldName()
+		assert.NoError(t, err)
+		assert.Equal(t, "test", filedname)
+	})
 }


### PR DESCRIPTION
**Describe the PR**
Change FormName. Trim bracket in filedname

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**
In gin binding, an array parameter goes like
```go
type Teacher struct {
  Books []string `form:"books[]"`
}
```
In swaggo/swag less than **v1.8.10**, it's field name should comes from ps.Filed.Names[0] which is "Names", which goes to toLowerCamelCase and generate "names".
![image](https://github.com/swaggo/swag/assets/43741654/2667fa02-cbef-4c10-8d8b-173df6635327)

```go
func (ps *tagBaseFieldParser) FieldName() (string, error) {
	var name string
	if ps.field.Tag != nil {
		// json:"tag,hoge"
		name = strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])

		if name != "" {
			return name, nil
		}
	}

	if ps.field.Names == nil {
		return "", nil
	}

	switch ps.p.PropNamingStrategy {
	case SnakeCase:
		return toSnakeCase(ps.field.Names[0].Name), nil
	case PascalCase:
		return ps.field.Names[0].Name, nil
	default:
		return toLowerCamelCase(ps.field.Names[0].Name), nil
	}
}
```
Since **v1.8.11**, FormName was introduced to parse form tag, which generates `books[]` tags, which lead to bad codegen in ts.
Ts code changes, which is not generated by tools, write by hand.
From:
```ts
const Teacher = {
  books: []
}
```
To:
```ts
const Teacher = {
  "books[]": []
}
```

`Teacher."books[]"` is not working in ts, which only can be use like `Teacher["books[]"]`.


