### PR TITLE
[Issue 1812] fix misalignment in expected.json and api.go, fixing test

### DIFF
--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -142,11 +142,11 @@ func GetPet6FunctionScopedResponse() {
 // @Success 200 {object}  api.GetPet6FunctionScopedComplexResponse.response "ok"
 // @Router /GetPet6FunctionScopedComplexResponse [get]
 func GetPet6FunctionScopedComplexResponse() {
-	type child struct {
+	type pet struct {
 		Name string
 	}
 
 	type response struct {
-		Child child
+		Pets []pet
 	}
 }

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -101,18 +101,6 @@
         }
       }
     },
-    "/GetPet6FunctionScopedResponse": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "ok",
-            "schema": {
-              "$ref": "#/definitions/api.GetPet6FunctionScopedResponse.response"
-            }
-          }
-        }
-      }
-    },
     "/GetPet6FunctionScopedComplexResponse": {
       "get": {
         "responses": {
@@ -120,6 +108,18 @@
             "description": "ok",
             "schema": {
               "$ref": "#/definitions/api.GetPet6FunctionScopedComplexResponse.response"
+            }
+          }
+        }
+      }
+    },
+    "/GetPet6FunctionScopedResponse": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "$ref": "#/definitions/api.GetPet6FunctionScopedResponse.response"
             }
           }
         }
@@ -416,7 +416,7 @@
     "api.GetPet6FunctionScopedComplexResponse.pet": {
       "type": "object",
       "properties": {
-        "name": {
+        "Name": {
           "type": "string"
         }
       }


### PR DESCRIPTION
**Describe the PR**
PR https://github.com/swaggo/swag/pull/1813 introduced test changes to both testdata/simple/expected.json and testdata/simple/api/api.go which were misaligned and out of alphabetical order. This is now fixed.

**Relation issue**
See comment and test errors after https://github.com/swaggo/swag/pull/1813
