### PR TITLE
adds support for complex types with function scope

### DIFF
--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -138,3 +138,15 @@ func GetPet6FunctionScopedResponse() {
 		Name string
 	}
 }
+
+// @Success 200 {object}  api.GetPet6FunctionScopedComplexResponse.response "ok"
+// @Router /GetPet6FunctionScopedComplexResponse [get]
+func GetPet6FunctionScopedComplexResponse() {
+	type child struct {
+		Name string
+	}
+
+	type response struct {
+		Child child
+	}
+}

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -113,6 +113,18 @@
         }
       }
     },
+    "/GetPet6FunctionScopedComplexResponse": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "$ref": "#/definitions/api.GetPet6FunctionScopedComplexResponse.response"
+            }
+          }
+        }
+      }
+    },
     "/GetPet6MapString": {
       "get": {
         "responses": {
@@ -401,6 +413,25 @@
     }
   },
   "definitions": {
+    "api.GetPet6FunctionScopedComplexResponse.pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "api.GetPet6FunctionScopedComplexResponse.response": {
+      "type": "object",
+      "properties": {
+        "Pets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/api.GetPet6FunctionScopedComplexResponse.pet"
+          }
+        }
+      }
+    },
     "api.GetPet6FunctionScopedResponse.response": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
**Describe the PR**
Building on top of: https://github.com/swaggo/swag/pull/1283
Further support for function scoped types, we will now be able to define more complex request and responses in a function scope:

```
package main

// @Param request body main.Fun.request true "query params" 
// @Success 200 {object} main.Fun.response
// @Router /test [post]
func Fun()  {
	type request struct {
		Name string
	}
	
        type child struct {
                Name string
        }

	type response struct {
		Child child
	}
}

```
**Relation issue**
[e.g. https://github.com/swaggo/swag/pull/118/files](https://github.com/swaggo/swag/issues/1812)

**Additional context**
I do not have a lot of experience with this project, so any input is more than welcome.
