### PR TITLE
V2 accept text event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ Besides that, `swag` also accepts aliases for some MIME Types as follows:
 | png                   | image/png                         |
 | jpeg                  | image/jpeg                        |
 | gif                   | image/gif                         |
+| event-stream          | text/event-stream                 |
 
 
 

--- a/README_pt.md
+++ b/README_pt.md
@@ -445,6 +445,7 @@ Além disso, `swag` também aceita pseudónimos para alguns tipos de MIME, como 
 | png                   | image/png                         |
 | jpeg                  | image/jpeg                        |
 | gif                   | image/gif                         |
+| event-stream          | text/event-stream                 |
 
 
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -9,7 +9,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/swaggo/swag)](https://goreportcard.com/report/github.com/swaggo/swag)
 [![codebeat badge](https://codebeat.co/badges/71e2f5e5-9e6b-405d-baf9-7cc8b5037330)](https://codebeat.co/projects/github-com-swaggo-swag-master)
 [![Go Doc](https://godoc.org/github.com/swaggo/swagg?status.svg)](https://godoc.org/github.com/swaggo/swag)
-[![Backers on Open Collective](https://opencollective.com/swag/backers/badge.svg)](#backers) 
+[![Backers on Open Collective](https://opencollective.com/swag/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/swag/sponsors/badge.svg)](#sponsors) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fswaggo%2Fswag.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fswaggo%2Fswag?ref=badge_shield)
 [![Release](https://img.shields.io/github/release/swaggo/swag.svg?style=flat-square)](https://github.com/swaggo/swag/releases)
 
@@ -299,7 +299,7 @@ swag init
 
 ## 格式化说明
 
-可以针对Swag的注释自动格式化，就像`go fmt`。   
+可以针对Swag的注释自动格式化，就像`go fmt`。
 此处查看格式化结果 [here](https://github.com/swaggo/swag/tree/master/example/celler).
 
 示例：
@@ -417,6 +417,7 @@ Example [celler/controller](https://github.com/swaggo/swag/tree/master/example/c
 | png                   | image/png                         |
 | jpeg                  | image/jpeg                        |
 | gif                   | image/gif                         |
+| event-stream          | text/event-stream                 |
 
 ## 参数类型
 

--- a/operation.go
+++ b/operation.go
@@ -49,6 +49,7 @@ var mimeTypeAliases = map[string]string{
 	"png":                   "image/png",
 	"jpeg":                  "image/jpeg",
 	"gif":                   "image/gif",
+	"event-stream":          "text/event-stream",
 }
 
 var mimeTypePattern = regexp.MustCompile("^[^/]+/[^/]+$")

--- a/parser_test.go
+++ b/parser_test.go
@@ -488,9 +488,10 @@ func TestParser_ParseAcceptComment(t *testing.T) {
 		"image/gif",
 		"application/xhtml+xml",
 		"application/health+json",
+		"text/event-stream",
 	}
 
-	comment := `@Accept json,xml,plain,html,mpfd,x-www-form-urlencoded,json-api,json-stream,octet-stream,png,jpeg,gif,application/xhtml+xml,application/health+json`
+	comment := `@Accept json,xml,plain,html,mpfd,x-www-form-urlencoded,json-api,json-stream,octet-stream,png,jpeg,gif,application/xhtml+xml,application/health+json,event-stream`
 
 	parser := New()
 	assert.NoError(t, parseGeneralAPIInfo(parser, []string{comment}))
@@ -521,9 +522,10 @@ func TestParser_ParseProduceComment(t *testing.T) {
 		"image/gif",
 		"application/xhtml+xml",
 		"application/health+json",
+		"text/event-stream",
 	}
 
-	comment := `@Produce json,xml,plain,html,mpfd,x-www-form-urlencoded,json-api,json-stream,octet-stream,png,jpeg,gif,application/xhtml+xml,application/health+json`
+	comment := `@Produce json,xml,plain,html,mpfd,x-www-form-urlencoded,json-api,json-stream,octet-stream,png,jpeg,gif,application/xhtml+xml,application/health+json,event-stream`
 
 	parser := New()
 	assert.NoError(t, parseGeneralAPIInfo(parser, []string{comment}))
@@ -3395,14 +3397,14 @@ func TestParseFunctionScopedComplexStructDefinition(t *testing.T) {
 	src := `
 package main
 
-// @Param request body main.Fun.request true "query params" 
+// @Param request body main.Fun.request true "query params"
 // @Success 200 {object} main.Fun.response
 // @Router /test [post]
 func Fun()  {
 	type request struct {
 		Name string
 	}
-	
+
 	type grandChild struct {
 		Name string
 	}
@@ -3539,16 +3541,16 @@ package main
 
 type PublicChild struct {
 	Name string
-}	
+}
 
-// @Param request body main.Fun.request true "query params" 
+// @Param request body main.Fun.request true "query params"
 // @Success 200 {object} main.Fun.response
 // @Router /test [post]
 func Fun()  {
 	type request struct {
 		Name string
 	}
-	
+
 	type grandChild struct {
 		Name string
 	}


### PR DESCRIPTION
**Describe the PR**
In this PR (https://github.com/swaggo/swag/pull/1992), I extended the accepted MIME Types to include the `text/event-stream` type used by SSE. That PR was merged into the V1 version of Swaggo.

This PR replicates that change into the V2 iteration of Swaggo.

**Relation issue**
https://github.com/swaggo/swag/issues/1931
