### PR TITLE
perf: make fmt parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/spec v0.20.4
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/sync v0.12.0
 	golang.org/x/text v0.23.0
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d
 	sigs.k8s.io/yaml v1.3.0


### PR DESCRIPTION
**Describe the PR**
use errgroup to parallelize fmt process.

**Relation issue**
#1927 import goimports which make fmt much slow than before

**Additional context**

