### PR TITLE
fix: respect @name annotation for recursive types

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1316,8 +1316,15 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 	if parser.isInStructStack(typeSpecDef) {
 		parser.debug.Printf("Skipping '%s', recursion detected.", typeName)
 
+		// Ensure SchemaName is set before using it
+		typeSpecDef.SetSchemaName()
+		schemaName := typeName
+		if typeSpecDef.SchemaName != "" {
+			schemaName = typeSpecDef.SchemaName
+		}
+
 		return &Schema{
-				Name:    typeSpecDef.SchemaName,
+				Name:    schemaName,
 				PkgPath: typeSpecDef.PkgPath,
 				Schema:  PrimitiveSchema(OBJECT),
 			},

--- a/parser_test.go
+++ b/parser_test.go
@@ -4424,3 +4424,64 @@ var Func2 = Func
 	assert.NotNil(t, val2.Get)
 	assert.Equal(t, val2.Get.OperationProps.Summary, "generate indirectly pointing")
 }
+
+
+// TestParser_ParseDefinitionWithRecursiveTypeAndNameAnnotation tests that @name annotations
+// are properly respected for recursive types
+func TestParser_ParseDefinitionWithRecursiveTypeAndNameAnnotation(t *testing.T) {
+	src := `package api
+
+// TreeNode represents a node in a tree structure
+type TreeNode struct {
+	Value    string     ` + "`json:\"value\"`" + `
+	Children []TreeNode ` + "`json:\"children\"`" + `
+} // @name TreeNode
+
+// LinkedNode represents a node in a linked structure  
+type LinkedNode struct {
+	Data string       ` + "`json:\"data\"`" + `
+	Next *LinkedNode  ` + "`json:\"next\"`" + `
+} // @name CustomLinkedNode
+`
+
+	p := New()
+	err := p.packages.ParseFile("api", "api/tree.go", src, ParseAll)
+	assert.NoError(t, err)
+
+	_, err = p.packages.ParseTypes()
+	assert.NoError(t, err)
+
+	// Find the TreeNode type
+	treeNodeDef := p.packages.FindTypeSpec("api.TreeNode", nil)
+	assert.NotNil(t, treeNodeDef)
+
+	// Parse the TreeNode definition
+	schema, err := p.ParseDefinition(treeNodeDef)
+	assert.NoError(t, err)
+	assert.NotNil(t, schema)
+	assert.Equal(t, "TreeNode", schema.Name) // Should use @name annotation
+
+	// Find the LinkedNode type
+	linkedNodeDef := p.packages.FindTypeSpec("api.LinkedNode", nil)
+	assert.NotNil(t, linkedNodeDef)
+
+	// Parse the LinkedNode definition
+	schema2, err := p.ParseDefinition(linkedNodeDef)
+	assert.NoError(t, err)
+	assert.NotNil(t, schema2)
+	assert.Equal(t, "CustomLinkedNode", schema2.Name) // Should use @name annotation
+
+	// Verify the definitions were added to swagger with correct names
+	assert.NotNil(t, p.swagger.Definitions["TreeNode"])
+	assert.NotNil(t, p.swagger.Definitions["CustomLinkedNode"])
+
+	// The fix is working if the definitions use the @name annotation
+	// TreeNode should be "TreeNode", not "api.TreeNode"
+	// LinkedNode should be "CustomLinkedNode", not "api.LinkedNode"
+	for name := range p.swagger.Definitions {
+		// Ensure no definitions use the full package path format
+		assert.NotContains(t, name, "api.TreeNode")
+		assert.NotContains(t, name, "api.LinkedNode")
+	}
+}
+

--- a/testdata/recursive_with_name/main.go
+++ b/testdata/recursive_with_name/main.go
@@ -1,0 +1,37 @@
+package main
+
+import "net/http"
+
+// @title Recursive Type with @name Test API
+// @version 1.0
+// @description This is a test for recursive types with @name annotations
+// @BasePath /api/v1
+
+// EntityHierarchyNode represents a node in the entity hierarchy tree.
+// Each node contains an entity and its child nodes.
+type EntityHierarchyNode struct {
+	ID       string                `json:"id"`
+	Name     string                `json:"name"`
+	Children []*EntityHierarchyNode `json:"children"`
+} // @name EntityHierarchyNode
+
+// TreeData represents a complete tree structure
+type TreeData struct {
+	Root EntityHierarchyNode `json:"root"`
+} // @name TreeData
+
+// GetEntityHierarchy returns the entity hierarchy
+// @Summary Get entity hierarchy
+// @Description Get the complete entity hierarchy tree
+// @Tags hierarchy
+// @Accept json
+// @Produce json
+// @Success 200 {object} TreeData
+// @Router /hierarchy [get]
+func GetEntityHierarchy(w http.ResponseWriter, r *http.Request) {
+	// Implementation
+}
+
+func main() {
+	// Server setup
+}


### PR DESCRIPTION
## Description

  This PR fixes an issue where the `@name` annotation
  was being ignored for recursive types, causing them
  to be generated with full package paths in the
  Swagger definitions instead of using the specified
  name.

  ## Problem

  When a type has a recursive reference to itself and
  uses the `@name` annotation, the generated Swagger
  definition would use the full package path (e.g.,
  `github_com_org_project_package.EntityHierarchyNode`)
   instead of the name specified in the annotation.

  ### Example:
  ```go
  // EntityHierarchyNode represents a node in a tree
  structure
  type EntityHierarchyNode struct {
      Entity   EntityModel           `json:"entity"`
      Children []*EntityHierarchyNode `json:"children"`
  } // @name EntityHierarchyNode

  Would generate:
  github_com_org_project_package.EntityHierarchyNode
  instead of EntityHierarchyNode

  Solution

  The issue was in parser.go where recursive types were
   handled. When recursion was detected, the code was
  using typeSpecDef.SchemaName before ensuring it was
  properly set via SetSchemaName().

  The fix ensures that SetSchemaName() is called before
   using the schema name for recursive types, allowing
  the @name annotation to be properly respected.

  Changes

  1. Modified ParseDefinition in parser.go to call
  SetSchemaName() when handling recursive types
  2. Added comprehensive tests to verify the fix works
  for various recursive type scenarios
  3. Added test data demonstrating the use case

  Testing

  - Added TestParser_ParseDefinitionWithRecursiveTypeAn
  dNameAnnotation test
  - All existing tests continue to pass
  - Tested with both self-referential types and types
  with custom @name annotations

  Impact

  This fix ensures that recursive types with @name
  annotations generate cleaner, more readable Swagger
  documentation without exposing internal package
  structures.
