### PR TITLE
fix: support empty object example value for map[string]struct{}

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1835,6 +1835,11 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 
 		return result, nil
 	case OBJECT:
+		// Handle empty object "{}" as a special case
+		if exampleValue == "{}" {
+			return map[string]any{}, nil
+		}
+
 		if arrayType == "" {
 			return nil, fmt.Errorf("%s is unsupported type in example value `%s`", schemaType, exampleValue)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3924,7 +3924,12 @@ func TestDefineTypeOfExample(t *testing.T) {
 	t.Run("Object type", func(t *testing.T) {
 		t.Parallel()
 
-		example, err := defineTypeOfExample("object", "", "key_one:one,key_two:two,key_three:three")
+		// Test empty object "{}" - issue #2018
+		example, err := defineTypeOfExample("object", "", "{}")
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]any{}, example)
+
+		example, err = defineTypeOfExample("object", "", "key_one:one,key_two:two,key_three:three")
 		assert.Error(t, err)
 		assert.Nil(t, example)
 
@@ -3945,6 +3950,13 @@ func TestDefineTypeOfExample(t *testing.T) {
 		}
 
 		assert.Equal(t, obj, map[string]string{"key_one": "one", "key_two": "two", "key_three": "three"})
+
+		// Test map[string]struct{} with empty object values - issue #2018
+		example, err = defineTypeOfExample("object", "object", "key1:{},key2:{}")
+		assert.NoError(t, err)
+		objMap := example.(map[string]interface{})
+		assert.Equal(t, map[string]any{}, objMap["key1"])
+		assert.Equal(t, map[string]any{}, objMap["key2"])
 	})
 
 	t.Run("Invalid type", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds support for parsing `{}` as an empty object in example values
- Fixes the error `object is unsupported type in example value {}` when using `map[string]struct{}` with examples

## Problem

When using a `map[string]struct{}` field with swaggertype and example tags:

```go
type Response struct {
    MyField map[string]struct{} `json:"my_field" swaggertype:"object,object" example:"key1:{},key2:{}"`
}
```

The parser would fail with:
```
object is unsupported type in example value `{}`
```

## Solution

Added a special case in `defineTypeOfExample` to handle empty object `{}` as a valid example value, returning an empty `map[string]any{}`.

## Test plan

- [x] Added unit tests for empty object parsing
- [x] Added unit tests for `map[string]struct{}` with empty object values
- [x] All existing tests pass

Fixes #2018