### PR TITLE
Support empty string as default value in the struct field

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -405,8 +405,8 @@ func (ps *tagBaseFieldParser) complementSchema(schema *spec.Schema, types []stri
 
 	schema.ReadOnly = ps.tag.Get(readOnlyTag) == "true"
 
-	defaultTagValue := ps.tag.Get(defaultTag)
-	if defaultTagValue != "" {
+	defaultTagValue, ok := ps.tag.Lookup(defaultTag)
+	if ok {
 		value, err := defineType(field.schemaType, defaultTagValue)
 		if err != nil {
 			return err


### PR DESCRIPTION
**Describe the PR**
This PR handles the issue with the `default` tag in the struct field. The tool ignores the empty string value for the `default` tag while generating the swagger specification.

The reason behind it is how the value for the `default` tag is being read. The code was using the `tag.Get()` [method](https://pkg.go.dev/reflect#StructTag.Get). This method could return an empty string in two cases: the value itself is an empty string, or the tag doesn't exist at all. And the condition below doesn't handle the first case correctly.

I have changed it to use the `tag.Lookup()` [method](https://pkg.go.dev/reflect#StructTag.Lookup) to distinguish between the two cases and changed the condition accordingly.

**Relation issue**
https://github.com/swaggo/swag/issues/2052