### PR TITLE
CICD update go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 
 # Start from the latest golang base image
-FROM --platform=$BUILDPLATFORM golang:1.21-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app


### PR DESCRIPTION
**Describe the PR**
Update go build version for gcr image.

**Relation issue**
NONE

**Additional context**
1.21-alpine has security issues.