### PR TITLE
Add support for specifying version of documents

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -43,6 +43,7 @@ const (
 	packagePrefixFlag        = "packagePrefix"
 	stateFlag                = "state"
 	parseFuncBodyFlag        = "parseFuncBody"
+	versionFlag              = "version"
 )
 
 var initFlags = []cli.Flag{
@@ -186,6 +187,11 @@ var initFlags = []cli.Flag{
 		// Value: false,
 		Usage: "Parse API info within body of functions in go files, disabled by default (default: false)",
 	},
+	&cli.StringFlag{
+		Name:  versionFlag,
+		Value: "",
+		Usage: "Specify the version of the version of the API in the generated files",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -268,6 +274,7 @@ func initAction(ctx *cli.Context) error {
 		PackagePrefix:       ctx.String(packagePrefixFlag),
 		State:               ctx.String(stateFlag),
 		ParseFuncBody:       ctx.Bool(parseFuncBodyFlag),
+		Version:             ctx.String(versionFlag),
 	})
 }
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -149,6 +149,9 @@ type Config struct {
 
 	// ParseFuncBody whether swag should parse api info inside of funcs
 	ParseFuncBody bool
+
+	// Version represents the version of the API in the generated swagger documents
+	Version string
 }
 
 // Build builds swagger json file  for given searchDir and mainAPIFile. Returns json.
@@ -223,6 +226,9 @@ func (g *Gen) Build(config *Config) error {
 	}
 
 	swagger := p.GetSwagger()
+	if config.Version != "" {
+		swagger.Info.Version = config.Version
+	}
 
 	if err := os.MkdirAll(config.OutputDir, os.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
**Describe the PR**
Add `--version` flag for `init` subcommand, to specify the version of the API in the generated files.

This can reset the version of API docs with external command lines, such as the following:

```bash
$ swag init --version $(git describe --tags `git rev-list --tags --max-count=1`)
```