### PR TITLE
adds support for pointer function scoped fields

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -216,16 +216,19 @@ func (pkgDefs *PackagesDefinitions) parseFunctionScopedTypesFromFile(astFile *as
 								fullName := typeSpecDef.TypeName()
 								if structType, ok := typeSpecDef.TypeSpec.Type.(*ast.StructType); ok {
 									for _, field := range structType.Fields.List {
-										if idt, ok := field.Type.(*ast.Ident); ok && !IsGolangPrimitiveType(idt.Name) {
+										var idt *ast.Ident
+										var ok bool
+										switch field.Type.(type) {
+										case *ast.Ident:
+											idt, ok = field.Type.(*ast.Ident)
+										case *ast.StarExpr:
+											idt, ok = field.Type.(*ast.StarExpr).X.(*ast.Ident)
+										case *ast.ArrayType:
+											idt, ok = field.Type.(*ast.ArrayType).Elt.(*ast.Ident)
+										}
+										if ok && !IsGolangPrimitiveType(idt.Name) {
 											if functype, ok := functionScopedTypes[idt.Name]; ok {
 												idt.Name = functype.TypeName()
-											}
-										}
-										if art, ok := field.Type.(*ast.ArrayType); ok {
-											if idt, ok := art.Elt.(*ast.Ident); ok && !IsGolangPrimitiveType(idt.Name) {
-												if functype, ok := functionScopedTypes[idt.Name]; ok {
-													idt.Name = functype.TypeName()
-												}
 											}
 										}
 									}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3407,8 +3407,18 @@ func Fun()  {
 		Name string
 	}
 
+	type pointerChild struct {
+		Name string
+	}
+
+	type arrayChild struct {
+		Name string
+	}
+
 	type child struct {
-		GrandChild grandChild
+		GrandChild 		grandChild
+		PointerChild 	*pointerChild
+		ArrayChildren   []arrayChild
 	}
 
 	type response struct {
@@ -3429,6 +3439,10 @@ func Fun()  {
 	_, ok = p.swagger.Definitions["main.Fun.child"]
 	assert.True(t, ok)
 	_, ok = p.swagger.Definitions["main.Fun.grandChild"]
+	assert.True(t, ok)
+	_, ok = p.swagger.Definitions["main.Fun.pointerChild"]
+	assert.True(t, ok)
+	_, ok = p.swagger.Definitions["main.Fun.arrayChild"]
 	assert.True(t, ok)
 }
 

--- a/testdata/simple/api/api.go
+++ b/testdata/simple/api/api.go
@@ -146,7 +146,12 @@ func GetPet6FunctionScopedComplexResponse() {
 		Name string
 	}
 
+	type pointerPet struct {
+		Name string
+	}
+
 	type response struct {
-		Pets []pet
+		Pets       []pet
+		PointerPet *pointerPet
 	}
 }

--- a/testdata/simple/expected.json
+++ b/testdata/simple/expected.json
@@ -421,6 +421,14 @@
         }
       }
     },
+    "api.GetPet6FunctionScopedComplexResponse.pointerPet": {
+      "type": "object",
+      "properties": {
+        "Name": {
+          "type": "string"
+        }
+      }
+    },
     "api.GetPet6FunctionScopedComplexResponse.response": {
       "type": "object",
       "properties": {
@@ -429,6 +437,9 @@
           "items": {
             "$ref": "#/definitions/api.GetPet6FunctionScopedComplexResponse.pet"
           }
+        },
+        "PointerPet": {
+          "$ref": "#/definitions/api.GetPet6FunctionScopedComplexResponse.pointerPet"
         }
       }
     },


### PR DESCRIPTION
**Describe the PR**
In https://github.com/swaggo/swag/pull/1813 I introduced additional support to complex fields in function-scoped types.
We have since then found a missing case: When a field is a pointer to a function-scoped type it does not get picked up properly.