### PR TITLE
fix: parseDependency parses all dependencies for all search dir now.

### DIFF
--- a/golist.go
+++ b/golist.go
@@ -8,9 +8,39 @@ import (
 	"go/build"
 	"os/exec"
 	"path/filepath"
+	"slices"
 )
 
-func listPackages(ctx context.Context, dir string, env []string, args ...string) (pkgs []*build.Package, finalErr error) {
+func listPackages(ctx context.Context, dirs []string, env []string, args ...string) ([]*build.Package, error) {
+	pkgMap := make(map[string]*build.Package)
+	for i, dir := range dirs {
+		pkgs, err := listOnePackages(ctx, dir, env, args...)
+		if err != nil {
+			if i == 0 {
+				return nil, fmt.Errorf("pkg %s cannot find all dependencies, %s", dir, err)
+			}
+			continue // ignore search dir load error?
+		}
+		for _, pkg := range pkgs {
+			pkgMap[pkg.Dir] = pkg
+		}
+	}
+	pkgs := make([]*build.Package, 0, len(pkgMap))
+	for _, pkg := range pkgMap {
+		pkgs = append(pkgs, pkg)
+	}
+	slices.SortFunc(pkgs, func(a, b *build.Package) int {
+		if a.Dir < b.Dir {
+			return -1
+		} else if a.Dir > b.Dir {
+			return 1
+		}
+		return 0
+	})
+	return pkgs, nil
+}
+
+func listOnePackages(ctx context.Context, dir string, env []string, args ...string) (pkgs []*build.Package, finalErr error) {
 	cmd := exec.CommandContext(ctx, "go", append([]string{"list", "-json", "-e"}, args...)...)
 	cmd.Env = env
 	cmd.Dir = dir

--- a/golist_test.go
+++ b/golist_test.go
@@ -42,7 +42,7 @@ func TestListPackages(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := listPackages(context.TODO(), c.searchDir, nil, c.args...)
+			_, err := listOnePackages(context.TODO(), c.searchDir, nil, c.args...)
 			if c.except != nil {
 				assert.NotNil(t, err)
 			} else {


### PR DESCRIPTION
if all dependecies were not loaded before parseTypes, every step for parseTypes/collectionConst may load new packages. it's will break uniqueness checking

**Describe the PR**
parseDependency parses all dependencies for all search dir now.

**Relation issue**
e.g. https://github.com/swaggo/swag/pull/118/files

**Additional context**
it may slow down if there are large number of deps or searchDir.

I will make a new PR to load dir in batch for better performance