### PR TITLE
[feature]: exclude api from UI with specified annotation

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -43,6 +43,7 @@ const (
 	packagePrefixFlag        = "packagePrefix"
 	stateFlag                = "state"
 	parseFuncBodyFlag        = "parseFuncBody"
+	excludeFromUIFlag        = "excludeFromUI"
 )
 
 var initFlags = []cli.Flag{
@@ -186,6 +187,11 @@ var initFlags = []cli.Flag{
 		// Value: false,
 		Usage: "Parse API info within body of functions in go files, disabled by default (default: false)",
 	},
+	&cli.StringFlag{
+		Name:  excludeFromUIFlag,
+		Value: "",
+		Usage: "Exclude the apis from UI with specified annotation. For Example: excludeFromUI=hidden,internal",
+	},
 }
 
 func initAction(ctx *cli.Context) error {
@@ -268,6 +274,7 @@ func initAction(ctx *cli.Context) error {
 		PackagePrefix:       ctx.String(packagePrefixFlag),
 		State:               ctx.String(stateFlag),
 		ParseFuncBody:       ctx.Bool(parseFuncBodyFlag),
+		ExcludeFromUI:       ctx.String(excludeFromUIFlag),
 	})
 }
 


### PR DESCRIPTION
**Describe the PR**
Add new flag ExcludeFromUI, This will remove API and unrelated definitions from only doc.go file so it won't be visible on Swagger UI.

**Additional context**
Hi Team, For long time I wanted this feature which just remove API from UI, so users can't access it from UI but it will be there in swagger.json/yaml so I can share this with other developers.

Usage:

```
// ShowAccount godoc
//
//	@Summary		Show an account
//	@Description	get string by ID
//	@Tags			accounts
//	@Accept			json
//	@Produce		json
//	@Param			id	path		int	true	"Account ID"
//	@Success		200	{object}	model.Account
//	@Failure		500	{object}	httputil.HTTPError
//	@Router			/accounts/{id} [get]
//      @x-hidden               true
```


```shell
go run cmd/swag/main.go init -d example/celler --excludeFromUI hidden
```
It will remove the API from UI which have this hidden annotation. 
