### PR TITLE
Support form:"-" tag to skip struct fields in params

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -325,6 +325,9 @@ func (operation *Operation) ParseParamComment(commentLine string, astFile *ast.F
 				// load overridden type specific name from extensions if exists
 				if nameVal, ok := item.Schema.Extensions.GetString(nameOverrideType); ok {
 					name = nameVal
+					if name == "-" {
+						continue
+					}
 				}
 
 				switch {

--- a/operation_test.go
+++ b/operation_test.go
@@ -1350,6 +1350,31 @@ func TestParseParamCommentQueryArrayFormatWithStructTag(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestParseParamCommentQuerySkipWithStructTag(t *testing.T) {
+	t.Parallel()
+
+	parser := New()
+	parser.packages.ParseFile("test",
+		"/test/test.go",
+		"package test\ntype MyQueryParam struct{Param string `form:\"param\"`\nSkipField string `form:\"-\"`}",
+		ParseAll)
+	parser.packages.ParseTypes()
+	comment := `@Param anyWhat query test.MyQueryParam true "Parameter"`
+	operation := NewOperation(parser)
+	err := operation.ParseComment(comment, nil)
+
+	assert.NoError(t, err)
+	b, _ := json.MarshalIndent(operation.Parameters, "", "    ")
+	expected := `[
+    {
+        "type": "string",
+        "name": "param",
+        "in": "query"
+    }
+]`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestParseParamCommentByID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Describe the PR**
This PR adds support for skipping struct fields with form:"-" tag when parsing query parameters from struct types in `@Param` comments.
- Modified operation.go to check for form:"-" tag and skip those fields during parameter parsing
- Added test case TestParseParamCommentQuerySkipWithStructTag to verify the behavior

**Relation issue**
#2096 
