### PR TITLE
chore: update version.go to v1.16.7

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package swag
 
 // Version of swag.
-const Version = "v1.16.4"
+const Version = "v1.16.7"


### PR DESCRIPTION
related: #2042

Per request from community - updating version.go to v1.16.7 to ensure that the version command of the client properly reports the version for the next release.
