### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/const.go
+++ b/const.go
@@ -13,7 +13,7 @@ import (
 type ConstVariable struct {
 	Name    *ast.Ident
 	Type    ast.Expr
-	Value   interface{}
+	Value   any
 	Comment string
 	File    *ast.File
 	Pkg     *PackageDefinitions
@@ -101,7 +101,7 @@ func EvaluateEscapedString(text string) string {
 }
 
 // EvaluateDataConversion evaluate the type a explicit type conversion
-func EvaluateDataConversion(x interface{}, typeName string) interface{} {
+func EvaluateDataConversion(x any, typeName string) any {
 	switch value := x.(type) {
 	case int:
 		switch typeName {
@@ -385,7 +385,7 @@ func EvaluateDataConversion(x interface{}, typeName string) interface{} {
 }
 
 // EvaluateUnary evaluate the type and value of a unary expression
-func EvaluateUnary(x interface{}, operator token.Token, xtype ast.Expr) (interface{}, ast.Expr) {
+func EvaluateUnary(x any, operator token.Token, xtype ast.Expr) (any, ast.Expr) {
 	switch operator {
 	case token.SUB:
 		switch value := x.(type) {
@@ -428,7 +428,7 @@ func EvaluateUnary(x interface{}, operator token.Token, xtype ast.Expr) (interfa
 }
 
 // EvaluateBinary evaluate the type and value of a binary expression
-func EvaluateBinary(x, y interface{}, operator token.Token, xtype, ytype ast.Expr) (interface{}, ast.Expr) {
+func EvaluateBinary(x, y any, operator token.Token, xtype, ytype ast.Expr) (any, ast.Expr) {
 	if operator == token.SHR || operator == token.SHL {
 		var rightOperand uint64
 		yValue := reflect.ValueOf(y)

--- a/enums.go
+++ b/enums.go
@@ -9,6 +9,6 @@ const (
 // EnumValue a model to record an enum consts variable
 type EnumValue struct {
 	key     string
-	Value   interface{}
+	Value   any
 	Comment string
 }

--- a/field_parser.go
+++ b/field_parser.go
@@ -184,9 +184,9 @@ type structField struct {
 	minLength    *int64
 	maxItems     *int64
 	minItems     *int64
-	exampleValue interface{}
-	enums        []interface{}
-	enumVarNames []interface{}
+	exampleValue any
+	enums        []any
+	enumVarNames []any
 	unique       bool
 }
 
@@ -443,13 +443,13 @@ func (ps *tagBaseFieldParser) complementSchema(schema *spec.Schema, types []stri
 		if field.schemaType == ARRAY {
 			// Add the var names in the items schema
 			if schema.Items.Schema.Extensions == nil {
-				schema.Items.Schema.Extensions = map[string]interface{}{}
+				schema.Items.Schema.Extensions = map[string]any{}
 			}
 			schema.Items.Schema.Extensions[enumVarNamesExtension] = field.enumVarNames
 		} else {
 			// Add to top level schema
 			if schema.Extensions == nil {
-				schema.Extensions = map[string]interface{}{}
+				schema.Extensions = map[string]any{}
 			}
 			schema.Extensions[enumVarNamesExtension] = field.enumVarNames
 		}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -31,8 +31,8 @@ type genTypeWriter func(*Config, *spec.Swagger) error
 
 // Gen presents a generate tool for swag.
 type Gen struct {
-	json          func(data interface{}) ([]byte, error)
-	jsonIndent    func(data interface{}) ([]byte, error)
+	json          func(data any) ([]byte, error)
+	jsonIndent    func(data any) ([]byte, error)
 	jsonToYAML    func(data []byte) ([]byte, error)
 	outputTypeMap map[string]genTypeWriter
 	debug         Debugger
@@ -40,14 +40,14 @@ type Gen struct {
 
 // Debugger is the interface that wraps the basic Printf method.
 type Debugger interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // New creates a new Gen.
 func New() *Gen {
 	gen := Gen{
 		json: json.Marshal,
-		jsonIndent: func(data interface{}) ([]byte, error) {
+		jsonIndent: func(data any) ([]byte, error) {
 			return json.MarshalIndent(data, "", "    ")
 		},
 		jsonToYAML: yaml.JSONToYAML,

--- a/operation.go
+++ b/operation.go
@@ -174,7 +174,7 @@ func (operation *Operation) ParseCodeSample(attribute, _, lineRemainder string) 
 			return err
 		}
 
-		var valueJSON interface{}
+		var valueJSON any
 
 		err = json.Unmarshal(data, &valueJSON)
 		if err != nil {
@@ -215,7 +215,7 @@ func (operation *Operation) ParseMetadata(attribute, lowerAttribute, lineRemaind
 			return fmt.Errorf("annotation %s need a value", attribute)
 		}
 
-		var valueJSON interface{}
+		var valueJSON any
 
 		err := json.Unmarshal([]byte(lineRemainder), &valueJSON)
 		if err != nil {
@@ -269,7 +269,7 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 		objectType = PRIMITIVE
 	}
 
-	var enums []interface{}
+	var enums []any
 	if !IsPrimitiveType(refType) {
 		schema, _ := operation.parser.getTypeSchema(refType, astFile, false)
 		if schema != nil && len(schema.Type) == 1 && schema.Enum != nil {
@@ -646,7 +646,7 @@ func setExample(param *spec.Parameter, schemaType string, value string) error {
 }
 
 // defineType enum value define the type (object and array unsupported).
-func defineType(schemaType string, value string) (v interface{}, err error) {
+func defineType(schemaType string, value string) (v any, err error) {
 	schemaType = TransToValidSchemeType(schemaType)
 
 	switch schemaType {
@@ -1186,7 +1186,7 @@ func (operation *Operation) AddResponse(code int, response *spec.Response) {
 }
 
 // createParameter returns swagger spec.Parameter for given  paramType, description, paramName, schemaType, required.
-func createParameter(paramType, description, paramName, objectType, schemaType string, format string, required bool, enums []interface{}, collectionFormat string) spec.Parameter {
+func createParameter(paramType, description, paramName, objectType, schemaType string, format string, required bool, enums []any, collectionFormat string) spec.Parameter {
 	// //five possible parameter types. 	query, path, body, header, form
 	result := spec.Parameter{
 		ParamProps: spec.ParamProps{

--- a/package.go
+++ b/package.go
@@ -34,8 +34,8 @@ type PackageDefinitions struct {
 
 // ConstVariableGlobalEvaluator an interface used to evaluate enums across packages
 type ConstVariableGlobalEvaluator interface {
-	EvaluateConstValue(pkg *PackageDefinitions, cv *ConstVariable, recursiveStack map[string]struct{}) (interface{}, ast.Expr)
-	EvaluateConstValueByName(file *ast.File, pkgPath, constVariableName string, recursiveStack map[string]struct{}) (interface{}, ast.Expr)
+	EvaluateConstValue(pkg *PackageDefinitions, cv *ConstVariable, recursiveStack map[string]struct{}) (any, ast.Expr)
+	EvaluateConstValueByName(file *ast.File, pkgPath, constVariableName string, recursiveStack map[string]struct{}) (any, ast.Expr)
 	FindTypeSpec(typeName string, file *ast.File) *TypeSpecDef
 }
 
@@ -83,7 +83,7 @@ func (pkg *PackageDefinitions) AddConst(astFile *ast.File, valueSpec *ast.ValueS
 	return pkg
 }
 
-func (pkg *PackageDefinitions) evaluateConstValue(file *ast.File, iota int, expr ast.Expr, globalEvaluator ConstVariableGlobalEvaluator, recursiveStack map[string]struct{}) (interface{}, ast.Expr) {
+func (pkg *PackageDefinitions) evaluateConstValue(file *ast.File, iota int, expr ast.Expr, globalEvaluator ConstVariableGlobalEvaluator, recursiveStack map[string]struct{}) (any, ast.Expr) {
 	switch valueExpr := expr.(type) {
 	case *ast.Ident:
 		if valueExpr.Name == "iota" {

--- a/packages.go
+++ b/packages.go
@@ -56,7 +56,7 @@ func (pkgDefs *PackagesDefinitions) AddPackages(pkgs []*packages.Package) {
 }
 
 // ParseFile parse a source file.
-func (pkgDefs *PackagesDefinitions) ParseFile(packageDir, path string, src interface{}, flag ParseFlag) error {
+func (pkgDefs *PackagesDefinitions) ParseFile(packageDir, path string, src any, flag ParseFlag) error {
 	// positions are relative to FileSet
 	fileSet := token.NewFileSet()
 	astFile, err := goparser.ParseFile(fileSet, path, src, goparser.ParseComments)
@@ -406,7 +406,7 @@ func tryParseTypeFromPackage(pkg *packages.Package, constObj *types.Const) ast.E
 }
 
 // EvaluateConstValue evaluate a const variable.
-func (pkgDefs *PackagesDefinitions) EvaluateConstValue(pkg *PackageDefinitions, cv *ConstVariable, recursiveStack map[string]struct{}) (interface{}, ast.Expr) {
+func (pkgDefs *PackagesDefinitions) EvaluateConstValue(pkg *PackageDefinitions, cv *ConstVariable, recursiveStack map[string]struct{}) (any, ast.Expr) {
 	if pkg.Package != nil {
 		obj := pkg.Package.Types.Scope().Lookup(cv.Name.Name)
 		if obj != nil {
@@ -450,7 +450,7 @@ func (pkgDefs *PackagesDefinitions) EvaluateConstValue(pkg *PackageDefinitions, 
 }
 
 // EvaluateConstValueByName evaluate a const variable by name.
-func (pkgDefs *PackagesDefinitions) EvaluateConstValueByName(file *ast.File, pkgName, constVariableName string, recursiveStack map[string]struct{}) (interface{}, ast.Expr) {
+func (pkgDefs *PackagesDefinitions) EvaluateConstValueByName(file *ast.File, pkgName, constVariableName string, recursiveStack map[string]struct{}) (any, ast.Expr) {
 	matchedPkgPaths, externalPkgPaths := pkgDefs.findPackagePathFromImports(pkgName, file)
 	for _, pkgPath := range matchedPkgPaths {
 		if pkg, ok := pkgDefs.packages[pkgPath]; ok {

--- a/parser.go
+++ b/parser.go
@@ -211,7 +211,7 @@ type FieldParser interface {
 
 // Debugger is the interface that wraps the basic Printf method.
 type Debugger interface {
-	Printf(format string, v ...interface{})
+	Printf(format string, v ...any)
 }
 
 // New creates a new Parser with default properties.
@@ -695,7 +695,7 @@ func parseGeneralAPIInfo(parser *Parser, comments []string) error {
 					return fmt.Errorf("annotation %s need a value", attribute)
 				}
 
-				var valueJSON interface{}
+				var valueJSON any
 				err := json.Unmarshal([]byte(value), &valueJSON)
 				if err != nil {
 					return fmt.Errorf("annotation %s need a valid json value", attribute)
@@ -705,7 +705,7 @@ func parseGeneralAPIInfo(parser *Parser, comments []string) error {
 					parser.swagger.Info.Extensions.Add(extensionName, valueJSON)
 				} else {
 					if parser.swagger.Extensions == nil {
-						parser.swagger.Extensions = make(map[string]interface{})
+						parser.swagger.Extensions = make(map[string]any)
 					}
 
 					parser.swagger.Extensions[attribute[1:]] = valueJSON
@@ -718,7 +718,7 @@ func parseGeneralAPIInfo(parser *Parser, comments []string) error {
 				}
 
 				if tag.Extensions == nil {
-					tag.Extensions = make(map[string]interface{})
+					tag.Extensions = make(map[string]any)
 				}
 
 				// tag.Extensions.Add(extensionName, value) works wrong (transforms extensionName to lower case)
@@ -788,7 +788,7 @@ func parseSecAttributes(context string, lines []string, index *int) (*spec.Secur
 	*index++
 
 	attrMap, scopes := make(map[string]string), make(map[string]string)
-	extensions, description := make(map[string]interface{}), ""
+	extensions, description := make(map[string]any), ""
 
 loopline:
 	for ; *index < len(lines); *index++ {
@@ -1823,7 +1823,7 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 		return v, nil
 	case ARRAY:
 		values := strings.Split(exampleValue, ",")
-		result := make([]interface{}, 0)
+		result := make([]any, 0)
 		for _, value := range values {
 			v, err := defineTypeOfExample(arrayType, "", value)
 			if err != nil {
@@ -1841,7 +1841,7 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 
 		values := strings.Split(exampleValue, ",")
 
-		result := map[string]interface{}{}
+		result := map[string]any{}
 
 		for _, value := range values {
 			mapData := strings.SplitN(value, ":", 2)
@@ -1939,7 +1939,7 @@ func (parser *Parser) getAllGoFileInfoFromDeps(pkg *depth.Pkg, parseFlag ParseFl
 	return nil
 }
 
-func (parser *Parser) parseFile(packageDir, path string, src interface{}, flag ParseFlag) error {
+func (parser *Parser) parseFile(packageDir, path string, src any, flag ParseFlag) error {
 	if strings.HasSuffix(strings.ToLower(path), "_test.go") || filepath.Ext(path) != ".go" {
 		return nil
 	}

--- a/spec.go
+++ b/spec.go
@@ -26,12 +26,12 @@ func (i *Spec) ReadDoc() string {
 	i.Description = strings.ReplaceAll(i.Description, "\n", "\\n")
 
 	tpl := template.New("swagger_info").Funcs(template.FuncMap{
-		"marshal": func(v interface{}) string {
+		"marshal": func(v any) string {
 			a, _ := json.Marshal(v)
 
 			return string(a)
 		},
-		"escape": func(v interface{}) string {
+		"escape": func(v any) string {
 			// escape tabs
 			var str = strings.ReplaceAll(v.(string), "\t", "\\t")
 			// replace " with \", and if that results in \\", replace that with \\\"


### PR DESCRIPTION
Replace `interface{}` with `any` type alias for Go 1.18+ style consistency.

No functional changes.