### PR TITLE
Fix global overrides for any/interface ref types

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -841,9 +841,9 @@ func parseObjectSchema(parser *Parser, refType string, astFile *ast.File) (*spec
 	case refType == NIL:
 		return nil, nil
 	case refType == INTERFACE:
-		return PrimitiveSchema(OBJECT), nil
+		return &spec.Schema{}, nil
 	case refType == ANY:
-		return PrimitiveSchema(OBJECT), nil
+		return &spec.Schema{}, nil
 	case IsGolangPrimitiveType(refType):
 		refType = TransToValidSchemeType(refType)
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -2448,15 +2448,16 @@ func TestParseObjectSchema(t *testing.T) {
 
 	schema, err := operation.parseObjectSchema("interface{}", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, schema, PrimitiveSchema(OBJECT))
+	assert.Equal(t, schema, &spec.Schema{})
 
 	schema, err = operation.parseObjectSchema("any", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, schema, PrimitiveSchema(OBJECT))
+	assert.Equal(t, schema, &spec.Schema{})
 
 	schema, err = operation.parseObjectSchema("any{data=string}", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, schema, PrimitiveSchema(OBJECT).SetProperty("data", *PrimitiveSchema("string")))
+	assert.Equal(t, schema,
+		(&spec.Schema{}).WithAllOf(spec.Schema{}, *PrimitiveSchema(OBJECT).SetProperty("data", *PrimitiveSchema("string"))))
 
 	schema, err = operation.parseObjectSchema("int", nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #1834

## Description
When overriding with `any` or `interface{}`, the code should prefer the "any" (empty) schema instead, not the object schema since that's different e.g.


#### .swaggo
```
replace json.RawMessage any
```

#### model.go
```go
type Thing struct {
	data json.RawMessage `json:"data"`
}
```

#### Output
```json
"model.Thing": {
	"type": "object",
	"properties": {
	  "data": {}
	}
}
```

## Test Plan

`make all`
