### PR TITLE
fix: generic types name generation

### DIFF
--- a/generics.go
+++ b/generics.go
@@ -30,10 +30,6 @@ func (t *genericTypeSpec) TypeName() string {
 	return t.Name
 }
 
-func normalizeGenericTypeName(name string) string {
-	return strings.Replace(name, ".", "_", -1)
-}
-
 func (pkgDefs *PackagesDefinitions) getTypeFromGenericParam(genericParam string, file *ast.File) (typeSpecDef *TypeSpecDef) {
 	if strings.HasPrefix(genericParam, "[]") {
 		typeSpecDef = pkgDefs.getTypeFromGenericParam(genericParam[2:], file)
@@ -176,8 +172,8 @@ func (pkgDefs *PackagesDefinitions) parametrizeGenericType(file *ast.File, origi
 		}
 	}
 
-	name += normalizeGenericTypeName(strings.Join(nameParts, "-"))
-	schemaName += normalizeGenericTypeName(strings.Join(schemaNameParts, "-"))
+	name += strings.Join(nameParts, "-")
+	schemaName += strings.Join(schemaNameParts, "-")
 
 	if typeSpec, ok := pkgDefs.uniqueDefinitions[name]; ok {
 		return typeSpec

--- a/parser.go
+++ b/parser.go
@@ -1340,13 +1340,11 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 	}
 
 	if parser.UseStructName {
-		schemaName := strings.Split(typeSpecDef.SchemaName, ".")
-		if len(schemaName) > 1 {
-			typeSpecDef.SchemaName = schemaName[len(schemaName)-1]
-			typeName = typeSpecDef.SchemaName
-		} else {
-			parser.debug.Printf("Could not strip type name of %s", typeName)
-		}
+		typeSpecDef.SchemaName = parser.stripToStructName(typeSpecDef.SchemaName)
+		typeName = typeSpecDef.SchemaName
+		parser.debug.Printf("Stripped type name to %s", typeName)
+	} else {
+		typeSpecDef.SchemaName = normalizeGenericTypeName(typeSpecDef.SchemaName)
 	}
 
 	parser.structStack = append(parser.structStack, typeSpecDef)
@@ -1408,6 +1406,19 @@ func (parser *Parser) ParseDefinition(typeSpecDef *TypeSpecDef) (*Schema, error)
 	}
 
 	return &sch, nil
+}
+
+func (parser *Parser) stripToStructName(schemaName string) string {
+	parts := strings.Split(schemaName, "-")
+	for i, part := range parts {
+		dotParts := strings.Split(part, ".")
+		parts[i] = dotParts[len(dotParts)-1]
+	}
+	return strings.Join(parts, "-")
+}
+
+func normalizeGenericTypeName(name string) string {
+	return strings.ReplaceAll(name, ".", "_")
 }
 
 func fullTypeName(parts ...string) string {

--- a/types.go
+++ b/types.go
@@ -52,7 +52,7 @@ func (t *TypeSpecDef) TypeName() string {
 	var names []string
 	if t.NotUnique {
 		pkgPath := strings.Map(func(r rune) rune {
-			if r == '\\' || r == '/' || r == '.' {
+			if r == '\\' || r == '/' || r == '.' || r == '-' {
 				return '_'
 			}
 			return r


### PR DESCRIPTION
**Describe the PR**
During `swag init` when using `useStructName` flag. Fixed the issue where types using in generic were generated with full path instead of only type name.

**Relation issue**
Expands changes introduced in https://github.com/swaggo/swag/pull/2043

**Additional context**
Assume following code example:
```
import (
	"github.com/mini-maxit/backend/internal/api/http/httputils"
	"github.com/mini-maxit/backend/package/domain/schemas"
)

// @Success      200 {object} httputils.APIResponse[schemas.WorkerStatus]
func foo() {}
```

When generating swagger with `swag init --st --dir . --ot yaml --st`
The resulting type definition in swagger looked something like:
```
APIResponse-github_com_mini-maxit_backend_package_domain_schemas_WorkerStatus:
  properties:
    data:
      $ref: '#/definitions/WorkerStatus'
    ok:
      type: boolean
  type: object
```
We see that `APIResponse` is generated correctly with only struct name, when type used in generic is generated with full path.

After change the definion looks correct, with underling generic type shortened:
```
APIResponse-WorkerStatus:
  properties:
    data:
      $ref: '#/definitions/WorkerStatus'
    ok:
      type: boolean
  type: object
```

I know the tests are broken now. However, I cannot think of any better solution right, and help is welcomed and will be highly appreciated
