### PR TITLE
Change dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o swag cmd/swag/
 
 
 ######## Start a new stage from scratch #######
-FROM scratch
+FROM golang:1.20-alpine
 
 WORKDIR /code/
 


### PR DESCRIPTION
**Describe the PR**
When building more complicated apps go is a mandatory dependency In the image due to https://github.com/swaggo/swag/blob/6cdaaf5c77457e82d9e0f8fccd303fefb8dc8072/golist.go#L14-L15
So we need to use image with go.

Otherwise, it fails with error `go not in path`

In addition, can somebody confirm GitHub image latest works fine? We had to rebuild manually as one in GitHub looks corrupted. 
