### PR TITLE
Struct fields supported for header and path param types

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -96,11 +96,19 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 	}
 }
 
-func (ps *tagBaseFieldParser) FormName() string {
+func (ps *tagBaseFieldParser) firstTagValue(tag string) string {
 	if ps.field.Tag != nil {
 		return strings.TrimRight(strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0]), "[]")
 	}
 	return ""
+}
+
+func (ps *tagBaseFieldParser) FormName() string {
+	return ps.firstTagValue(formTag)
+}
+
+func (ps *tagBaseFieldParser) HeaderName() string {
+	return ps.firstTagValue(headerTag)
 }
 
 func toSnakeCase(in string) string {

--- a/field_parser.go
+++ b/field_parser.go
@@ -98,7 +98,7 @@ func (ps *tagBaseFieldParser) FieldName() (string, error) {
 
 func (ps *tagBaseFieldParser) firstTagValue(tag string) string {
 	if ps.field.Tag != nil {
-		return strings.TrimRight(strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0]), "[]")
+		return strings.TrimRight(strings.TrimSpace(strings.Split(ps.tag.Get(tag), ",")[0]), "[]")
 	}
 	return ""
 }
@@ -109,6 +109,10 @@ func (ps *tagBaseFieldParser) FormName() string {
 
 func (ps *tagBaseFieldParser) HeaderName() string {
 	return ps.firstTagValue(headerTag)
+}
+
+func (ps *tagBaseFieldParser) PathName() string {
+	return ps.firstTagValue(uriTag)
 }
 
 func toSnakeCase(in string) string {

--- a/operation.go
+++ b/operation.go
@@ -315,8 +315,13 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 					}
 				}
 
+				nameOverrideType := paramType
+				// query also uses formData tags
+				if paramType == "query" {
+					nameOverrideType = "formData"
+				}
 				// load overridden type specific name from extensions if exists
-				if nameVal, ok := item.Schema.Extensions[paramType]; ok {
+				if nameVal, ok := item.Schema.Extensions[nameOverrideType]; ok {
 					name = nameVal.(string)
 				}
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -2098,6 +2098,7 @@ func TestParseParamStructCodeExample(t *testing.T) {
 				if p.Name == param.Name {
 					assert.Equal(t, param.ParamProps, p.ParamProps)
 					assert.Equal(t, param.CommonValidations, p.CommonValidations)
+					assert.Equal(t, param.SimpleSchema, p.SimpleSchema)
 					found = true
 					break
 				}
@@ -2130,12 +2131,18 @@ func TestParseParamStructCodeExample(t *testing.T) {
 					CommonValidations: spec.CommonValidations{
 						MaxLength: &maxLen,
 					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "string",
+					},
 				},
 				spec.Parameter{
 					ParamProps: spec.ParamProps{
 						Name:        "b",
 						Description: "B is another field",
 						In:          param,
+					},
+					SimpleSchema: spec.SimpleSchema{
+						Type: "boolean",
 					},
 				})
 		})
@@ -2155,6 +2162,9 @@ func TestParseParamStructCodeExample(t *testing.T) {
 					In:          "header",
 					Required:    true,
 				},
+				SimpleSchema: spec.SimpleSchema{
+					Type: "string",
+				},
 			}, spec.Parameter{
 				ParamProps: spec.ParamProps{
 					Name:        "anotherHeader",
@@ -2164,6 +2174,41 @@ func TestParseParamStructCodeExample(t *testing.T) {
 				CommonValidations: spec.CommonValidations{
 					Maximum: &max,
 					Minimum: &min,
+				},
+				SimpleSchema: spec.SimpleSchema{
+					Type: "integer",
+				},
+			})
+	})
+
+	t.Run("path struct", func(t *testing.T) {
+		operation := NewOperation(parser)
+		comment := `@Param path path structs.PathModel true "path params"`
+		err = operation.ParseComment(comment, ast)
+		assert.NoError(t, err)
+
+		validateParameters(operation,
+			spec.Parameter{
+				ParamProps: spec.ParamProps{
+					Name:        "id",
+					Description: "ID is the id",
+					In:          "path",
+					Required:    true,
+				},
+				SimpleSchema: spec.SimpleSchema{
+					Type: "integer",
+				},
+			}, spec.Parameter{
+				ParamProps: spec.ParamProps{
+					Name:        "name",
+					Description: "",
+					In:          "path",
+				},
+				CommonValidations: spec.CommonValidations{
+					MaxLength: &maxLen,
+				},
+				SimpleSchema: spec.SimpleSchema{
+					Type: "string",
 				},
 			})
 	})

--- a/parser.go
+++ b/parser.go
@@ -189,6 +189,7 @@ type FieldParser interface {
 	ShouldSkip() bool
 	FieldName() (string, error)
 	FormName() string
+	HeaderName() string
 	CustomSchema() (*spec.Schema, error)
 	ComplementSchema(schema *spec.Schema) error
 	IsRequired() (bool, error)
@@ -1506,11 +1507,14 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 		tagRequired = append(tagRequired, fieldName)
 	}
 
+	if schema.Extensions == nil {
+		schema.Extensions = make(spec.Extensions)
+	}
 	if formName := ps.FormName(); len(formName) > 0 {
-		if schema.Extensions == nil {
-			schema.Extensions = make(spec.Extensions)
-		}
-		schema.Extensions[formTag] = formName
+		schema.Extensions["formData"] = formName
+	}
+	if headerName := ps.HeaderName(); len(headerName) > 0 {
+		schema.Extensions["header"] = headerName
 	}
 
 	return map[string]spec.Schema{fieldName: *schema}, tagRequired, nil

--- a/parser.go
+++ b/parser.go
@@ -190,6 +190,7 @@ type FieldParser interface {
 	FieldName() (string, error)
 	FormName() string
 	HeaderName() string
+	PathName() string
 	CustomSchema() (*spec.Schema, error)
 	ComplementSchema(schema *spec.Schema) error
 	IsRequired() (bool, error)
@@ -1515,6 +1516,9 @@ func (parser *Parser) parseStructField(file *ast.File, field *ast.Field) (map[st
 	}
 	if headerName := ps.HeaderName(); len(headerName) > 0 {
 		schema.Extensions["header"] = headerName
+	}
+	if pathName := ps.PathName(); len(pathName) > 0 {
+		schema.Extensions["path"] = pathName
 	}
 
 	return map[string]spec.Schema{fieldName: *schema}, tagRequired, nil

--- a/testdata/param_structs/structs.go
+++ b/testdata/param_structs/structs.go
@@ -1,5 +1,11 @@
 package structs
 
+type FormModel struct {
+	Foo string `form:"f" binding:"required" validate:"max=10"`
+	// B is another field
+	B string
+}
+
 type AuthHeader struct {
 	// Token is the auth token
 	Token string `header:"X-Auth-Token" binding:"required"`

--- a/testdata/param_structs/structs.go
+++ b/testdata/param_structs/structs.go
@@ -1,0 +1,8 @@
+package structs
+
+type AuthHeader struct {
+	// Token is the auth token
+	Token string `header:"X-Auth-Token" binding:"required"`
+	// AnotherHeader is another header
+	AnotherHeader int `validate:"gte=0,lte=10"`
+}

--- a/testdata/param_structs/structs.go
+++ b/testdata/param_structs/structs.go
@@ -3,7 +3,7 @@ package structs
 type FormModel struct {
 	Foo string `form:"f" binding:"required" validate:"max=10"`
 	// B is another field
-	B string
+	B bool
 }
 
 type AuthHeader struct {
@@ -11,4 +11,10 @@ type AuthHeader struct {
 	Token string `header:"X-Auth-Token" binding:"required"`
 	// AnotherHeader is another header
 	AnotherHeader int `validate:"gte=0,lte=10"`
+}
+
+type PathModel struct {
+	// ID is the id
+	Identifier int    `uri:"id" binding:"required"`
+	Name       string `validate:"max=10"`
 }


### PR DESCRIPTION
**Describe the PR**
Supports "object" (i.e. struct model) data types for `header` and `path` parameter types via `@Param` operation comment in the same way that `query` and `formData` already work - basic structs are supported to represent multiple paramters at once.

This allows struct models, e.g. for a number of related headers, to be used directly rather than duplicating all the `@Param` comments for every field in those structs.

This works similarly to existing `formData` and `query` types and largely reuses all the same operation parsing logic.

In addition this supports using struct tags `header:"name"`  and `uri:"name"` for `header` and `path` params respectively. This follows the Gin specific tag naming conventions.

**Relation issues**
A few issues with similar feature requests:
- https://github.com/swaggo/swag/issues/248
- https://github.com/swaggo/swag/issues/1720
- https://github.com/swaggo/swag/issues/1197 (closed in error I believe)