### PR TITLE
feat: ParseComment error to contain the comment

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -386,7 +386,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 			param.Schema = schema
 		}
 	default:
-		return fmt.Errorf("%s is not supported paramType", paramType)
+		return fmt.Errorf("not supported paramType: %s", paramType)
 	}
 
 	err := operation.parseParamAttribute(commentLine, objectType, refType, paramType, &param)

--- a/parser.go
+++ b/parser.go
@@ -1078,7 +1078,7 @@ func (parser *Parser) parseRouterAPIInfoComment(comments []*ast.Comment, fileInf
 		for _, comment := range comments {
 			err := operation.ParseComment(comment.Text, fileInfo.File)
 			if err != nil {
-				return fmt.Errorf("ParseComment error in file %s :%+v", fileInfo.Path, err)
+				return fmt.Errorf("ParseComment error in file %s for comment: '%s': %+v", fileInfo.Path, comment.Text, err)
 			}
 			if operation.State != "" && operation.State != parser.HostState {
 				return nil


### PR DESCRIPTION
When a comment has an error then we print only a file name and the error text but not the comment that caused an error. To make it easier to understand print it.

**Context:**
I spent a lot of time while investigating the error message:

    Generating dto.DeleteRequest
    Key is not supported paramType

It turned out that the DTO was fine but a problem was in another place with a comment:

    // @Param User Key body dto.UserRequest true "Event"

In the comment instead of `UserKey` it was written `User Key` and the Key was threatened as a `paramType`. I wasn't able to figure out which key they are talking about.

So the change should significantly improve troubleshooting which is important.
