### PR TITLE
feat: add warning for types which has MarshalJSON method

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1288,6 +1288,8 @@ func (parser *Parser) getTypeSchema(typeName string, file *ast.File, ref bool) (
 		typeSpecDef = parser.packages.findTypeSpec(override[0:separator], override[separator+1:])
 	}
 
+	parser.packages.CheckTypeSpec(typeSpecDef)
+
 	schema, ok := parser.parsedSchemas[typeSpecDef]
 	if !ok {
 		var err error


### PR DESCRIPTION
**Describe the PR**
when some model type has `MarshalJSON` method, it means that it will be marshaled same with it's original data type.
so we need pick them up.

**Relation issue**


**Additional context**

