### PR TITLE
fix: prevent nil pointer dereference in getAllGoFileInfo when parsing the files

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1845,7 +1845,10 @@ func (parser *Parser) getAllGoFileInfo(packageDir, searchDir string) error {
 	if parser.skipPackageByPrefix(packageDir) {
 		return nil // ignored by user-defined package path prefixes
 	}
-	return filepath.Walk(searchDir, func(path string, f os.FileInfo, _ error) error {
+	return filepath.Walk(searchDir, func(path string, f os.FileInfo, wError error) error {
+		if wError != nil {
+			return fmt.Errorf("failed to access path %q, err: %v\n", path, wError)
+		}
 		err := parser.Skip(path, f)
 		if err != nil {
 			return err


### PR DESCRIPTION
**Describe the PR**
If there's a file or dir that can't be read, the tool throws a cryptic error that is not easy to debug.
In this fix, we handle the errors inside the walkFunc so that the user knows there are issues with some file in the path.

I opted for throwing an error and letting the user fix his env, assuming the tool runs already inside a folder where the user wants all the files to be accessible. The other alternative would be to just print the error and skip the file/dir, which can potentially cause extra confusion if some other file gets excluded due to that.

Example of error before this fix, running v1.16.6:

```
2025/09/17 12:42:25 Generate swagger docs....
2025/09/17 12:42:25 Generate general API Info, search dir:./
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x10075ae28]

goroutine 1 [running]:
github.com/swaggo/swag.(*Parser).Skip.walkWith.func1(...)
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/parser.go:1959
github.com/swaggo/swag.(*Parser).Skip(0x1400031f2b8?, {0x140000d6700, 0x31}, {0x0, 0x0})
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/parser.go:1954 +0x28
github.com/swaggo/swag.(*Parser).getAllGoFileInfo.func1({0x140000d6700, 0x31}, {0x0, 0x0}, {0x1400031f368?, 0x1003cf27c?})
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/parser.go:1849 +0x64
path/filepath.walk({0x140000d8540, 0x21}, {0x100a0fc10, 0x140003236c0}, 0x1400031f618)
	/opt/homebrew/Cellar/go/1.25.1/libexec/src/path/filepath/path.go:365 +0x160
path/filepath.walk({0x14000332130, 0x4}, {0x100a0fc10, 0x140003235f0}, 0x1400031f618)
	/opt/homebrew/Cellar/go/1.25.1/libexec/src/path/filepath/path.go:369 +0x1c0
path/filepath.walk({0x1007bf427, 0x2}, {0x100a0fc10, 0x140000bc000}, 0x1400031f618)
	/opt/homebrew/Cellar/go/1.25.1/libexec/src/path/filepath/path.go:369 +0x1c0
path/filepath.Walk({0x1007bf427, 0x2}, 0x14000231618)
	/opt/homebrew/Cellar/go/1.25.1/libexec/src/path/filepath/path.go:427 +0x6c
github.com/swaggo/swag.(*Parser).getAllGoFileInfo(0x1007bf427?, {0x1400028b068?, 0x1008d2d10?}, {0x1007bf427?, 0x0?})
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/parser.go:1848 +0x8c
github.com/swaggo/swag.(*Parser).ParseAPIMultiSearchDir(0x1400017b200, {0x1400027e890, 0x1, 0x0?}, {0x16fb235c5, 0xa}, 0x64)
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/parser.go:409 +0x1e4
github.com/swaggo/swag/gen.(*Gen).Build(0x14000288570, 0x1400014e780)
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/gen/gen.go:225 +0x578
main.initAction(0x1400027ca80)
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/cmd/swag/main.go:248 +0x778
github.com/urfave/cli/v2.(*Command).Run(0x1400017ad80, 0x1400012fe80)
	/Users/valeriovalerio/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x44c
github.com/urfave/cli/v2.(*App).RunContext(0x14000115520, {0x100a0d8b8, 0x100e89f00}, {0x1400012a120, 0x6, 0x6})
	/Users/valeriovalerio/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x7a0
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/valeriovalerio/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
	/Users/valeriovalerio/go/pkg/mod/github.com/swaggo/swag@v1.16.6/cmd/swag/main.go:339 +0x47c
Error: running "swag init -g MY_APP.go -o apidocs" failed with exit code 2
```

After the fix:
```
2025/09/17 13:21:59 Generate swagger docs....
2025/09/17 13:21:59 Generate general API Info, search dir:./
2025/09/17 13:21:59 failed to access path "REDACTED", err: lstat REDACTED: permission denied
Error: running "swag init -g MY_APP.go -o apidocs" failed with exit code 1
```

Fixes: #1916

**Relation issue**
https://github.com/swaggo/swag/issues/1916

**Additional context**
N/A