### PR TITLE
fix: prevent panic when parsing custom string types in OpenAPI v3

### DIFF
--- a/parserv3.go
+++ b/parserv3.go
@@ -1048,7 +1048,7 @@ func (p *Parser) parseStructFieldV3(file *ast.File, field *ast.Field) (map[strin
 		tagRequired = append(tagRequired, fieldName)
 	}
 
-	if formName := ps.FormName(); len(formName) > 0 {
+	if formName := ps.FormName(); len(formName) > 0 && schema != nil && schema.Spec != nil {
 		if schema.Spec.Extensions == nil {
 			schema.Spec.Extensions = make(map[string]any)
 		}


### PR DESCRIPTION
**Describe the PR**
Prevent panic when parsing custom string types with form tags in OpenAPI v3

**Relation issue**
Fixing https://github.com/swaggo/swag/issues/2114 and probably https://github.com/swaggo/swag/issues/2078

