### PR TITLE
Fix typo error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ type DeepObject struct { //in `proto` package
 }
 @success 200 {object} jsonresult.JSONResult{data1=proto.Order{data=proto.DeepObject},data2=[]proto.Order{data=[]proto.DeepObject}} "desc"
 ```
-### Add response request
+### Add request headers
 
 ```go
 // @Param        X-MyHeader	  header    string    true   	"MyHeader must be set for valid response"


### PR DESCRIPTION
**Describe the PR**
- The link in the README file does not direct users to the correct section when clicked. Although the target section exists, it is incorrectly titled as "Add response request", which causes the link to fail. This issue disrupts navigation within the documentation.

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

- This Pull Request resolves the issue by:

1. Updating the section title in the README from "Add response request" to "Add Request Headers" to align with the 
hyperlink.
2. Alternatively, modifying the hyperlink to match the existing section title if renaming the section is not suitable.

**Additional context**
- The fix is a small but meaningful improvement to the overall documentation quality.
