### PR TITLE
fix: enum generation in v3.1

### DIFF
--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -180,6 +180,35 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("Enums tag twice", func(t *testing.T) {
+		t.Parallel()
+
+		schema := spec.NewSchemaSpec()
+		schema.Spec.Type = []string{"string"}
+		parser := &Parser{}
+		fieldParser := newTagBaseFieldParserV3(
+			parser,
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" enums:"a,b,c"`,
+			}},
+		)
+		err := fieldParser.ComplementSchema(schema)
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{"a", "b", "c"}, schema.Spec.Enum)
+
+		fieldParser2 := newTagBaseFieldParserV3(
+			parser,
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" enums:"d,e,f"`,
+			}},
+		)
+		fieldParser2.ComplementSchema(schema)
+		assert.Equal(t, []interface{}{"a", "b", "c", "d", "e", "f"}, schema.Spec.Enum)
+
+	})
+
 	t.Run("EnumVarNames tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -376,7 +376,7 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 	elemSchema.MultipleOf = field.multipleOf
 	elemSchema.MaxLength = field.maxLength
 	elemSchema.MinLength = field.minLength
-	elemSchema.Enum = field.enums
+	elemSchema.Enum = append(elemSchema.Enum, field.enums...)
 	elemSchema.Pattern = field.pattern
 	elemSchema.OneOf = oneOfSchemas
 


### PR DESCRIPTION
**Describe the PR**
some enums was not being generate when setting flag `--v3.1=true` 
e.g it was like this:

```
      "SomeEnum": {,
        "type": "string",
        "x-enum-varnames": [
          "SomeEnumA",
          "SomeEnumB"
        ]
      }
```

with this PR is like this:

```
      "SomeEnum": {
        "enum": [
          "confirmation_code",
          "transaction_confirmation"
        ],
        "type": "string",
        "x-enum-comments": {
          "SomeEnumA": "a",
          "SomeEnumB": "b"
        },
        "x-enum-varnames": [
          "SomeEnumA",
          "SomeEnumB"
        ]
      }
```


**Relation issue**
https://github.com/swaggo/swag/issues/1955


