### PR TITLE
fix: set markdown description on info with correct attribute

### DIFF
--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -184,7 +184,7 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		t.Parallel()
 
 		schema := spec.NewSchemaSpec()
-		schema.Spec.Type = []string{"string"}
+		schema.Spec.Type = &spec.SingleOrArray[string]{"string"}
 		parser := &Parser{}
 		fieldParser := newTagBaseFieldParserV3(
 			parser,

--- a/parserv3.go
+++ b/parserv3.go
@@ -72,7 +72,7 @@ func (p *Parser) parseGeneralAPIInfoV3(comments []string) error {
 				return err
 			}
 
-			setspecInfo(p.openAPI, attr, string(commentInfo))
+			setspecInfo(p.openAPI, descriptionAttr, string(commentInfo))
 		case "@host":
 			if len(p.openAPI.Servers) == 0 {
 				server := spec.NewServer()


### PR DESCRIPTION
# Description
Noticed the markdown description wasn't being rendered for the `info` block when the v3 flag was on. The call to `setSpecInfo` didn't have a case for `description.markdown`, which is the value of `attr` at that time. Swapped it to the `description` const.

Also, there's a compiler error on HEAD of the v2 branch, fixed that real fast to run tests.