### PR TITLE
fix: add regex lookahead for api operation tags to preserve parenthesis

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -431,27 +431,27 @@ const (
 
 var regexAttributes = map[string]*regexp.Regexp{
 	// for Enums(A, B)
-	enumsTag: regexp.MustCompile(`(?i)\s+enums\(.*\)`),
+	enumsTag: regexp.MustCompile(`(?i)\s+enums\(.*?\)(?:\s|$)`),
 	// for maximum(0)
-	maximumTag: regexp.MustCompile(`(?i)\s+maxinum|maximum\(.*\)`),
+	maximumTag: regexp.MustCompile(`(?i)\s+(?:maxinum|maximum)\(.*?\)(?:\s|$)`),
 	// for minimum(0)
-	minimumTag: regexp.MustCompile(`(?i)\s+mininum|minimum\(.*\)`),
+	minimumTag: regexp.MustCompile(`(?i)\s+(?:mininum|minimum)\(.*?\)(?:\s|$)`),
 	// for default(0)
-	defaultTag: regexp.MustCompile(`(?i)\s+default\(.*\)`),
+	defaultTag: regexp.MustCompile(`(?i)\s+default\(.*?\)(?:\s|$)`),
 	// for minlength(0)
-	minLengthTag: regexp.MustCompile(`(?i)\s+minlength\(.*\)`),
+	minLengthTag: regexp.MustCompile(`(?i)\s+minlength\(.*?\)(?:\s|$)`),
 	// for maxlength(0)
-	maxLengthTag: regexp.MustCompile(`(?i)\s+maxlength\(.*\)`),
+	maxLengthTag: regexp.MustCompile(`(?i)\s+maxlength\(.*?\)(?:\s|$)`),
 	// for format(email)
-	formatTag: regexp.MustCompile(`(?i)\s+format\(.*\)`),
+	formatTag: regexp.MustCompile(`(?i)\s+format\(.*?\)(?:\s|$)`),
 	// for extensions(x-example=test)
-	extensionsTag: regexp.MustCompile(`(?i)\s+extensions\(.*\)`),
+	extensionsTag: regexp.MustCompile(`(?i)\s+extensions\(.*?\)(?:\s|$)`),
 	// for collectionFormat(csv)
-	collectionFormatTag: regexp.MustCompile(`(?i)\s+collectionFormat\(.*\)`),
+	collectionFormatTag: regexp.MustCompile(`(?i)\s+collectionFormat\(.*?\)(?:\s|$)`),
 	// example(0)
-	exampleTag: regexp.MustCompile(`(?i)\s+example\(.*\)`),
+	exampleTag: regexp.MustCompile(`(?i)\s+example\(.*?\)(?:\s|$)`),
 	// schemaExample(0)
-	schemaExampleTag: regexp.MustCompile(`(?i)\s+schemaExample\(.*\)`),
+	schemaExampleTag: regexp.MustCompile(`(?i)\s+schemaExample\(.*?\)(?:\s|$)`),
 }
 
 func (operation *Operation) parseParamAttribute(comment, objectType, schemaType, paramType string, param *spec.Parameter) error {
@@ -495,7 +495,7 @@ func (operation *Operation) parseParamAttribute(comment, objectType, schemaType,
 func findAttr(re *regexp.Regexp, commentLine string) (string, error) {
 	attr := re.FindString(commentLine)
 
-	l, r := strings.Index(attr, "("), strings.Index(attr, ")")
+	l, r := strings.Index(attr, "("), strings.LastIndex(attr, ")")
 	if l == -1 || r == -1 {
 		return "", fmt.Errorf("can not find regex=%s, comment=%s", re.String(), commentLine)
 	}

--- a/operation_test.go
+++ b/operation_test.go
@@ -1975,6 +1975,28 @@ func TestParseParamCommentByExampleString(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseParamCommentByExampleStringComplex(t *testing.T) {
+	t.Parallel()
+
+	comment := `@Param some_id query string true "Some ID" Example(user_id.eq(1))`
+	operation := NewOperation(nil)
+	err := operation.ParseComment(comment, nil)
+
+	assert.NoError(t, err)
+	b, _ := json.MarshalIndent(operation.Parameters, "", "    ")
+	expected := `[
+    {
+        "type": "string",
+        "example": "user_id.eq(1)",
+        "description": "Some ID",
+        "name": "some_id",
+        "in": "query",
+        "required": true
+    }
+]`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseParamCommentByExampleUnsupportedType(t *testing.T) {
 	t.Parallel()
 	var param spec.Parameter


### PR DESCRIPTION
## Describe the PR

Fix greedy regex matching in operation attribute parsing to correctly handle nested parentheses and multiple attributes on the same line.

**Changes made:**
1. Updated all regex patterns in `regexAttributes` map to use non-greedy matching (`.*?` instead of `.*`)
2. Added lookahead assertion `(?:\s|$)` to ensure closing `)` is followed by whitespace or end-of-line
3. Fixed `maximumTag` and `minimumTag` to use non-capturing groups `(?:maxinum|maximum)` instead of character class
4. Added test case `TestParseParamCommentByExampleStringComplex` to verify nested parentheses handling

## Relation issue

https://github.com/swaggo/swag/issues/2094

## Additional context

**Problem:** The previous implementation used greedy regex matching which caused incorrect parsing when:
- Attribute values contained parentheses (e.g., `example(user_id.eq(1))`)
- Multiple attributes appeared on the same line (e.g., `default(1) maximum(100) minimum(0)`)

**Example of the bug:**
```go
// Before fix:
// @Param filter query string false "Filter" example(user_id.eq(1))
// Parsed as: "user_id.eq(1" (truncated at first closing parenthesis)

// After fix:
// @Param filter query string false "Filter" example(user_id.eq(1))
// Parsed as: "user_id.eq(1)" (correctly captures full value)
```

**Why this matters:** This fix enables proper integration testing workflows where API documentation examples containing function-like syntax (e.g., filter expressions like `user_id.eq(1)`) are used to generate test data for tools like Portman and Newman.

The existing test suite already validates the expected behavior, so no additional tests were required beyond the new `TestParseParamCommentByExampleStringComplex` test case that specifically demonstrates the nested parentheses fix.