### PR TITLE
Add @securitydefinitions.bearer (#1100)

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -63,6 +63,7 @@ const (
 	secImplicitAttr          = "@securitydefinitions.oauth2.implicit"
 	secPasswordAttr          = "@securitydefinitions.oauth2.password"
 	secAccessCodeAttr        = "@securitydefinitions.oauth2.accesscode"
+	secBearerAttr            = "@securitydefinitions.bearer"
 	tosAttr                  = "@termsofservice"
 	extDocsDescAttr          = "@externaldocs.description"
 	extDocsURLAttr           = "@externaldocs.url"

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -136,7 +136,7 @@ func TestParserParseGeneralApiInfoV3(t *testing.T) {
 	assert.Equal(t, "OpenAPI", p.openAPI.ExternalDocs.Spec.Description)
 	assert.Equal(t, "https://swagger.io/resources/open-api", p.openAPI.ExternalDocs.Spec.URL)
 
-	assert.Equal(t, 6, len(p.openAPI.Components.Spec.SecuritySchemes))
+	assert.Equal(t, 7, len(p.openAPI.Components.Spec.SecuritySchemes))
 
 	security := p.openAPI.Components.Spec.SecuritySchemes
 	assert.Equal(t, "basic", security["basic"].Spec.Spec.Scheme)
@@ -164,6 +164,10 @@ func TestParserParseGeneralApiInfoV3(t *testing.T) {
 	assert.Equal(t, "oauth2", security["OAuth2AccessCode"].Spec.Spec.Type)
 	assert.Equal(t, "header", security["OAuth2AccessCode"].Spec.Spec.In)
 	assert.Equal(t, "https://example.com/oauth/token", security["OAuth2AccessCode"].Spec.Spec.Flows.Spec.AuthorizationCode.Spec.TokenURL)
+
+	assert.Equal(t, "http", security["BearerToken"].Spec.Spec.Type)
+	assert.Equal(t, "bearer", security["BearerToken"].Spec.Spec.Scheme)
+	assert.Equal(t, "JWT", security["BearerToken"].Spec.Spec.BearerFormat)
 }
 
 func TestParser_ParseGeneralApiInfoExtensionsV3(t *testing.T) {

--- a/testdata/v3/main.go
+++ b/testdata/v3/main.go
@@ -54,6 +54,9 @@ package main
 // @in header
 // @name name
 
+// @securitydefinitions.bearer BearerToken
+// @bearerFormat JWT
+
 // @externalDocs.description OpenAPI
 // @externalDocs.url https://swagger.io/resources/open-api
 


### PR DESCRIPTION
**Describe the PR**
Added the ability to define @securitydefinitions.bearer according to the OpenAPI v3 documentation
https://swagger.io/docs/specification/authentication/bearer-authentication/

**Relation issue**
Issues were closed long time ago, but with spec v3 support that feature already possible to implement
https://github.com/swaggo/swag/issues/1142
https://github.com/swaggo/swag/issues/1100
https://github.com/swaggo/swag/issues/864
https://github.com/swaggo/swag/issues/804

**Additional context**
I do not have a lot of experience with this project, so any input is more than welcome.
