### PR TITLE
fix: deduplicate enum values (#1888)

### DIFF
--- a/testdata/enums_duplicate/expected.json
+++ b/testdata/enums_duplicate/expected.json
@@ -1,0 +1,49 @@
+{
+    "schemes": [
+        "http"
+    ],
+    "swagger": "2.0",
+    "info": {
+        "description": "Test API for enum deduplication and @swaggerignore",
+        "title": "Enum Deduplication API",
+        "contact": {},
+        "version": "1.0"
+    },
+    "host": "localhost:8080",
+    "basePath": "/api/v1",
+    "paths": {
+        "/language": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get a language",
+                "parameters": [
+                    {
+                        "enum": [
+                            "EN",
+                            "DE",
+                            "ZH"
+                        ],
+                        "type": "string",
+                        "description": "Language parameter",
+                        "name": "language",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testdata/enums_duplicate/main.go
+++ b/testdata/enums_duplicate/main.go
@@ -1,0 +1,24 @@
+// Package main for enums_duplicate tests
+// @title Enum Deduplication API
+// @version 1.0
+// @description Test API for enum deduplication and @swaggerignore
+// @host localhost:8080
+// @basePath /api/v1
+// @schemes http
+package main
+
+import "github.com/swaggo/swag/testdata/enums_duplicate/types"
+
+// GetLanguage retrieves a language
+// @Summary Get a language
+// @Accept json
+// @Produce json
+// @Param language query types.Language true "Language parameter"
+// @Success 200 {string} types.Language
+// @Router /language [get]
+func GetLanguage(language types.Language) string {
+	return string(language)
+}
+
+func main() {
+}

--- a/testdata/enums_duplicate/types/model.go
+++ b/testdata/enums_duplicate/types/model.go
@@ -1,0 +1,17 @@
+package types
+
+// Language represents supported languages
+type Language string
+
+const (
+	// English language
+	En Language = "EN"
+	// German language
+	De Language = "DE"
+	// Chinese language
+	Zh Language = "ZH"
+	// DefaultLanguage is an alias for English (should be excluded via deduplication)
+	DefaultLanguage = En
+	// @swaggerignore
+	Fr Language = "FR"
+)


### PR DESCRIPTION
**Describe the PR**

Resolves duplicate enum creations and allows the ability to ignore constants

**Relation issue**

https://github.com/swaggo/swag/issues/1888

**Additional context**

I'm not a great go programmer, so relied heavily on copy pasting from the existing test code. 