### PR TITLE
feat: add multiple securitydefinitions.bearerauth for bearer token setting in V2

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -336,13 +336,14 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 	var search []string
 
 	attribute := strings.ToLower(FieldsByAnySpace(lines[*index], 2)[0])
+	key := getSecurityDefinitionKey(lines)
 	switch attribute {
 	case secBasicAttr:
 		scheme := spec.SecurityScheme{
 			Type:   "http",
 			Scheme: "basic",
 		}
-		return "basic", &scheme, nil
+		return key, &scheme, nil
 	case secAPIKeyAttr:
 		search = []string{in, name}
 	case secApplicationAttr, secPasswordAttr:
@@ -352,12 +353,38 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 	case secAccessCodeAttr:
 		search = []string{tokenURL, authorizationURL, in}
 	case secBearerAuthAttr:
+		// Support Bearer scheme with parameters
 		scheme := spec.SecurityScheme{
-			Type:         "http",
-			Scheme:       "bearer",
-			BearerFormat: "JWT",
+			Type:   "http",
+			Scheme: "bearer",
 		}
-		return "bearerauth", &scheme, nil
+		// Parse parameters
+		*index++
+		description := ""
+		for ; *index < len(lines); *index++ {
+			v := strings.TrimSpace(lines[*index])
+			if len(v) == 0 {
+				continue
+			}
+			fields := FieldsByAnySpace(v, 2)
+			securityAttr := strings.ToLower(fields[0])
+			var value string
+			if len(fields) > 1 {
+				value = fields[1]
+			}
+			if securityAttr == "@description" {
+				description = value
+			}
+			if securityAttr == "@bearerformat" {
+				scheme.BearerFormat = value
+			}
+			if strings.HasPrefix(securityAttr, "@securitydefinitions.") {
+				*index--
+				break
+			}
+		}
+		scheme.Description = description
+		return key, &scheme, nil
 	}
 
 	// For the first line we get the attributes in the context parameter, so we skip to the next one
@@ -420,7 +447,7 @@ func parseSecAttributesV3(context string, lines []string, index *int) (string, *
 	}
 
 	scheme := &spec.SecurityScheme{}
-	key := getSecurityDefinitionKey(lines)
+	key = getSecurityDefinitionKey(lines)
 
 	switch attribute {
 	case secAPIKeyAttr:

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -137,38 +137,53 @@ func TestParserParseGeneralApiInfoV3(t *testing.T) {
 	assert.Equal(t, "OpenAPI", p.openAPI.ExternalDocs.Spec.Description)
 	assert.Equal(t, "https://swagger.io/resources/open-api", p.openAPI.ExternalDocs.Spec.URL)
 
-	assert.Equal(t, 7, len(p.openAPI.Components.Spec.SecuritySchemes))
+	assert.Equal(t, 8, len(p.openAPI.Components.Spec.SecuritySchemes))
 
 	security := p.openAPI.Components.Spec.SecuritySchemes
-	assert.Equal(t, "basic", security["basic"].Spec.Spec.Scheme)
-	assert.Equal(t, "http", security["basic"].Spec.Spec.Type)
-
-	assert.Equal(t, "apiKey", security["ApiKeyAuth"].Spec.Spec.Type)
-	assert.Equal(t, "Authorization", security["ApiKeyAuth"].Spec.Spec.Name)
-	assert.Equal(t, "header", security["ApiKeyAuth"].Spec.Spec.In)
-	assert.Equal(t, "some description", security["ApiKeyAuth"].Spec.Spec.Description)
-
-	assert.Equal(t, "oauth2", security["OAuth2Application"].Spec.Spec.Type)
-	assert.Equal(t, "header", security["OAuth2Application"].Spec.Spec.In)
-	assert.Equal(t, "https://example.com/oauth/token", security["OAuth2Application"].Spec.Spec.Flows.Spec.ClientCredentials.Spec.TokenURL)
-	assert.Equal(t, 2, len(security["OAuth2Application"].Spec.Spec.Flows.Spec.ClientCredentials.Spec.Scopes))
-
-	assert.Equal(t, "oauth2", security["OAuth2Implicit"].Spec.Spec.Type)
-	assert.Equal(t, "header", security["OAuth2Implicit"].Spec.Spec.In)
-	assert.Equal(t, "https://example.com/oauth/authorize", security["OAuth2Implicit"].Spec.Spec.Flows.Spec.Implicit.Spec.AuthorizationURL)
-	assert.Equal(t, "some_audience.google.com", security["OAuth2Implicit"].Spec.Spec.Flows.Extensions["x-google-audiences"])
-
-	assert.Equal(t, "oauth2", security["OAuth2Password"].Spec.Spec.Type)
-	assert.Equal(t, "header", security["OAuth2Password"].Spec.Spec.In)
-	assert.Equal(t, "https://example.com/oauth/token", security["OAuth2Password"].Spec.Spec.Flows.Spec.Password.Spec.TokenURL)
-
-	assert.Equal(t, "oauth2", security["OAuth2AccessCode"].Spec.Spec.Type)
-	assert.Equal(t, "header", security["OAuth2AccessCode"].Spec.Spec.In)
-	assert.Equal(t, "https://example.com/oauth/token", security["OAuth2AccessCode"].Spec.Spec.Flows.Spec.AuthorizationCode.Spec.TokenURL)
-
-	assert.Equal(t, "bearer", security["bearerauth"].Spec.Spec.Scheme)
-	assert.Equal(t, "http", security["bearerauth"].Spec.Spec.Type)
-	assert.Equal(t, "JWT", security["bearerauth"].Spec.Spec.BearerFormat)
+	if v, ok := security["basic"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "basic", v.Spec.Spec.Scheme)
+		assert.Equal(t, "http", v.Spec.Spec.Type)
+	}
+	if v, ok := security["ApiKeyAuth"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "apiKey", v.Spec.Spec.Type)
+		assert.Equal(t, "Authorization", v.Spec.Spec.Name)
+		assert.Equal(t, "header", v.Spec.Spec.In)
+		assert.Equal(t, "some description", v.Spec.Spec.Description)
+	}
+	if v, ok := security["OAuth2Application"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "oauth2", v.Spec.Spec.Type)
+		assert.Equal(t, "header", v.Spec.Spec.In)
+		assert.Equal(t, "https://example.com/oauth/token", v.Spec.Spec.Flows.Spec.ClientCredentials.Spec.TokenURL)
+		assert.Equal(t, 2, len(v.Spec.Spec.Flows.Spec.ClientCredentials.Spec.Scopes))
+	}
+	if v, ok := security["OAuth2Implicit"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "oauth2", v.Spec.Spec.Type)
+		assert.Equal(t, "header", v.Spec.Spec.In)
+		assert.Equal(t, "https://example.com/oauth/authorize", v.Spec.Spec.Flows.Spec.Implicit.Spec.AuthorizationURL)
+		assert.Equal(t, "some_audience.google.com", v.Spec.Spec.Flows.Extensions["x-google-audiences"])
+	}
+	if v, ok := security["OAuth2Password"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "oauth2", v.Spec.Spec.Type)
+		assert.Equal(t, "header", v.Spec.Spec.In)
+		assert.Equal(t, "https://example.com/oauth/token", v.Spec.Spec.Flows.Spec.Password.Spec.TokenURL)
+	}
+	if v, ok := security["OAuth2AccessCode"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "oauth2", v.Spec.Spec.Type)
+		assert.Equal(t, "header", v.Spec.Spec.In)
+		assert.Equal(t, "https://example.com/oauth/token", v.Spec.Spec.Flows.Spec.AuthorizationCode.Spec.TokenURL)
+	}
+	if v, ok := security["BearerAuth1"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "bearer", v.Spec.Spec.Scheme)
+		assert.Equal(t, "http", v.Spec.Spec.Type)
+		assert.Equal(t, "JWT", v.Spec.Spec.BearerFormat)
+		assert.Equal(t, "First bearer token", v.Spec.Spec.Description)
+	}
+	if v, ok := security["BearerAuth2"]; ok && v != nil && v.Spec != nil && v.Spec.Spec != nil {
+		assert.Equal(t, "bearer", v.Spec.Spec.Scheme)
+		assert.Equal(t, "http", v.Spec.Spec.Type)
+		assert.Equal(t, "CustomToken", v.Spec.Spec.BearerFormat)
+		assert.Equal(t, "Second bearer token", v.Spec.Spec.Description)
+	}
 }
 
 func TestParser_ParseGeneralApiInfoExtensionsV3(t *testing.T) {

--- a/testdata/v3/main.go
+++ b/testdata/v3/main.go
@@ -54,7 +54,13 @@ package main
 // @in header
 // @name name
 
-// @securitydefinitions.bearerauth BearerAuth
+// @securitydefinitions.bearerauth BearerAuth1
+// @description First bearer token
+// @bearerformat JWT
+
+// @securitydefinitions.bearerauth BearerAuth2
+// @description Second bearer token
+// @bearerformat CustomToken
 
 // @externalDocs.description OpenAPI
 // @externalDocs.url https://swagger.io/resources/open-api


### PR DESCRIPTION
**Describe the PR**
add multiple `securitydefinitions.bearerauth` for [bearer-authentication documentation](https://swagger.io/docs/specification/authentication/bearer-authentication/)

**Relation issue**
https://github.com/swaggo/swag/issues/2026

**Additional context**
Updating the current implementation `securitydefinitions.bearerauth`
