### PR TITLE
fix: getSecurityDefinitionKey white space parsing

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -484,8 +484,8 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 
 func getSecurityDefinitionKey(lines []string) string {
 	for _, line := range lines {
-		if strings.HasPrefix(strings.ToLower(line), "@securitydefinitions") {
-			splittedLine := strings.Split(line, " ")
+		if strings.HasPrefix(strings.TrimSpace(strings.ToLower(line)), "@securitydefinitions") {
+			splittedLine := strings.Fields(line)
 			return splittedLine[len(splittedLine)-1]
 		}
 	}


### PR DESCRIPTION
**Describe the PR**
Fixes parsing of security definitions on V2

**Relation issue**
https://github.com/swaggo/swag/issues/1941

