### PR TITLE
fix: parse security definition key for Bearer auth

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -335,6 +335,7 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 
 	var search []string
 
+	key := getSecurityDefinitionKey(lines)
 	attribute := strings.ToLower(FieldsByAnySpace(lines[*index], 2)[0])
 	switch attribute {
 	case secBasicAttr:
@@ -357,7 +358,7 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 			Scheme:       "bearer",
 			BearerFormat: "JWT",
 		}
-		return "bearerauth", &scheme, nil
+		return key, &scheme, nil
 	}
 
 	// For the first line we get the attributes in the context parameter, so we skip to the next one
@@ -420,7 +421,6 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 	}
 
 	scheme := &spec.SecurityScheme{}
-	key := getSecurityDefinitionKey(lines)
 
 	switch attribute {
 	case secAPIKeyAttr:

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -166,9 +166,9 @@ func TestParserParseGeneralApiInfoV3(t *testing.T) {
 	assert.Equal(t, "header", security["OAuth2AccessCode"].Spec.Spec.In)
 	assert.Equal(t, "https://example.com/oauth/token", security["OAuth2AccessCode"].Spec.Spec.Flows.Spec.AuthorizationCode.Spec.TokenURL)
 
-	assert.Equal(t, "bearer", security["bearerauth"].Spec.Spec.Scheme)
-	assert.Equal(t, "http", security["bearerauth"].Spec.Spec.Type)
-	assert.Equal(t, "JWT", security["bearerauth"].Spec.Spec.BearerFormat)
+	assert.Equal(t, "bearer", security["BearerAuth"].Spec.Spec.Scheme)
+	assert.Equal(t, "http", security["BearerAuth"].Spec.Spec.Type)
+	assert.Equal(t, "JWT", security["BearerAuth"].Spec.Spec.BearerFormat)
 }
 
 func TestParser_ParseGeneralApiInfoExtensionsV3(t *testing.T) {


### PR DESCRIPTION
This PR fixes an issue that caused the tool to always generate a security definition with the `bearerauth` key, regardless of the user-specified value.