### PR TITLE
Fixes Issue 1829

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -885,6 +885,13 @@ func isGeneralAPIComment(comments []string) bool {
 }
 
 func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
+	if tagName == "" {
+		// this happens when parsing the @description.markdown attribute
+		// it will be called properly another time with tagName="api"
+		// so we can safely return an empty byte slice here
+		return make([]byte, 0), nil
+	}
+
 	dirEntries, err := os.ReadDir(dirPath)
 	if err != nil {
 		return nil, err
@@ -897,11 +904,9 @@ func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
 
 		fileName := entry.Name()
 
-		if !strings.Contains(fileName, ".md") {
-			continue
-		}
+		expectedFileName := tagName + ".md"
 
-		if strings.Contains(fileName, tagName) {
+		if fileName == expectedFileName {
 			fullPath := filepath.Join(dirPath, fileName)
 
 			commentInfo, err := os.ReadFile(fullPath)

--- a/parser.go
+++ b/parser.go
@@ -904,7 +904,10 @@ func getMarkdownForTag(tagName string, dirPath string) ([]byte, error) {
 
 		fileName := entry.Name()
 
-		expectedFileName := tagName + ".md"
+		expectedFileName := tagName
+		if !strings.HasSuffix(tagName, ".md") {
+			expectedFileName = tagName + ".md"
+		}
 
 		if fileName == expectedFileName {
 			fullPath := filepath.Join(dirPath, fileName)


### PR DESCRIPTION
**Describe the PR**
Fixes the issue described in https://github.com/swaggo/swag/issues/1829

**Relation issue**
https://github.com/swaggo/swag/issues/1829

**Additional context**
The previous logic could select the wrong markdown file if one tag was a substring of another. E.g. "objects" and "my-special-objects".
