### PR TITLE
fix: swag fmt not working with relative path like ../

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -87,9 +87,10 @@ func (f *Format) Build(config *Config) error {
 }
 
 func (f *Format) excludeDir(path string) bool {
-	return f.exclude[path] ||
-		filepath.Base(path)[0] == '.' &&
-			len(filepath.Base(path)) > 1 // exclude hidden folders
+	base := filepath.Base(path)
+	// exclude hidden folders (starting with .) but not "." or ".."
+	isHidden := len(base) > 1 && base[0] == '.' && base != ".."
+	return f.exclude[path] || isHidden
 }
 
 func (f *Format) excludeFile(path string) bool {

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -79,6 +79,29 @@ func TestFormat_InvalidSearchDir(t *testing.T) {
 	assert.Error(t, formatter.Build(&Config{SearchDir: "no_such_dir"}))
 }
 
+func TestFormat_RelativePath(t *testing.T) {
+	fx := setup(t)
+	// Create a subdirectory and run format from there with relative path
+	subdir := filepath.Join(fx.basedir, "subdir")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change to subdirectory and format parent with relative path
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(subdir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	assert.NoError(t, New().Build(&Config{SearchDir: ".."}))
+	assert.True(t, fx.isFormatted("main.go"))
+	assert.True(t, fx.isFormatted("api/api.go"))
+}
+
 type fixture struct {
 	t       *testing.T
 	basedir string


### PR DESCRIPTION
## Summary
- Fix `swag fmt --dir ../` not formatting files when using relative parent path
- The `excludeDir` function incorrectly treated `..` as a hidden folder because it checked if path starts with `.` and has length > 1

## Changes
- Modified hidden folder detection to exclude `..` from being treated as hidden
- Added test case for relative path formatting

Fixes #2112