### PR TITLE
Non-empty stderr for `go list` is not an error in itself

### DIFF
--- a/golist.go
+++ b/golist.go
@@ -22,7 +22,7 @@ func listPackages(ctx context.Context, dir string, env []string, args ...string)
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
 	defer func() {
-		if stderrBuf.Len() > 0 {
+		if (finalErr != nil) && (stderrBuf.Len() > 0) {
 			finalErr = fmt.Errorf("%v\n%s", finalErr, stderrBuf.Bytes())
 		}
 	}()


### PR DESCRIPTION
**Describe the PR**
The current implementation of getting a list of packages (`listPackages`) assumes that a non-empty stderr in the output of `go list` is an error, regardless of the result of the call, which is not true. Here is an example of a non-empty stderr:

```
go: downloading github.com/go-sql-driver/mysql v1.8.1
go: downloading github.com/go-errors/errors v1.0.1
go: downloading github.com/go-playground/validator/v10 v10.22.1
...
go: downloading go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
go: downloading github.com/felixge/httpsnoop v1.0.4
```

There is no information on errors. This is [a legitimate output of additional information](https://github.com/golang/go/blob/e33f7c4/src/cmd/go/internal/modfetch/fetch.go#L231).

As a result, we get a non-zero status code without any reason.

Let's rely on the error return, and only add the contents of stderr along with it (preferably removing all lines with `go: downloading`).
