### PR TITLE
fix: avoid segmentation violation panic

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -463,7 +463,10 @@ func (ps *tagBaseFieldParser) complementSchema(schema *spec.Schema, types []stri
 		schema.MinItems = field.minItems
 		schema.UniqueItems = field.unique
 
-		eleSchema = schema.Items.Schema
+		if schema.Items != nil {
+			eleSchema = schema.Items.Schema
+		}
+
 		eleSchema.Format = field.formatType
 	}
 


### PR DESCRIPTION
**Describe the PR**
Fix a possible nil reference that causes a panic.

**Relation issue**
No Issue.

**Additional context**
Example to replicate involving generics and custom native types:

```
type MyType string

type CType[T any] struct {
  Data T `json:"data"`
}


// @Failure 400 {object} shared.CType[[]MyType]
```

