### PR TITLE
[issue 1863] fix parse nested structs and aliases

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1316,8 +1316,14 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 		}
 	}
 
+	schemaName := typeName
+
+	if typeSpecDef.SchemaName != "" {
+		schemaName = typeSpecDef.SchemaName
+	}
+
 	sch := Schema{
-		Name:    typeName,
+		Name:    schemaName,
 		PkgPath: typeSpecDef.PkgPath,
 		Schema:  definition,
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -4367,3 +4367,22 @@ func Test(){
 	assert.True(t, ok)
 	assert.NotNil(t, val2.Get)
 }
+
+func TestParser_EmbeddedStructAsOtherAliasGoListNested(t *testing.T) {
+	t.Parallel()
+
+	p := New(SetParseDependency(1), ParseUsingGoList(true))
+
+	p.parseGoList = true
+
+	searchDir := "testdata/alias_nested"
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	assert.NoError(t, err)
+
+	err = p.ParseAPI(searchDir, "cmd/main/main.go", 0)
+	assert.NoError(t, err)
+
+	b, err := json.MarshalIndent(p.swagger, "", "    ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(expected), string(b))
+}

--- a/testdata/alias_nested/cmd/main/main.go
+++ b/testdata/alias_nested/cmd/main/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/swaggo/swag/testdata/alias_nested/pkg/good"
+
+// @Success 200 {object} good.Gen
+// @Router /api [get].
+func main() {
+	var _ good.Gen
+}

--- a/testdata/alias_nested/expected.json
+++ b/testdata/alias_nested/expected.json
@@ -1,0 +1,38 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "contact": {}
+    },
+    "paths": {
+        "/api": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/Gen"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Gen": {
+            "type": "object",
+            "properties": {
+                "emb": {
+                    "$ref": "#/definitions/github_com_swaggo_swag_testdata_alias_nested_pkg_good.Emb"
+                }
+            }
+        },
+        "github_com_swaggo_swag_testdata_alias_nested_pkg_good.Emb": {
+            "type": "object",
+            "properties": {
+                "good": {
+                    "type": "boolean"
+                }
+            }
+        }
+    }
+}

--- a/testdata/alias_nested/pkg/bad/data.go
+++ b/testdata/alias_nested/pkg/bad/data.go
@@ -1,0 +1,5 @@
+package bad
+
+type Emb struct {
+	Bad bool `json:"bad"`
+} // @name Emb

--- a/testdata/alias_nested/pkg/good/data.go
+++ b/testdata/alias_nested/pkg/good/data.go
@@ -1,0 +1,9 @@
+package good
+
+type Gen struct {
+	Emb Emb `json:"emb"`
+} // @name Gen
+
+type Emb struct {
+	Good bool `json:"good"`
+}


### PR DESCRIPTION
**Describe the PR**
Using aliases only for describing definitions

**Relation issue**
#1863 

**Additional context**
A field has been added to TypeSpecDef, which defines the name of the result definition (SchemaName)