### PR TITLE
fix: @name does not working for v3.1

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -164,12 +164,6 @@ var initFlags = []cli.Flag{
 		Name:    templateDelimsFlag,
 		Aliases: []string{"td"},
 		Value:   "",
-		Usage:   "Provide custom delimeters for Go template generation. The format is leftDelim,rightDelim. For example: \"[[,]]\"",
-	},
-	&cli.StringFlag{
-		Name:    templateDelimsFlag,
-		Aliases: []string{"td"},
-		Value:   "",
 		Usage:   "Provide custom delimiters for Go template generation. The format is leftDelim,rightDelim. For example: \"[[,]]\"",
 	},
 	&cli.StringFlag{

--- a/parserv3.go
+++ b/parserv3.go
@@ -745,9 +745,13 @@ func (p *Parser) ParseDefinitionV3(typeSpecDef *TypeSpecDef) (*SchemaV3, error) 
 			definition.Spec.Extensions[enumCommentsExtension] = enumComments
 		}
 	}
+	schemaName := typeName
+	if typeSpecDef.SchemaName != "" {
+		schemaName = typeSpecDef.SchemaName
+	}
 
 	sch := SchemaV3{
-		Name:    typeName,
+		Name:    schemaName,
 		PkgPath: typeSpecDef.PkgPath,
 		Schema:  definition.Spec,
 	}


### PR DESCRIPTION
**Describe the PR**
The @name tag does not work for init with the --v3.1 flag.
This PR introduces the use of the new schemaName field in the case of ParseDefinitionV3.

Additionally, it fixes a Segmentation Fault that occurred during startup due to a duplicate flag.

**Relation issue**
https://github.com/swaggo/swag/issues/1909