### PR TITLE
fix: use modfile to get module name when go.mod exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-openapi/spec v0.22.1
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/mod v0.21.0
 	golang.org/x/sync v0.12.0
 	golang.org/x/text v0.23.0
 	golang.org/x/tools v0.26.0
@@ -29,7 +30,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/mod v0.21.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/parser.go
+++ b/parser.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/KyleBanks/depth"
 	"github.com/go-openapi/spec"
+	"golang.org/x/mod/modfile"
 )
 
 const (
@@ -500,6 +501,18 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 }
 
 func getPkgName(searchDir string) (string, error) {
+	// If go.mod exists in the search directory, parse it to get the module name.
+	// This avoids errors when there are no Go files in the directory.
+	gomodPath := filepath.Join(searchDir, "go.mod")
+	if data, err := os.ReadFile(gomodPath); err == nil {
+		modFile, err := modfile.Parse(gomodPath, data, nil)
+		if err != nil {
+			return "", fmt.Errorf("parse go.mod: %w", err)
+		}
+
+		return modFile.Module.Mod.Path, nil
+	}
+
 	cmd := exec.Command("go", "list", "-f={{.ImportPath}}")
 	cmd.Dir = searchDir
 
@@ -512,7 +525,7 @@ func getPkgName(searchDir string) (string, error) {
 		return "", fmt.Errorf("execute go list command, %s, stdout:%s, stderr:%s", err, stdout.String(), stderr.String())
 	}
 
-	outStr, _ := stdout.String(), stderr.String()
+	outStr := stdout.String()
 
 	if outStr[0] == '_' { // will shown like _/{GOPATH}/src/{YOUR_PACKAGE} when NOT enable GO MODULE.
 		outStr = strings.TrimPrefix(outStr, "_"+build.Default.GOPATH+"/src/")

--- a/parser_test.go
+++ b/parser_test.go
@@ -4628,3 +4628,56 @@ type LinkedNode struct {
 		assert.NotContains(t, name, "api.LinkedNode")
 	}
 }
+
+func TestGetPkgName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		searchDir string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "with go.mod in directory",
+			searchDir: "testdata/gomod_no_root_go_files",
+			want:      "example.com/gomod_no_root_go_files",
+			wantErr:   false,
+		},
+		{
+			name:      "with go files in directory",
+			searchDir: "testdata/simple",
+			want:      "github.com/swaggo/swag/testdata/simple",
+			wantErr:   false,
+		},
+		{
+			name:      "non-existent directory",
+			searchDir: "testdata/non_existent",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := getPkgName(tt.searchDir)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseGoModWithoutRootGoFiles(t *testing.T) {
+	t.Parallel()
+
+	p := New()
+	err := p.ParseAPI("testdata/gomod_no_root_go_files", "cmd/main.go", defaultParseDepth)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test API", p.swagger.Info.Title)
+}

--- a/testdata/gomod_no_root_go_files/cmd/main.go
+++ b/testdata/gomod_no_root_go_files/cmd/main.go
@@ -1,0 +1,26 @@
+package main
+
+import "net/http"
+
+// @title Test API
+// @version 1.0
+// @description Test API for go.mod without root Go files
+
+// @host localhost:8080
+// @BasePath /api/v1
+func main() {
+	http.HandleFunc("/test", testHandler)
+	http.ListenAndServe(":8080", nil)
+}
+
+// testHandler handles test requests
+// @Summary Test endpoint
+// @Description Returns a test response
+// @Tags test
+// @Accept json
+// @Produce json
+// @Success 200 {string} string "OK"
+// @Router /test [get]
+func testHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
+}

--- a/testdata/gomod_no_root_go_files/go.mod
+++ b/testdata/gomod_no_root_go_files/go.mod
@@ -1,0 +1,3 @@
+module example.com/gomod_no_root_go_files
+
+go 1.25.0


### PR DESCRIPTION
**Describe the PR**

This PR fixes the warning that occurs when running `swag init` in a project where `go.mod` exists but there are no Go files in the root directory.

**Before:** When the search directory contains `go.mod` but no `.go` files, `go list -f={{.ImportPath}}` fails and produces a warning:
```
warning: failed to get package name in dir: ./, error: execute go list command, exit status 1, stdout:, stderr:no Go files in /path/to/project
```

**After:** The module name is parsed directly from `go.mod` using `golang.org/x/mod/modfile`, avoiding the need for Go files in the root directory.

Changes:
- Modified `getPkgName()` to first check if `go.mod` exists in the search directory
- If `go.mod` exists, parse it directly using `golang.org/x/mod/modfile` to get the module name
- Fall back to the original `go list -f={{.ImportPath}}` behavior when `go.mod` is not present
- Added unit tests for `getPkgName()` function
- Added integration test with a test case that has `go.mod` but no Go files in the root directory

**Relation issue**

Fixes #1811

**Additional context**

- All existing tests pass
- New unit tests for `getPkgName()` cover both go.mod and non-go.mod cases
- New integration test verifies parsing works correctly with go.mod but no root Go files