### PR TITLE
Feat: Add support for parenthesis in router patterns

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -707,7 +707,7 @@ func parseMimeTypeList(mimeTypeList string, typeList *[]string, format string) e
 	return nil
 }
 
-var routerPattern = regexp.MustCompile(`^(/[\w./\-{}+:$]*)[[:blank:]]+\[(\w+)]`)
+var routerPattern = regexp.MustCompile(`^(/[\w./\-{}\(\)+:$]*)[[:blank:]]+\[(\w+)]`)
 
 // ParseRouterComment parses comment for given `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string, deprecated bool) error {

--- a/operation_test.go
+++ b/operation_test.go
@@ -175,6 +175,18 @@ func TestParseRouterCommentWithDollarSign(t *testing.T) {
 	assert.Equal(t, "POST", operation.RouterProperties[0].HTTPMethod)
 }
 
+func TestParseRouterCommentWithParens(t *testing.T) {
+	t.Parallel()
+
+	comment := `/@Router /customer({id}) [get]`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+	assert.Len(t, operation.RouterProperties, 1)
+	assert.Equal(t, "/Resource({id})", operation.RouterProperties[0].Path)
+	assert.Equal(t, "GET", operation.RouterProperties[0].HTTPMethod)
+}
+
 func TestParseRouterCommentNoDollarSignAtPathStartErr(t *testing.T) {
 	t.Parallel()
 

--- a/operation_test.go
+++ b/operation_test.go
@@ -183,7 +183,7 @@ func TestParseRouterCommentWithParens(t *testing.T) {
 	err := operation.ParseComment(comment, nil)
 	assert.NoError(t, err)
 	assert.Len(t, operation.RouterProperties, 1)
-	assert.Equal(t, "/Resource({id})", operation.RouterProperties[0].Path)
+	assert.Equal(t, "/customer({id})", operation.RouterProperties[0].Path)
 	assert.Equal(t, "GET", operation.RouterProperties[0].HTTPMethod)
 }
 


### PR DESCRIPTION
**Describe the PR**
Allow route patterns with parenthesis i.e. `/odata/Resource({id}) [get]`

**Relation issue**
[e.g. https://github.com/swaggo/swag/pull/118/files](https://github.com/swaggo/swag/issues/1799)

**Additional context**
Odata specification allows for single resource lookups using the described syntax, but it currently generates a `cannot parse router comment` error. This just adds parenthesis to the regex to fix the error.

![Screenshot 2024-08-02 at 12 01 12 PM](https://github.com/user-attachments/assets/66119370-cf5f-443d-9c86-c182e231fbbc)

