### PR TITLE
Feat: multi-arch docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/swaggo/swag:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,8 +36,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/swaggo/swag:latest
-            ghcr.io/swaggo/swag:${{github.ref_name}}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{github.ref_name}}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,6 +30,7 @@ jobs:
           images: ghcr.io/swaggo/swag
 
       - name: Build image and push to GitHub Container Registry
+        id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,13 +29,13 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/swaggo/swag
 
       - name: Build image and push to GitHub Container Registry
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o swag cmd/swag/
 
 
 ######## Start a new stage from scratch #######
-FROM scratch
+FROM --platform=$TARGETPLATFORM scratch
 
 WORKDIR /code/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN go mod download
 COPY . .
 
 # Configure go compiler target platform
-ARG TARGETARCH TARGETOS
+ARG TARGETOS
+ARG TARGETARCH
 ENV GOARCH=$TARGETARCH \
     GOOS=$TARGETOS
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 
 # Start from the latest golang base image
-FROM golang:1.21-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -14,6 +14,11 @@ RUN go mod download
 
 # Copy the source from the current directory to the Working Directory inside the container
 COPY . .
+
+# Configure go compiler target platform
+ARG TARGETARCH TARGETOS
+ENV GOARCH=$TARGETARCH \
+    GOOS=$TARGETOS
 
 # Build the Go app
 RUN CGO_ENABLED=0 GOOS=linux go build -v -a -installsuffix cgo -o swag cmd/swag/main.go


### PR DESCRIPTION
**Describe the PR**

Fix https://github.com/swaggo/swag/issues/1755 by enabling go cross-compilation in Dockerfile and setting multiple target architectures in docker/build-push-action.

**Relation issue**
https://github.com/swaggo/swag/issues/1755 - Create multi-arch docker image for amd64/arm64 

**Additional context**
Validated the Dockerfile change by building a multi-arch image locally. ~~I have no way to test the change in github worklfow though.~~ Thanks to @ngehrsitz, changes to github workflow could be validated on this fork repo, too.
