### PR TITLE
feat: Add support for "title" property

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -169,6 +169,7 @@ func (ps *tagBaseFieldParser) CustomSchema() (*spec.Schema, error) {
 }
 
 type structField struct {
+	title        string
 	schemaType   string
 	arrayType    string
 	formatType   string
@@ -274,6 +275,7 @@ func (ps *tagBaseFieldParser) complementSchema(schema *spec.Schema, types []stri
 	field := &structField{
 		schemaType: types[0],
 		formatType: ps.tag.Get(formatTag),
+		title:      ps.tag.Get(titleTag),
 	}
 
 	if len(types) > 1 && (types[0] == ARRAY || types[0] == OBJECT) {
@@ -414,6 +416,7 @@ func (ps *tagBaseFieldParser) complementSchema(schema *spec.Schema, types []stri
 	if field.schemaType != ARRAY {
 		schema.Format = field.formatType
 	}
+	schema.Title = field.title
 
 	extensionsTagValue := ps.tag.Get(extensionsTag)
 	if extensionsTagValue != "" {

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -60,6 +60,21 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.Equal(t, "csv", schema.Format)
 	})
 
+	t.Run("Title tag", func(t *testing.T) {
+		t.Parallel()
+
+		schema := spec.Schema{}
+		schema.Type = []string{"string"}
+		err := newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" title:"myfield"`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, "myfield", schema.Title)
+	})
+
 	t.Run("Required tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/operation.go
+++ b/operation.go
@@ -411,6 +411,7 @@ const (
 	exampleTag          = "example"
 	schemaExampleTag    = "schemaExample"
 	formatTag           = "format"
+	titleTag            = "title"
 	validateTag         = "validate"
 	minimumTag          = "minimum"
 	maximumTag          = "maximum"


### PR DESCRIPTION
**Describe the PR**
Added support for "title" property, as defined by [Openapi Specification Schema Object](https://swagger.io/specification/v2/).
The property is provided via "title" tag on structs.

**Relation issue**
none

**Additional context**
The problem arose from having to generate the API in typescript for the client through openapi-generator. Because some fields (marked with "x-nullable") were considered "Inline Models" and the openapi-generator CLI suggested using the "title" field to give it a unique name, i tried to find a ready-made solution with no luck.

The "schema" struct already contained the "Title" field, but this is never assigned, so I proceeded to complete the assignment of the field through the "title" tag.

**Usage:**

the following definition:

```
type CreatePageRequest struct {
	Title       string                `json:"title" validate:"required,max=255"`
	CoverImage  *EmbeddedImageRequest `json:"coverImage,omitempty" extensions:"x-nullable" title:"EmbeddedImageRequest"`
}
```
will generate this:

```
...
{
"title": {
                    "type": "string",
                    "maxLength": 255
                },
"coverImage": {
                    "format": "url",
                    "title": "EmbeddedImageRequest",
                    "allOf": [
                        {
                            "$ref": "#/definitions/EmbeddedImageRequestInternal"
                        }
                    ],
                    "x-nullable": true
                },
}
```