### PR TITLE
fix: @name for recursion

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1316,7 +1316,7 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 		parser.debug.Printf("Skipping '%s', recursion detected.", typeName)
 
 		return &Schema{
-				Name:    typeName,
+				Name:    typeSpecDef.SchemaName,
 				PkgPath: typeSpecDef.PkgPath,
 				Schema:  PrimitiveSchema(OBJECT),
 			},

--- a/types.go
+++ b/types.go
@@ -48,20 +48,6 @@ func (t *TypeSpecDef) Name() string {
 func (t *TypeSpecDef) TypeName() string {
 	if ignoreNameOverride(t.TypeSpec.Name.Name) {
 		return t.TypeSpec.Name.Name[1:]
-	} else if t.TypeSpec.Comment != nil {
-		// get alias from comment '// @name '
-		const regexCaseInsensitive = "(?i)"
-		reTypeName, err := regexp.Compile(regexCaseInsensitive + `^@name\s+(\S+)`)
-		if err != nil {
-			panic(err)
-		}
-		for _, comment := range t.TypeSpec.Comment.List {
-			trimmedComment := strings.TrimSpace(strings.TrimLeft(comment.Text, "/"))
-			texts := reTypeName.FindStringSubmatch(trimmedComment)
-			if len(texts) > 1 {
-				return texts[1]
-			}
-		}
 	}
 
 	var names []string

--- a/types.go
+++ b/types.go
@@ -48,6 +48,20 @@ func (t *TypeSpecDef) Name() string {
 func (t *TypeSpecDef) TypeName() string {
 	if ignoreNameOverride(t.TypeSpec.Name.Name) {
 		return t.TypeSpec.Name.Name[1:]
+	} else if t.TypeSpec.Comment != nil {
+		// get alias from comment '// @name '
+		const regexCaseInsensitive = "(?i)"
+		reTypeName, err := regexp.Compile(regexCaseInsensitive + `^@name\s+(\S+)`)
+		if err != nil {
+			panic(err)
+		}
+		for _, comment := range t.TypeSpec.Comment.List {
+			trimmedComment := strings.TrimSpace(strings.TrimLeft(comment.Text, "/"))
+			texts := reTypeName.FindStringSubmatch(trimmedComment)
+			if len(texts) > 1 {
+				return texts[1]
+			}
+		}
 	}
 
 	var names []string


### PR DESCRIPTION
**Describe the PR**
Since this PR https://github.com/swaggo/swag/pull/1866 was merged, the tag `@name` doesn't work anymore for recursion, as you can see on this issue: https://github.com/swaggo/swag/issues/1909.

This PR is to use the new field schemaName in case of recursion

**Relation issue**
https://github.com/swaggo/swag/issues/1909

**Additional context**
Add any other context about the problem here.
