### PR TITLE
feat: allow description line continuation

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -204,7 +204,7 @@ func (operation *Operation) ParseDescriptionComment(lineRemainder string) {
 		return
 	}
 
-	operation.Description += "\n" + lineRemainder
+	operation.Description = AppendDescription(operation.Description, lineRemainder)
 }
 
 // ParseMetadata parse metadata.

--- a/parser.go
+++ b/parser.go
@@ -546,8 +546,7 @@ func parseGeneralAPIInfo(parser *Parser, comments []string) error {
 			setSwaggerInfo(parser.swagger, attr, value)
 		case descriptionAttr:
 			if previousAttribute == attribute {
-				parser.swagger.Info.Description += "\n" + value
-
+				parser.swagger.Info.Description = AppendDescription(parser.swagger.Info.Description, value)
 				continue
 			}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -4491,3 +4491,19 @@ var Func2 = Func
 	assert.NotNil(t, val2.Get)
 	assert.Equal(t, val2.Get.OperationProps.Summary, "generate indirectly pointing")
 }
+
+func TestParser_DescriptionLineContinuation(t *testing.T) {
+	t.Parallel()
+
+	p := New()
+	searchDir := "testdata/description_line_continuation"
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	assert.NoError(t, err)
+
+	err = p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	assert.NoError(t, err)
+
+	b, err := json.MarshalIndent(p.swagger, "", "    ")
+	assert.NoError(t, err)
+	assert.Equal(t, string(expected), string(b))
+}

--- a/testdata/description_line_continuation/api/api.go
+++ b/testdata/description_line_continuation/api/api.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+)
+
+// @Summary Endpoint A
+// @Description This is a mock endpoint description \
+// @Description which is long and descriptions that \
+// @Description end with backslash do not add a new line.
+// @Description This sentence is in a new line.
+// @Description
+// @Description And this have an empty line above it.
+// @Description Lorem ipsum dolor sit amet \
+// @Description consectetur adipiscing elit, \
+// @Description sed do eiusmod tempor incididunt \
+// @Description ut labore et dolore magna aliqua.
+// @Success 200
+// @Router /a [get]
+func EndpointA(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// @Summary Endpoint B
+// @Description Something something.
+// @Description
+// @Description A new line, \
+// @Description continue to the line.
+// @Success 200
+// @Router /b [get]
+func EndpointB(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/testdata/description_line_continuation/expected.json
+++ b/testdata/description_line_continuation/expected.json
@@ -1,0 +1,34 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "description": "Example long description that should not be split into multiple lines.\nThis is a new line thatescapes new line withoutadding a whitespace.\n\nAnother line that has an empty line above it.",
+        "title": "Swagger Example API",
+        "contact": {},
+        "version": "1.0"
+    },
+    "host": "localhost:8080",
+    "paths": {
+        "/a": {
+            "get": {
+                "description": "This is a mock endpoint description which is long and descriptions that end with backslash do not add a new line.\nThis sentence is in a new line.\n\nAnd this have an empty line above it.\nLorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                "summary": "Endpoint A",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        },
+        "/b": {
+            "get": {
+                "description": "Something something.\n\nA new line, continue to the line.",
+                "summary": "Endpoint B",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testdata/description_line_continuation/main.go
+++ b/testdata/description_line_continuation/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/testdata/description_escape_new_line/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description Example long description \
+// @description that should not be split \
+// @description into multiple lines.
+// @description This is a new line that\
+// @description escapes new line without\
+// @description adding a whitespace.
+// @description
+// @description Another line that has an \
+// @description empty line above it.
+// @host localhost:8080
+func main() {
+	http.HandleFunc("/a", api.EndpointA)
+	http.HandleFunc("/b", api.EndpointB)
+	http.ListenAndServe(":8080", nil)
+}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,9 @@
 package swag
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+)
 
 // FieldsFunc split a string s by a func splitter into max n parts
 func FieldsFunc(s string, f func(rune2 rune) bool, n int) []string {
@@ -52,4 +55,13 @@ func FieldsFunc(s string, f func(rune2 rune) bool, n int) []string {
 // FieldsByAnySpace split a string s by any space character into max n parts
 func FieldsByAnySpace(s string, n int) []string {
 	return FieldsFunc(s, unicode.IsSpace, n)
+}
+
+// AppendDescription appends a new string to the existing description, treating
+// a trailing backslash as a line continuation.
+func AppendDescription(current, addition string) string {
+	if strings.HasSuffix(current, "\\") {
+		return current[:len(current)-1] + addition
+	}
+	return current + "\n" + addition
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,9 @@
 package swag
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFieldsByAnySpace(t *testing.T) {
@@ -33,6 +34,45 @@ func TestFieldsByAnySpace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, FieldsByAnySpace(tt.args.s, tt.args.n), "FieldsByAnySpace(%v,  %v)", tt.args.s, tt.args.n)
+		})
+	}
+}
+
+func TestAppendDescription(t *testing.T) {
+	type args struct {
+		current  string
+		addition string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"test1",
+			args{
+				"aa",
+				"bb",
+			},
+			"aa\nbb",
+		},
+		{"test2",
+			args{
+				"aa\\",
+				"bb",
+			},
+			"aabb",
+		},
+		{"test3",
+			args{
+				"aa \\",
+				"bb",
+			},
+			"aa bb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, AppendDescription(tt.args.current, tt.args.addition), "AppendDescription(%v,  %v)", tt.args.current, tt.args.addition)
 		})
 	}
 }


### PR DESCRIPTION
**Describe the PR**
This PR adds support for escaping newlines in `@description` annotations. This allows for long descriptions to be split across multiple lines in the source code for better readability, without introducing unwanted newlines in the generated Swagger UI.


**Relation issue**
fixes #2047 

**Additional context**
This feature is implemented by introducing a new `AppendDescription` utility function that handles the concatenation of description lines based on the presence of a trailing backslash.

Unit tests for the `AppendDescription` function and an end-to-end test for the line continuation have been added to ensure the correct behavior.