### PR TITLE
fix: parse oct const error

### DIFF
--- a/enums_test.go
+++ b/enums_test.go
@@ -33,6 +33,7 @@ func TestParseGlobalEnums(t *testing.T) {
 	assert.Equal(t, "aa\nbb\u8888cc", p.packages.packages[constsPath].ConstTable["escapestr"].Value)
 	assert.Equal(t, 1_000_000, p.packages.packages[constsPath].ConstTable["underscored"].Value)
 	assert.Equal(t, 0b10001000, p.packages.packages[constsPath].ConstTable["binaryInteger"].Value)
+	assert.Equal(t, 0o755, p.packages.packages[constsPath].ConstTable["octInteger"].Value)
 
 	typesPath := "github.com/swaggo/swag/testdata/enums/types"
 

--- a/package.go
+++ b/package.go
@@ -5,7 +5,6 @@ import (
 	"go/token"
 	"reflect"
 	"strconv"
-	"strings"
 )
 
 // PackageDefinitions files and definition in a package.
@@ -100,36 +99,10 @@ func (pkg *PackageDefinitions) evaluateConstValue(file *ast.File, iota int, expr
 	case *ast.BasicLit:
 		switch valueExpr.Kind {
 		case token.INT:
-			// handle underscored number, such as 1_000_000
-			if strings.ContainsRune(valueExpr.Value, '_') {
-				valueExpr.Value = strings.Replace(valueExpr.Value, "_", "", -1)
-			}
-			if len(valueExpr.Value) >= 2 && valueExpr.Value[0] == '0' {
-				var start, base = 2, 8
-				switch valueExpr.Value[1] {
-				case 'x', 'X':
-					//hex
-					base = 16
-				case 'b', 'B':
-					//binary
-					base = 2
-				default:
-					//octet
-					start = 1
-				}
-				if x, err := strconv.ParseInt(valueExpr.Value[start:], base, 64); err == nil {
-					return int(x), nil
-				} else if x, err := strconv.ParseUint(valueExpr.Value[start:], base, 64); err == nil {
-					return x, nil
-				} else {
-					panic(err)
-				}
-			}
-
 			//a basic literal integer is int type in default, or must have an explicit converting type in front
-			if x, err := strconv.ParseInt(valueExpr.Value, 10, 64); err == nil {
+			if x, err := strconv.ParseInt(valueExpr.Value, 0, 64); err == nil {
 				return int(x), nil
-			} else if x, err := strconv.ParseUint(valueExpr.Value, 10, 64); err == nil {
+			} else if x, err := strconv.ParseUint(valueExpr.Value, 0, 64); err == nil {
 				return x, nil
 			} else {
 				panic(err)

--- a/testdata/enums/consts/const.go
+++ b/testdata/enums/consts/const.go
@@ -12,3 +12,4 @@ const escapestr = "aa\nbb\u8888cc"
 const escapechar = '\u8888'
 const underscored = 1_000_000
 const binaryInteger = 0b10001000
+const octInteger = 0o755


### PR DESCRIPTION
strconv.ParseInt can handle integer literal correctly with base=0.

**Describe the PR**
parse integer literal by `strconv.ParseInt` directly

**Relation issue**
Fixes #1614

**Additional context**

