### PR TITLE
feat: try use packages API resolve const value

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/sync v0.12.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/package.go
+++ b/package.go
@@ -5,6 +5,8 @@ import (
 	"go/token"
 	"reflect"
 	"strconv"
+
+	"golang.org/x/tools/go/packages"
 )
 
 // PackageDefinitions files and definition in a package.
@@ -26,6 +28,8 @@ type PackageDefinitions struct {
 
 	// package path
 	Path string
+
+	Package *packages.Package
 }
 
 // ConstVariableGlobalEvaluator an interface used to evaluate enums across packages

--- a/parsergopackages.go
+++ b/parsergopackages.go
@@ -61,6 +61,8 @@ func (parser *Parser) loadPackagesAndDeps(searchDirs []string, absMainAPIFilePat
 		}
 		return nil
 	})
+
+	parser.packages.AddPackages(pkgs)
 	return err
 }
 


### PR DESCRIPTION
**Describe the PR**
if swag init with `--parseGoPackages` flag, using packages API resolve constant variables.
it can fix all warning about `failed to evaluate const`.

**Relation issue**
#1922 #1819 #1614 #1519

**Additional context**

