### PR TITLE
Fix for interface-valued schemas

### DIFF
--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -562,3 +562,22 @@ func TestParseTypeAlias(t *testing.T) {
 
 	assert.JSONEq(t, string(expected), string(result))
 }
+
+func TestParseInterface(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/v3/interface"
+
+	p := New(GenerateOpenAPI3Doc(true))
+
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	require.NoError(t, err)
+
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	require.NoError(t, err)
+
+	result, err := json.Marshal(p.openAPI)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(result))
+}

--- a/schemav3.go
+++ b/schemav3.go
@@ -21,6 +21,11 @@ func IsComplexSchemaV3(schema *SchemaV3) bool {
 		return true
 	}
 
+	// a schema without type (i.e. `any`) cannot be complex
+	if schema.Type == nil {
+		return false
+	}
+
 	// a deep array type is complex, how to determine deep? here more than 2 ,for example: [][]object,[][][]int
 	if len(*schema.Type) > 2 {
 		return true

--- a/testdata/v3/interface/api/api.go
+++ b/testdata/v3/interface/api/api.go
@@ -1,0 +1,10 @@
+package api
+
+import "net/http"
+
+// @Router /test [GET]
+// @Produce json
+// @Success 200 {object} types.Response "Success"
+func Handle(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/testdata/v3/interface/expected.json
+++ b/testdata/v3/interface/expected.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Swagger Example API",
+    "version": "1.0"
+  },
+  "externalDocs": {
+    "description": "",
+    "url": ""
+  },
+  "components": {
+  },
+  "paths": {
+    "/test": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/v3/interface/main.go
+++ b/testdata/v3/interface/main.go
@@ -1,0 +1,4 @@
+package main
+
+// @title Swagger Example API
+// @version 1.0

--- a/testdata/v3/interface/types/types.go
+++ b/testdata/v3/interface/types/types.go
@@ -1,0 +1,3 @@
+package types
+
+type Response interface{}


### PR DESCRIPTION
This fixes the panic when using interface-valued schemas (the added test was panicking before fix).

Seems to be a regression from #1985.