### PR TITLE
fix: tag.markdown.description finds correct markdown per tag

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -897,11 +897,9 @@ func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
 
 		fileName := entry.Name()
 
-		if !strings.Contains(fileName, ".md") {
-			continue
-		}
+		expectedFileName := tagName + ".md"
 
-		if strings.Contains(fileName, tagName) {
+		if fileName == expectedFileName {
 			fullPath := filepath.Join(dirPath, fileName)
 
 			commentInfo, err := os.ReadFile(fullPath)


### PR DESCRIPTION
**Describe the PR**
e.g. add cool parser.

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**
Add any other context about the problem here.
