### PR TITLE
[v2] fix: duplicate print version

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -279,7 +279,6 @@ func initAction(ctx *cli.Context) error {
 }
 
 func main() {
-	fmt.Println("Swag version: ", swag.Version)
 	app := cli.NewApp()
 	app.Version = swag.Version
 	app.Usage = "Automatically generate RESTful API documentation with Swagger 2.0 for Go."


### PR DESCRIPTION
**Describe the PR**
Fix duplicate version printing when running swag -v.

![2025-02-01_22-23](https://github.com/user-attachments/assets/bd666474-5a3e-4e97-8f86-db99a3447bcf)


**Relation issue**
N/A

**Additional context**
Previously, running swag -v printed the version multiple times. This PR ensures that the version is displayed only once.
