### PR TITLE
fix: parse form name "-" as skipped field

### DIFF
--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -132,6 +132,34 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		assert.False(t, got)
 	})
 
+	t.Run("Skipped tag", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParserV3(
+			&Parser{
+				RequiredByDefault: true,
+			},
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"-"`,
+			}},
+		).FieldName()
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+
+		got, err = newTagBaseFieldParserV3(
+			&Parser{
+				RequiredByDefault: true,
+			},
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `form:"-"`,
+			}},
+		).FieldName()
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
 	t.Run("Extensions tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -476,8 +476,8 @@ func (ps *tagBaseFieldParserV3) ShouldSkip() bool {
 	}
 
 	// json:"tag,hoge"
-	name := strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
-	if name == "-" {
+	name := ps.JsonName()
+	if name == "" {
 		return true
 	}
 
@@ -487,18 +487,16 @@ func (ps *tagBaseFieldParserV3) ShouldSkip() bool {
 func (ps *tagBaseFieldParserV3) FieldName() (string, error) {
 	var name string
 
-	if ps.field.Tag != nil {
-		// json:"tag,hoge"
-		name = strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
-		if name != "" {
-			return name, nil
-		}
+	// json:"tag,hoge"
+	name = ps.JsonName()
+	if name != "" {
+		return name, nil
+	}
 
-		// use "form" tag over json tag
-		name = ps.FormName()
-		if name != "" {
-			return name, nil
-		}
+	// use "form" tag over json tag
+	name = ps.FormName()
+	if name != "" {
+		return name, nil
 	}
 
 	if ps.field.Names == nil {
@@ -517,7 +515,20 @@ func (ps *tagBaseFieldParserV3) FieldName() (string, error) {
 
 func (ps *tagBaseFieldParserV3) FormName() string {
 	if ps.field.Tag != nil {
-		return strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+		name := strings.TrimSpace(strings.Split(ps.tag.Get(formTag), ",")[0])
+		if name != "-" {
+			return name
+		}
+	}
+	return ""
+}
+
+func (ps *tagBaseFieldParserV3) JsonName() string {
+	if ps.field.Tag != nil {
+		name := strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
+		if name != "-" {
+			return name
+		}
 	}
 	return ""
 }

--- a/testdata/v3/simple/api/api.go
+++ b/testdata/v3/simple/api/api.go
@@ -165,6 +165,7 @@ func GetPetByID() {
 // @Param cat body web.Cat false "cat description"
 // @Param dog body web.Dog false "dog description"
 // @Param fish body web.Fish false "fish description"
+// @Param catchedFish body web.CatchedFishForm false "fish description"
 // @Success 200 {object} web.Pet "Pet added successfully"
 // @Router /pets [post]
 func AddPet() {

--- a/testdata/v3/simple/web/handler.go
+++ b/testdata/v3/simple/web/handler.go
@@ -132,3 +132,8 @@ type Fish struct {
 	Breed string `json:"breed"`
 	Size  int    `json:"size"`
 }
+
+type CatchedFishForm struct {
+	Count uint  `form:"count"`
+	Fish  *Fish `form:"-"`
+}


### PR DESCRIPTION
**Describe the PR**

Given following struct with `form:"-"` annotation:

```go
type CatchedFishForm struct {
	Count uint  `form:"count"`
	Fish  *Fish `form:"-"`
}
```

The tool had panic:

```
2025/10/29 22:35:34 Generating web.CatchedFishForm
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x2b8 pc=0x1031d6524]

goroutine 1 [running]:
github.com/swaggo/swag/v2.(*Parser).parseStructFieldV3(0x1400021ca00, 0x140002a61e0, 0x140002b4780)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:1006 +0x3e4
github.com/swaggo/swag/v2.(*Parser).parseStructV3(0x1400021ca00, 0x140002a61e0, 0x1400007fef0)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:885 +0xa8
github.com/swaggo/swag/v2.(*Parser).parseTypeExprV3(0x1400021ca00, 0x1032e6b0c?, {0x103527c08?, 0x1400000d1d0?}, 0x38?)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:808 +0x3e4
github.com/swaggo/swag/v2.(*Parser).ParseDefinitionV3(0x1400021ca00, 0x14006176fc0)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:718 +0x3a4
github.com/swaggo/swag/v2.(*Parser).getTypeSchemaV3(0x1400021ca00, {0x140000361fb, 0x13}, 0x140002a6000, 0x0)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:669 +0xa80
github.com/swaggo/swag/v2.(*OperationV3).ParseParamComment(0x1400825d000, {0x140000361ea, 0x3d}, 0x140002a6000)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/operationv3.go:342 +0x928
github.com/swaggo/swag/v2.(*OperationV3).ParseComment(0x1400825d000, {0x140000361e0?, 0x1?}, 0x140002a6000)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/operationv3.go:86 +0x190
github.com/swaggo/swag/v2.(*Parser).ParseRouterAPIInfoV3(0x1400021ca00, 0x1400028c700)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parserv3.go:514 +0x184
github.com/swaggo/swag/v2.(*PackagesDefinitions).RangeFiles(0x140001ff770, 0x14007fbf510)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/packages.go:107 +0x2c8
github.com/swaggo/swag/v2.(*Parser).ParseAPIMultiSearchDir(0x1400021ca00, {0x140002412c0, 0x1, 0x0?}, {0x1032df71c, 0x7}, 0x64)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/parser.go:499 +0x4a4
github.com/swaggo/swag/v2/gen.(*Gen).Build(0x140001ff470, 0x140001de180)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/gen/gen.go:233 +0x608
main.initAction(0x14000224240)
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/cmd/swag/main.go:249 +0x7ec
github.com/urfave/cli/v2.(*Command).Run(0x140001ee420, 0x14000224240, {0x1400021ad20, 0xa, 0xa})
	~/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/command.go:274 +0x5d0
github.com/urfave/cli/v2.(*Command).Run(0x140001ee840, 0x14000224100, {0x14000132000, 0xb, 0xb})
	~/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/command.go:267 +0x808
github.com/urfave/cli/v2.(*App).RunContext(0x14000226000, {0x103528ca8, 0x1039b48c0}, {0x14000132000, 0xb, 0xb})
	~/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/app.go:332 +0x4f8
github.com/urfave/cli/v2.(*App).Run(...)
	~/go/pkg/mod/github.com/urfave/cli/v2@v2.25.1/app.go:309
main.main()
	~/go/pkg/mod/github.com/swaggo/swag/v2@v2.0.0-rc4/cmd/swag/main.go:341 +0x58c
```

**Relation issue**

https://github.com/swaggo/swag/issues/1639

