### PR TITLE
fix: router with tilde #2004

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -713,7 +713,7 @@ func parseMimeTypeList(mimeTypeList string, typeList *[]string, format string) e
 	return nil
 }
 
-var routerPattern = regexp.MustCompile(`^(/[\w./\-{}\(\)+:$]*)[[:blank:]]+\[(\w+)]`)
+var routerPattern = regexp.MustCompile(`^(/[\w./\-{}\(\)+:$~]*)[[:blank:]]+\[(\w+)]`)
 
 // ParseRouterComment parses comment for given `router` comment string.
 func (operation *Operation) ParseRouterComment(commentLine string, deprecated bool) error {

--- a/operation_test.go
+++ b/operation_test.go
@@ -217,6 +217,15 @@ func TestParseRouterCommentNoColonSignAtPathStartErr(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParseRouterCommentWithTilde(t *testing.T) {
+	t.Parallel()
+
+	comment := `@Router /customer/{id}/~last-name [patch]`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+	assert.NoError(t, err)
+}
+
 func TestParseRouterCommentMethodSeparationErr(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Describe the PR**
Supporting URL paths with `~` character.

**Relation issue**
https://github.com/swaggo/swag/issues/2004
