### PR TITLE
fix issue: #1780: filter $GOROOT path

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -93,7 +93,7 @@ func (pkgDefs *PackagesDefinitions) RangeFiles(handle func(info *AstFileInfo) er
 	for _, info := range pkgDefs.files {
 		// ignore package path prefix with 'vendor' or $GOROOT,
 		// because the router info of api will not be included these files.
-		if strings.HasPrefix(info.PackagePath, "vendor") || (runtime.GOROOT() != "" && strings.HasPrefix(info.Path, runtime.GOROOT())) {
+		if strings.HasPrefix(info.PackagePath, "vendor") || (runtime.GOROOT() != "" && strings.HasPrefix(info.Path, runtime.GOROOT()+string(filepath.Separator))) {
 			continue
 		}
 		sortedFiles = append(sortedFiles, info)


### PR DESCRIPTION
**Describe the PR**
the path filter will filter out the code path in this scenario: the $GOROOT path is "~/development/go" and the code path is "~/development/golang/src/github.com/xxxx"

**Relation issue**
https://github.com/swaggo/swag/issues/1780
**Additional context**
the limitation may need to be written into documentation.