### PR TITLE
Update operation.go

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -334,6 +334,9 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 					if len(itemSchema.Type) == 0 {
 						itemSchema = operation.parser.getUnderlyingSchema(prop.Items.Schema)
 					}
+					if itemSchema == nil {
+						continue
+					}
 					if len(itemSchema.Type) == 0 {
 						continue
 					}


### PR DESCRIPTION
getUnderlyingSchema can return nil, so it has to be checked here otherwise the code is exposed to invalid memory address or nil pointer dereference

**Describe the PR**
A fix for an issue I opened.

**Relation issue**
#1752 

**Additional context**
Add any other context about the problem here.
