### PR TITLE
fix: avoid oneOf when @Accept adds default schema

### DIFF
--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1092,6 +1092,31 @@ func TestParseParamCommentByBodyTypeV3(t *testing.T) {
 	assert.Equal(t, "#/components/schemas/model.OrderRow", requestBodySpec.Content["application/json"].Spec.Schema.Ref.Ref)
 }
 
+func TestParseParamCommentByBodyTypeV3WithAcceptDefaultSchema(t *testing.T) {
+	t.Parallel()
+
+	acceptComment := `//@Accept json`
+	bodyComment := `@Param request body model.OrderRow true "Some ID"`
+	operation := NewOperationV3(New())
+
+	operation.parser.addTestType("model.OrderRow")
+
+	err := operation.ParseComment(acceptComment, nil)
+	require.NoError(t, err)
+
+	err = operation.ParseComment(bodyComment, nil)
+	require.NoError(t, err)
+
+	requestBody := operation.RequestBody
+	require.NotNil(t, requestBody)
+
+	schema := requestBody.Spec.Spec.Content["application/json"].Spec.Schema
+	require.NotNil(t, schema)
+	require.NotNil(t, schema.Ref)
+	assert.Equal(t, "#/components/schemas/model.OrderRow", schema.Ref.Ref)
+	assert.Nil(t, schema.Spec)
+}
+
 func TestParseParamCommentByBodyTextPlainV3(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Describe the PR**

- Fix OpenAPI v3 requestBody schema generation so the default schema created by `@Accept` does not get merged via `oneOf` with the actual body schema.
- Replace the placeholder `type: object` with the real body schema when `@Param ... body` is parsed after `@Accept`.
- Add a regression test covering `@Accept json` + body parameter.

**Relation issue**

N/A (no related issue)

**Additional context**

Example setup:

```go
// @Accept json
// @Param request body types.CreateRequest true "作成リクエスト"
```

Command (example):

Generated specs using swag init with OpenAPI v3.1 output and YAML format.
Before, the generated requestBody schema included:

```yaml
oneOf:
  - type: object
  - $ref: '#/components/schemas/CreateRequest'
```

This PR ensures the placeholder type: object from @Accept is replaced by the actual body schema, resulting in only the $ref entry.