### PR TITLE
Flags to parse internal and dependency package

### DIFF
--- a/README.md
+++ b/README.md
@@ -947,6 +947,17 @@ swag init -g http/api.go -td "[[,]]"
 ```
 The new delimiter is a string with the format "`<left delimiter>`,`<right delimiter>`".
 
+### Parse Internal and Dependency Packages
+
+If the struct is defined in a dependency package, use `--parseDependency`.
+
+If the struct is defined in your main project, use `--parseInternal`.
+
+if you want to include both internal and from dependencies use both flags 
+```
+swag init --parseDependency --parseInternal
+```
+
 ## About the Project
 This project was inspired by [yvasiyarov/swagger](https://github.com/yvasiyarov/swagger) but we simplified the usage and added support a variety of [web frameworks](#supported-web-frameworks). Gopher image source is [tenntenn/gopher-stickers](https://github.com/tenntenn/gopher-stickers). It has licenses [creative commons licensing](http://creativecommons.org/licenses/by/3.0/deed.en).
 ## Contributors


### PR DESCRIPTION
**Remove cannot find type definition error**
```go
package model

type PaginatedListResp[T any] struct {
	Data         []T  `json:"data"`
	TotalCount   int  `json:"total_count"`
	HasMore      bool `json:"has_more"`
	Page         int  `json:"page"`
	ItemsPerPage int  `json:"items_per_page"`
}

type User struct {
	ID          uuid.UUID `json:"id"`
	Name        string    `json:"name"`
	PhoneNum    string    `json:"phone_number"`
	Email       string    `json:"email"`
	Username    string    `json:"username"`
}
```

```go
package api
.
.
.
//	@Success	200	{object}	models.PaginatedListResp[models.User]
```


**Additional context**
If the model is part of an external dependency or internal package then flags mentioned in the PR can be used but were not mentioned in the generics section.

In some cases simple `import _ github.com/xxx/models` also works but if it does not then adding either `--parseDependency` or `--parseInternal` helps in solving the issue based on requirement.
