### PR TITLE
Add missing null check

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -1061,11 +1061,13 @@ func (p *Parser) GetSchemaTypePathV3(schema *spec.RefOrSpec[spec.Schema], depth 
 	if schema.Spec.Type != nil && len(*schema.Spec.Type) > 0 {
 		switch (*schema.Spec.Type)[0] {
 		case ARRAY:
-			depth--
+			if schema.Spec.Items != nil && schema.Spec.Items.Schema != nil {
+				depth--
 
-			s := []string{(*schema.Spec.Type)[0]}
+				s := []string{(*schema.Spec.Type)[0]}
 
-			return append(s, p.GetSchemaTypePathV3(schema.Spec.Items.Schema, depth)...)
+				return append(s, p.GetSchemaTypePathV3(schema.Spec.Items.Schema, depth)...)
+			}
 		case OBJECT:
 			if schema.Spec.AdditionalProperties != nil && schema.Spec.AdditionalProperties.Schema != nil {
 				// for map


### PR DESCRIPTION
Avoid a crash when generating OpenAPI 3 documentation.

**Describe the PR**
`GetSchemaTypePathV3` has a missing nil check, which results in a crash. This looks like an oversight, as different locations have this check in place.
