### PR TITLE
Allow parenthesis in examples

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -426,23 +426,23 @@ const (
 
 var regexAttributes = map[string]*regexp.Regexp{
 	// for Enums(A, B)
-	enumsTag: regexp.MustCompile(`(?i)\s+enums\(.*\)`),
+	enumsTag: regexp.MustCompile(`(?Ui)\s+enums\(.*\)`),
 	// for maximum(0)
-	maximumTag: regexp.MustCompile(`(?i)\s+maxinum|maximum\(.*\)`),
+	maximumTag: regexp.MustCompile(`(?Ui)\s+maxinum|maximum\(.*\)`),
 	// for minimum(0)
-	minimumTag: regexp.MustCompile(`(?i)\s+mininum|minimum\(.*\)`),
+	minimumTag: regexp.MustCompile(`(?Ui)\s+mininum|minimum\(.*\)`),
 	// for default(0)
-	defaultTag: regexp.MustCompile(`(?i)\s+default\(.*\)`),
+	defaultTag: regexp.MustCompile(`(?Ui)\s+default\(.*\)`),
 	// for minlength(0)
-	minLengthTag: regexp.MustCompile(`(?i)\s+minlength\(.*\)`),
+	minLengthTag: regexp.MustCompile(`(?Ui)\s+minlength\(.*\)`),
 	// for maxlength(0)
-	maxLengthTag: regexp.MustCompile(`(?i)\s+maxlength\(.*\)`),
+	maxLengthTag: regexp.MustCompile(`(?Ui)\s+maxlength\(.*\)`),
 	// for format(email)
-	formatTag: regexp.MustCompile(`(?i)\s+format\(.*\)`),
+	formatTag: regexp.MustCompile(`(?Ui)\s+format\(.*\)`),
 	// for extensions(x-example=test)
-	extensionsTag: regexp.MustCompile(`(?i)\s+extensions\(.*\)`),
+	extensionsTag: regexp.MustCompile(`(?Ui)\s+extensions\(.*\)`),
 	// for collectionFormat(csv)
-	collectionFormatTag: regexp.MustCompile(`(?i)\s+collectionFormat\(.*\)`),
+	collectionFormatTag: regexp.MustCompile(`(?Ui)\s+collectionFormat\(.*\)`),
 	// example(0)
 	exampleTag: regexp.MustCompile(`(?i)\s+example\(.*\)`),
 	// schemaExample(0)

--- a/operation.go
+++ b/operation.go
@@ -490,7 +490,7 @@ func (operation *Operation) parseParamAttribute(comment, objectType, schemaType,
 func findAttr(re *regexp.Regexp, commentLine string) (string, error) {
 	attr := re.FindString(commentLine)
 
-	l, r := strings.Index(attr, "("), strings.Index(attr, ")")
+	l, r := strings.Index(attr, "("), strings.LastIndex(attr, ")")
 	if l == -1 || r == -1 {
 		return "", fmt.Errorf("can not find regex=%s, comment=%s", re.String(), commentLine)
 	}

--- a/operation_test.go
+++ b/operation_test.go
@@ -1919,7 +1919,7 @@ func TestParseParamCommentByExampleInt(t *testing.T) {
 func TestParseParamCommentByExampleString(t *testing.T) {
 	t.Parallel()
 
-	comment := `@Param some_id query string true "Some ID" Example(True feelings)`
+	comment := `@Param some_id query string true "Some ID" Example(True feelings (maybe))`
 	operation := NewOperation(nil)
 	err := operation.ParseComment(comment, nil)
 
@@ -1928,7 +1928,7 @@ func TestParseParamCommentByExampleString(t *testing.T) {
 	expected := `[
     {
         "type": "string",
-        "example": "True feelings",
+        "example": "True feelings (maybe)",
         "description": "Some ID",
         "name": "some_id",
         "in": "query",
@@ -1958,7 +1958,7 @@ func TestParseParamCommentByExampleUnsupportedType(t *testing.T) {
 func TestParseParamCommentBySchemaExampleString(t *testing.T) {
 	t.Parallel()
 
-	comment := `@Param some_id body string true "Some ID" SchemaExample(True feelings)`
+	comment := `@Param some_id body string true "Some ID" SchemaExample(True feelings (maybe))`
 	operation := NewOperation(nil)
 	err := operation.ParseComment(comment, nil)
 
@@ -1972,7 +1972,7 @@ func TestParseParamCommentBySchemaExampleString(t *testing.T) {
         "required": true,
         "schema": {
             "type": "string",
-            "example": "True feelings"
+            "example": "True feelings (maybe)"
         }
     }
 ]`


### PR DESCRIPTION
**Describe the PR**
Allow parentheses in `Example` and `SchemaExample`, e.g. `Example(True feelings (maybe))`

**Additional context**
The implementation assumes that the `[Schema]Example` tag will always be the last tag in a comment string. 