### PR TITLE
feat: json:omitempty marks field as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ type Foo struct {
 Field Name | Type | Description
 ---|:---:|---
 <a name="validate"></a>validate | `string` | 	Determines the validation for the parameter. Possible values are: `required,optional`.
+<a name="json"></a>json | `string` | JSON tag options. The `omitempty` option will mark the field as not required.
 <a name="parameterDefault"></a>default | * | Declares the value of the parameter that the server will use if none is provided, for example a "count" to control the number of results per page might default to 100 if not supplied by the client in the request. (Note: "default" has no meaning for required parameters.)  See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-6.2. Unlike JSON Schema this value MUST conform to the defined [`type`](#parameterType) for this parameter.
 <a name="parameterMaximum"></a>maximum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.2.
 <a name="parameterMinimum"></a>minimum | `number` | See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-5.1.3.

--- a/field_parser.go
+++ b/field_parser.go
@@ -18,6 +18,7 @@ var _ FieldParser = &tagBaseFieldParser{p: nil, field: nil, tag: ""}
 const (
 	requiredLabel    = "required"
 	optionalLabel    = "optional"
+	omitEmptyLabel   = "omitempty"
 	swaggerTypeTag   = "swaggertype"
 	swaggerIgnoreTag = "swaggerignore"
 )
@@ -528,6 +529,15 @@ func (ps *tagBaseFieldParser) IsRequired() (bool, error) {
 			case requiredLabel:
 				return true, nil
 			case optionalLabel:
+				return false, nil
+			}
+		}
+	}
+
+	jsonTag := ps.tag.Get(jsonTag)
+	if jsonTag != "" {
+		for _, val := range strings.Split(jsonTag, ",") {
+			if val == omitEmptyLabel {
 				return false, nil
 			}
 		}

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -136,6 +136,17 @@ func TestDefaultFieldParser(t *testing.T) {
 		).IsRequired()
 		assert.NoError(t, err)
 		assert.False(t, got)
+
+		got, err = newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefault: true,
+			},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test,omitempty"`,
+			}},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.False(t, got)
 	})
 
 	t.Run("Extensions tag", func(t *testing.T) {


### PR DESCRIPTION
**Describe the PR**
- Enhances field parser to recognize 'omitempty' in `json:` tag as `required: false`, updating IsRequired logic (following existing pattern present in parsing logic) and adding corresponding test case. 
- Update README to document the new behavior w.r.t `json:omitempty`

**Relation issue**
Related: #2040  

**Additional context**
While I believe this behavior makes the most sense to use in conjunction with the `--requiredByDefault` flag - there is no hard requirement or dependency to force both these options to co-exist.  Implementation gives preference to existing supported `tag` values ( `binding` + `validate`) so anything presently relying on them for `required` calculation is unaffected by this change.
