### PR TITLE
Support array of array examples

### DIFF
--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -43,6 +43,36 @@ func TestDefaultFieldParser(t *testing.T) {
 			}},
 		).ComplementSchema(&schema)
 		assert.Error(t, err)
+
+		schema = spec.Schema{}
+		schema.Type = []string{"array"}
+		schema.Items = &spec.SchemaOrArray{
+			Schema: &spec.Schema{},
+		}
+		schema.Items.Schema.Type = []string{"string"}
+		err = newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" example:"one,two"`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{"one", "two"}, schema.Example)
+
+		schema = spec.Schema{}
+		schema.Type = []string{"array"}
+		schema.Items = &spec.SchemaOrArray{
+			Schema: &spec.Schema{},
+		}
+		schema.Items.Schema.Type = []string{"string"}
+		err = newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" example:"{{one,two},{three,four}}"`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{[]interface{}{"one", "two"}, []interface{}{"three", "four"}}, schema.Example)
 	})
 
 	t.Run("Format tag", func(t *testing.T) {
@@ -420,6 +450,56 @@ func TestDefaultFieldParser(t *testing.T) {
 			&ast.Field{Names: []*ast.Ident{{Name: "BasicStruct"}}},
 		).ComplementSchema(nil)
 		assert.Error(t, err)
+	})
+}
+
+func TestParseNestedArray(t *testing.T) {
+	t.Run("[]string", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("one,two", "string")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{"one", "two"}, res)
+	})
+
+	t.Run("[]float64", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("35.2,12.3", "number")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{35.2, 12.3}, res)
+	})
+
+	t.Run("[][]string", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("{{one,two},{three,four}}", "string")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{[]any{"one", "two"}, []any{"three", "four"}}, res)
+	})
+
+	t.Run("[][]int", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("{{5,6},{4,5}}", "integer")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{[]any{5, 6}, []any{4, 5}}, res)
+	})
+
+	t.Run("[][][]string", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("{{one,two},{{three},{four},{five,six}}}", "string")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{[]any{"one", "two"}, []any{[]any{"three"}, []any{"four"}, []any{"five", "six"}}}, res)
+	})
+
+	t.Run("[][][]boolean", func(t *testing.T) {
+		t.Parallel()
+
+		res, err := parseNestedArrays("{{{true},{true},{true,false}},{true,false}}", "boolean")
+		assert.NoError(t, err)
+		assert.Equal(t, []any{[]any{[]any{true}, []any{true}, []any{true, false}}, []any{true, false}}, res)
 	})
 }
 


### PR DESCRIPTION
**Describe the PR**
Add a nested array parser for an array of array examples. To achieve this, the example string is parsed into a tree and then the tree structure is converted to an array of arrays. "{" and "}" are chosen to specify the nested array beginning and end but this can easily be changed. An example of a nested array example is:```{{one,two},{three,four}}```. This implementation is backward compatible with arrays. The example could be "{one,two}" as well as "one,two"

**Relation issue**
https://github.com/swaggo/swag/issues/1041

**Additional context**
For an extensive fix, [depth in ComplementSchema](https://github.com/swaggo/swag/blob/94ff0fcc35857862b6c1f2bac2063e84522b6b50/field_parser.go#L244) should be a variable instead of constant 2. 
