### PR TITLE
Handle case of empty GOROOT

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -93,7 +93,7 @@ func (pkgDefs *PackagesDefinitions) RangeFiles(handle func(info *AstFileInfo) er
 	for _, info := range pkgDefs.files {
 		// ignore package path prefix with 'vendor' or $GOROOT,
 		// because the router info of api will not be included these files.
-		if strings.HasPrefix(info.PackagePath, "vendor") || strings.HasPrefix(info.Path, runtime.GOROOT()) {
+		if strings.HasPrefix(info.PackagePath, "vendor") || (runtime.GOROOT() != "" && strings.HasPrefix(info.Path, runtime.GOROOT())) {
 			continue
 		}
 		sortedFiles = append(sortedFiles, info)


### PR DESCRIPTION
**Describe the PR**

In some situations, such as when using the go-swag Nix package, `runtime.GOROOT()` will be empty, and `RangeFiles` will skip all source paths since technically, all paths are prefixed with the empty string.

See also https://github.com/NixOS/nixpkgs/issues/224701

May resolve some cases of https://github.com/swaggo/swag/issues/1622.

**Relation issue**
https://github.com/NixOS/nixpkgs/issues/224701
https://github.com/swaggo/swag/issues/1622

**Additional context**
