### PR TITLE
fix: prevent nil pointer dereference in getFuncDoc when parsing depen…

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1049,6 +1049,9 @@ func getFuncDoc(decl any) (*ast.CommentGroup, bool) {
 		if astDecl.Tok != token.VAR {
 			return nil, false
 		}
+		if len(astDecl.Specs) == 0 {
+			return nil, false
+		}
 		varSpec, ok := astDecl.Specs[0].(*ast.ValueSpec)
 		if !ok || len(varSpec.Values) != 1 {
 			return nil, false
@@ -1056,8 +1059,11 @@ func getFuncDoc(decl any) (*ast.CommentGroup, bool) {
 		_, ok = getFuncDoc(varSpec)
 		return astDecl.Doc, ok
 	case *ast.ValueSpec:
+		if len(astDecl.Values) == 0 {
+			return nil, false
+		}
 		value, ok := astDecl.Values[0].(*ast.Ident)
-		if !ok || value == nil {
+		if !ok || value == nil || value.Obj == nil || value.Obj.Decl == nil {
 			return nil, false
 		}
 		_, ok = getFuncDoc(value.Obj.Decl)


### PR DESCRIPTION
https://github.com/swaggo/swag/issues/2042

## Fix nil pointer dereference in getFuncDoc function when parsing dependencies

### Problem
When parsing dependencies with `ParseDependency` enabled, swag encounters a segmentation fault due to nil pointer dereferences in the `getFuncDoc` function. This occurs when the parser encounters AST nodes from standard library types (like `atomic.Int32`, `json.scanner`, `ecdh.PrivateKey`, etc.) that don't have all their fields properly initialized.

**Error Stack Trace:**
```
2025/07/17 05:48:56 atomic.Int32 TypeSpecDef is nil
2025/07/17 05:48:56 json.scanner TypeSpecDef is nil
2025/07/17 05:48:56 ecdh.PrivateKey TypeSpecDef is nil
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x912b14]

goroutine 1 [running]:
github.com/swaggo/swag.getFuncDoc({0xa31760?, 0xc000ac7180})
/home/runner/go/pkg/mod/github.com/swaggo/swag@v1.16.5/parser.go:1063 +0x114
```

### Root Cause
The `getFuncDoc` function was accessing AST node fields without proper nil checks:

1. In the `*ast.GenDecl` case, it accessed `astDecl.Specs[0]` without checking if `astDecl.Specs` was empty
2. In the `*ast.ValueSpec` case, it accessed `astDecl.Values[0]` without checking if `astDecl.Values` was empty  
3. It accessed `value.Obj.Decl` without checking if `value.Obj` or `value.Obj.Decl` were nil

When parsing dependencies, especially standard library packages, these AST nodes may not have all fields initialized, leading to nil pointer dereferences.

### Solution
Added comprehensive nil checks in the `getFuncDoc` function:

1. **Check for empty Specs slice**: Added `if len(astDecl.Specs) == 0` before accessing `astDecl.Specs[0]`
2. **Check for empty Values slice**: Added `if len(astDecl.Values) == 0` before accessing `astDecl.Values[0]`
3. **Check for nil object chain**: Enhanced the existing nil check to include `value.Obj == nil || value.Obj.Decl == nil`

### Changes Made
- Added 3 strategic nil checks in `parser.go` at lines 1052, 1062, and 1066
- No breaking changes to the API
- Maintains backward compatibility
- Gracefully handles malformed or incomplete AST nodes

### Testing
This fix resolves the segmentation fault when running swag with dependency parsing enabled. The parser now gracefully skips over problematic AST nodes instead of crashing.

### Impact
- **Fixes**: Critical segmentation fault when parsing dependencies
- **Improves**: Robustness when dealing with incomplete AST nodes from external packages
- **Maintains**: All existing functionality and performance
- **Risk**: Very low - only adds defensive programming checks

This is a critical stability fix that allows swag to successfully parse projects with dependencies without crashing.