### PR TITLE
bugfix: parse generic parameterized enum constants

### DIFF
--- a/enums_test.go
+++ b/enums_test.go
@@ -45,6 +45,14 @@ func TestParseGlobalEnums(t *testing.T) {
 	assert.Equal(t, "DifficultyHard", difficultyEnums[2].key)
 	assert.Equal(t, "This means really hard", difficultyEnums[2].Comment)
 
+	genericDifficultyEnums := p.packages.packages[typesPath].TypeDefinitions["GenericDifficulty"].Enums
+	assert.Equal(t, "GenericEasy", genericDifficultyEnums[0].key)
+	assert.Equal(t, "", genericDifficultyEnums[0].Comment)
+	assert.Equal(t, "GenericMedium", genericDifficultyEnums[1].key)
+	assert.Equal(t, "This one also has a comment", genericDifficultyEnums[1].Comment)
+	assert.Equal(t, "GenericDifficultyHard", genericDifficultyEnums[2].key)
+	assert.Equal(t, "This means really hard", genericDifficultyEnums[2].Comment)
+
 	securityLevelEnums := p.packages.packages[typesPath].TypeDefinitions["SecurityClearance"].Enums
 	assert.Equal(t, "Public", securityLevelEnums[0].key)
 	assert.Equal(t, "", securityLevelEnums[0].Comment)

--- a/generics.go
+++ b/generics.go
@@ -183,6 +183,7 @@ func (pkgDefs *PackagesDefinitions) parametrizeGenericType(file *ast.File, origi
 	parametrizedTypeSpec := &TypeSpecDef{
 		File:    original.File,
 		PkgPath: original.PkgPath,
+		Enums:   original.Enums,
 		TypeSpec: &ast.TypeSpec{
 			Name: &ast.Ident{
 				Name:    name,

--- a/packages.go
+++ b/packages.go
@@ -479,10 +479,28 @@ func (pkgDefs *PackagesDefinitions) collectConstEnums(parsedSchemas map[*TypeSpe
 			if constVar.Type == nil {
 				continue
 			}
-			ident, ok := constVar.Type.(*ast.Ident)
+
+			var (
+				ident *ast.Ident
+				ok    bool
+			)
+
+			switch expr := constVar.Type.(type) {
+			case *ast.IndexExpr:
+				ident, ok = expr.X.(*ast.Ident)
+			case *ast.IndexListExpr:
+				ident, ok = expr.X.(*ast.Ident)
+			case *ast.Ident:
+				ident = expr
+				ok = true
+			default:
+				continue
+			}
+
 			if !ok || IsGolangPrimitiveType(ident.Name) {
 				continue
 			}
+
 			typeDef, ok := pkg.TypeDefinitions[ident.Name]
 			if !ok {
 				continue

--- a/testdata/enums/expected.json
+++ b/testdata/enums/expected.json
@@ -147,6 +147,30 @@
                     },
                     {
                         "enum": [
+                            "g_easy",
+                            "g_medium",
+                            "g_hard"
+                        ],
+                        "type": "string",
+                        "x-enum-comments": {
+                            "GenericDifficultyHard": "This means really hard",
+                            "GenericMedium": "This one also has a comment"
+                        },
+                        "x-enum-descriptions": [
+                            "",
+                            "This one also has a comment",
+                            "This means really hard"
+                        ],
+                        "x-enum-varnames": [
+                            "GenericEasy",
+                            "GenericMedium",
+                            "GenericDifficultyHard"
+                        ],
+                        "name": "genericDifficulty",
+                        "in": "formData"
+                    },
+                    {
+                        "enum": [
                             1,
                             2,
                             4,
@@ -291,6 +315,19 @@
                         "type": "array",
                         "items": {
                             "enum": [
+                                "g_easy",
+                                "g_medium",
+                                "g_hard"
+                            ],
+                            "type": "string"
+                        },
+                        "name": "genericDifficulty",
+                        "in": "formData"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "enum": [
                                 1,
                                 2,
                                 4,
@@ -408,6 +445,28 @@
                 "DifficultyHard"
             ]
         },
+        "types.GenericDifficulty-types_Level": {
+            "type": "string",
+            "enum": [
+                "g_easy",
+                "g_medium",
+                "g_hard"
+            ],
+            "x-enum-comments": {
+                "GenericDifficultyHard": "This means really hard",
+                "GenericMedium": "This one also has a comment"
+            },
+            "x-enum-descriptions": [
+                "",
+                "This one also has a comment",
+                "This means really hard"
+            ],
+            "x-enum-varnames": [
+                "GenericEasy",
+                "GenericMedium",
+                "GenericDifficultyHard"
+            ]
+        },
         "types.Mask": {
             "type": "integer",
             "enum": [
@@ -446,6 +505,9 @@
                 },
                 "difficulty": {
                     "$ref": "#/definitions/types.Difficulty"
+                },
+                "genericDifficulty": {
+                    "$ref": "#/definitions/types.GenericDifficulty-types_Level"
                 },
                 "mask": {
                     "$ref": "#/definitions/types.Mask"

--- a/testdata/enums/types/model.go
+++ b/testdata/enums/types/model.go
@@ -68,6 +68,17 @@ const (
 	SecurityClearanceSecret                             // @name SuperSecret This one has a name override and a comment
 )
 
+type (
+	GenericDifficulty[T any] string
+	Level                    int
+)
+
+const (
+	GenericDifficultyEasy   GenericDifficulty[Level] = "g_easy"   // @name GenericEasy
+	GenericDifficultyMedium GenericDifficulty[Level] = "g_medium" // @name GenericMedium This one also has a comment
+	GenericDifficultyHard   GenericDifficulty[Level] = "g_hard"   // This means really hard
+)
+
 type Person struct {
 	Name              string
 	Class             Class
@@ -75,6 +86,7 @@ type Person struct {
 	Type              Type
 	Sex               Sex
 	Difficulty        Difficulty
+	GenericDifficulty GenericDifficulty[Level]
 	SecurityClearance SecurityClearance
 }
 
@@ -83,6 +95,7 @@ type PersonWithArrayEnum struct {
 	Class             []Class
 	Mask              []Mask
 	Difficulty        []Difficulty
+	GenericDifficulty []GenericDifficulty[Level]
 	SecurityClearance []SecurityClearance
 	Type              Type
 }


### PR DESCRIPTION
**Describe the PR**
While parsing generic enum types, the parser does not set enums for these types. And due to this, in the generated swagger spec, there are not any enumerations for generic type. Instead the type converted into primitive type.

**Relation issue**
Fixes https://github.com/swaggo/swag/issues/2116
