### PR TITLE
Use the structs name without the @name comment

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -24,6 +24,7 @@ const (
 	outputTypesFlag          = "outputTypes"
 	parseVendorFlag          = "parseVendor"
 	parseDependencyFlag      = "parseDependency"
+	useStructNameFlag        = "useStructName"
 	parseDependencyLevelFlag = "parseDependencyLevel"
 	markdownFilesFlag        = "markdownFiles"
 	codeExampleFilesFlag     = "codeExampleFiles"
@@ -98,6 +99,11 @@ var initFlags = []cli.Flag{
 		Name:    parseDependencyFlag,
 		Aliases: []string{"pd"},
 		Usage:   "Parse go files inside dependency folder, disabled by default",
+	},
+	&cli.BoolFlag{
+		Name:    useStructNameFlag,
+		Aliases: []string{"st"},
+		Usage:   "Dont use those ugly full-path names when using dependency flag",
 	},
 	&cli.StringFlag{
 		Name:    markdownFilesFlag,
@@ -251,6 +257,7 @@ func initAction(ctx *cli.Context) error {
 		ParseDependency:     pdv,
 		MarkdownFilesDir:    ctx.String(markdownFilesFlag),
 		ParseInternal:       ctx.Bool(parseInternalFlag),
+		UseStructNames:      ctx.Bool(useStructNameFlag),
 		GeneratedTime:       ctx.Bool(generatedTimeFlag),
 		RequiredByDefault:   ctx.Bool(requiredByDefaultFlag),
 		CodeExampleFilesDir: ctx.String(codeExampleFilesFlag),

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -108,6 +108,9 @@ type Config struct {
 	// ParseDependencies whether swag should be parse outside dependency folder: 0 none, 1 models, 2 operations, 3 all
 	ParseDependency int
 
+	// UseStructNames stick to the struct name instead of those ugly full-path names
+	UseStructNames bool
+
 	// ParseInternal whether swag should parse internal packages
 	ParseInternal bool
 
@@ -198,6 +201,7 @@ func (g *Gen) Build(config *Config) error {
 
 	p := swag.New(
 		swag.SetParseDependency(config.ParseDependency),
+		swag.SetUseStructName(config.UseStructNames),
 		swag.SetMarkdownFileDirectory(config.MarkdownFilesDir),
 		swag.SetDebugger(config.Debugger),
 		swag.SetExcludedDirsAndFiles(config.Excludes),

--- a/parser.go
+++ b/parser.go
@@ -1339,8 +1339,9 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 		if len(schemaName) > 1 {
 			typeSpecDef.SchemaName = schemaName[len(schemaName)-1]
 			typeName = typeSpecDef.SchemaName
+		} else {
+			parser.debug.Printf("Could not strip type name of %s", typeName)
 		}
-		parser.debug.Printf("Could not strip type name of %s", typeName)
 	}
 
 	parser.structStack = append(parser.structStack, typeSpecDef)

--- a/parser.go
+++ b/parser.go
@@ -264,7 +264,7 @@ func SetParseDependency(parseDependency int) func(*Parser) {
 	}
 }
 
-// SetUseStructName sets whether to parse the dependent packages.
+// SetUseStructName sets whether to strip the full-path definition name.
 func SetUseStructName(useStructName bool) func(*Parser) {
 	return func(p *Parser) {
 		p.UseStructName = useStructName
@@ -1340,6 +1340,7 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 			typeSpecDef.SchemaName = schemaName[len(schemaName)-1]
 			typeName = typeSpecDef.SchemaName
 		}
+		parser.debug.Printf("Could not strip type name of %s", typeName)
 	}
 
 	parser.structStack = append(parser.structStack, typeSpecDef)

--- a/parser.go
+++ b/parser.go
@@ -182,6 +182,9 @@ type Parser struct {
 
 	// ParseFuncBody whether swag should parse api info inside of funcs
 	ParseFuncBody bool
+
+	// UseStructName Dont use those ugly full-path names when using dependency flag
+	UseStructName bool
 }
 
 // FieldParserFactory create FieldParser.
@@ -258,6 +261,13 @@ func SetParseDependency(parseDependency int) func(*Parser) {
 		if p.packages != nil {
 			p.packages.parseDependency = p.ParseDependency
 		}
+	}
+}
+
+// SetUseStructName sets whether to parse the dependent packages.
+func SetUseStructName(useStructName bool) func(*Parser) {
+	return func(p *Parser) {
+		p.UseStructName = useStructName
 	}
 }
 
@@ -1322,6 +1332,14 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 				Schema:  PrimitiveSchema(OBJECT),
 			},
 			ErrRecursiveParseStruct
+	}
+
+	if parser.UseStructName {
+		schemaName := strings.Split(typeSpecDef.SchemaName, ".")
+		if len(schemaName) > 1 {
+			typeSpecDef.SchemaName = schemaName[len(schemaName)-1]
+			typeName = typeSpecDef.SchemaName
+		}
 	}
 
 	parser.structStack = append(parser.structStack, typeSpecDef)


### PR DESCRIPTION
**Describe the PR**
I have added an extra flag that removes long names from struct definitions when using the `--pd` flag. 

Example:

Struct is in `myProject/internal/database/model/mytest.go`
Struct's name is `MyTest`

Outcome without the schema rename of `myProject_internal_database_model.MyTest`. 
``` json
"definitions": {
        "myProject_internal_database_model.MyTest": {
            "type": "object",
            "properties": {
                "data": {
                    "type": "string"
                }
            }
        }
}
```

Outcome with the schema rename `MyTest`. 
``` json
"definitions": {
        "MyTest": {
            "type": "object",
            "properties": {
                "data": {
                    "type": "string"
                }
            }
        }
}
```

This makes generating code from the swagger JSON way more readable. 

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**
Add any other context about the problem here.
