### PR TITLE
Add swaggerneedtag to filter out struct fields depending on tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,21 @@ type Account struct {
 }
 ```
 
+### Use swaggerneedtag tag to exclude a field depending on tags
+
+```go
+type Account struct {
+    ID   string    `json:"id"`
+    Name string     `json:"name"`
+    OnlyAdmin int   `json:"onlyadmin" swaggerneedtag:"admin"`
+    NotAdmin  int   `json:"notadmin" swaggerneedtag:"!admin"`
+}
+```
+
+will include `onlyadmin` only if `--tags` contains `admin`,
+
+and `notadmin` only if `--tags` does not contain `admin`.
+
 ### Add extension info to struct field
 
 ```go

--- a/field_parser.go
+++ b/field_parser.go
@@ -21,6 +21,7 @@ const (
 	omitEmptyLabel   = "omitempty"
 	swaggerTypeTag   = "swaggertype"
 	swaggerIgnoreTag = "swaggerignore"
+	swaggerNeedTag   = "swaggerneedtag"
 )
 
 type tagBaseFieldParser struct {
@@ -63,6 +64,19 @@ func (ps *tagBaseFieldParser) ShouldSkip() bool {
 		return true
 	}
 
+	// swaggerneedtag:[!]needtag
+	needTag := ps.tag.Get(swaggerNeedTag)
+	if len(needTag) > 0 {
+		if needTag[0] != '!' {
+			if !ps.p.matchTag(needTag) {
+				return true
+			}
+		} else {
+			if ps.p.matchTag(needTag[1:]) {
+				return true
+			}
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
**Describe the PR**
When using tags to filter the APIs, it can be handy to filter out some struct fields depending on the tags.

For instance, an administrator may get more information about a customer than a normal user.

This commit adds the `swaggerneedtag` tag to select a filter tag.

Example:
```go
type Account struct {
    ID   string    `json:"id"`
    Name string     `json:"name"`
    OnlyAdmin int   `json:"onlyadmin" swaggerneedtag:"admin"`
    NotAdmin  int   `json:"notadmin" swaggerneedtag:"!admin"`
}
```
will include `onlyadmin` only if `--tags` contains `admin`,

and `notadmin` only if `--tags` does not contain `admin`, or contains `!admin`.
