### PR TITLE
fix(openapi3): handle yaml:",inline" tag for embedded structs

### DIFF
--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -475,9 +475,10 @@ func (ps *tagBaseFieldParserV3) ShouldSkip() bool {
 		return true
 	}
 
-	// json:"tag,hoge"
-	name := ps.JsonName()
-	if name == "" {
+	// json:"tag,hoge" or json:"-"
+	// Only skip if explicitly marked with json:"-", not for fields with other tags like yaml:",inline"
+	name := strings.TrimSpace(strings.Split(ps.tag.Get(jsonTag), ",")[0])
+	if name == "-" {
 		return true
 	}
 

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -598,6 +598,42 @@ func TestParseInterface(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(result))
 }
 
+func TestParseCompositionInlineV3(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/v3/composition_inline"
+
+	p := New(GenerateOpenAPI3Doc(true))
+
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	require.NoError(t, err)
+
+	// Check that ServerMetadata has all the expected properties (including embedded BaseMetadata fields)
+	assert.Contains(t, p.openAPI.Components.Spec.Schemas, "api.ServerMetadata")
+	schema := p.openAPI.Components.Spec.Schemas["api.ServerMetadata"].Spec
+	assert.Contains(t, schema.Properties, "name", "embedded field 'name' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "description", "embedded field 'description' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "status", "embedded field 'status' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "image", "direct field 'image' should be present")
+
+	// Check that ServerMetadataJSONInline also has all the expected properties
+	assert.Contains(t, p.openAPI.Components.Spec.Schemas, "api.ServerMetadataJSONInline")
+	schema = p.openAPI.Components.Spec.Schemas["api.ServerMetadataJSONInline"].Spec
+	assert.Contains(t, schema.Properties, "name", "embedded field 'name' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "description", "embedded field 'description' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "status", "embedded field 'status' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "image", "direct field 'image' should be present")
+
+	// Check that ServerMetadataWithIgnored has embedded fields but NOT the json:"-" field
+	assert.Contains(t, p.openAPI.Components.Spec.Schemas, "api.ServerMetadataWithIgnored")
+	schema = p.openAPI.Components.Spec.Schemas["api.ServerMetadataWithIgnored"].Spec
+	assert.Contains(t, schema.Properties, "name", "embedded field 'name' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "description", "embedded field 'description' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "status", "embedded field 'status' from BaseMetadata should be present")
+	assert.Contains(t, schema.Properties, "image", "direct field 'image' should be present")
+	assert.NotContains(t, schema.Properties, "secret", "field with json:\"-\" should be skipped")
+}
+
 func TestParseRecursionWithSchemaName(t *testing.T) {
 	t.Parallel()
 

--- a/testdata/v3/composition_inline/api/api.go
+++ b/testdata/v3/composition_inline/api/api.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+)
+
+// BaseMetadata contains common metadata fields
+type BaseMetadata struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description" yaml:"description"`
+	Status      string `json:"status" yaml:"status"`
+}
+
+// ServerMetadata embeds BaseMetadata with yaml inline tag
+type ServerMetadata struct {
+	BaseMetadata `yaml:",inline"`
+	Image        string `json:"image" yaml:"image"`
+}
+
+// ServerMetadataJSONInline embeds BaseMetadata with both json and yaml inline tags
+type ServerMetadataJSONInline struct {
+	BaseMetadata `json:",inline" yaml:",inline"`
+	Image        string `json:"image" yaml:"image"`
+}
+
+// ServerMetadataWithIgnored has a field that should be ignored via json:"-"
+type ServerMetadataWithIgnored struct {
+	BaseMetadata `yaml:",inline"`
+	Image        string `json:"image" yaml:"image"`
+	Secret       string `json:"-"` // This field should be skipped
+}
+
+// @Description get ServerMetadata
+// @ID get-server-metadata
+// @Accept json
+// @Produce json
+// @Success 200 {object} api.ServerMetadata
+// @Router /testapi/get-server-metadata [get]
+func GetServerMetadata(w http.ResponseWriter, r *http.Request) {
+	var _ = ServerMetadata{}
+}
+
+// @Description get ServerMetadataJSONInline
+// @ID get-server-metadata-json-inline
+// @Accept json
+// @Produce json
+// @Success 200 {object} api.ServerMetadataJSONInline
+// @Router /testapi/get-server-metadata-json-inline [get]
+func GetServerMetadataJSONInline(w http.ResponseWriter, r *http.Request) {
+	var _ = ServerMetadataJSONInline{}
+}
+
+// @Description get ServerMetadataWithIgnored
+// @ID get-server-metadata-with-ignored
+// @Accept json
+// @Produce json
+// @Success 200 {object} api.ServerMetadataWithIgnored
+// @Router /testapi/get-server-metadata-with-ignored [get]
+func GetServerMetadataWithIgnored(w http.ResponseWriter, r *http.Request) {
+	var _ = ServerMetadataWithIgnored{}
+}

--- a/testdata/v3/composition_inline/main.go
+++ b/testdata/v3/composition_inline/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/v2/testdata/v3/composition_inline/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server
+// @termsOfService http://swagger.io/terms/
+
+// @host petstore.swagger.io
+// @BasePath /v2
+
+func main() {
+	http.HandleFunc("/testapi/get-server-metadata", api.GetServerMetadata)
+	http.HandleFunc("/testapi/get-server-metadata-json-inline", api.GetServerMetadataJSONInline)
+	http.HandleFunc("/testapi/get-server-metadata-with-ignored", api.GetServerMetadataWithIgnored)
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
**Describe the PR**

Fix embedded struct fields being omitted from OpenAPI 3.x schema when using `yaml:",inline"` tag.

The v3 field parser's `ShouldSkip()` was incorrectly skipping fields when `JsonName()` returned an empty string. This caused embedded struct fields with `yaml:",inline"` (but no json tag) to be skipped entirely.

The fix changes `ShouldSkip()` to only skip fields explicitly marked with `json:"-"`, matching the behavior of the Swagger 2.0 parser.

**Relation issue**

Fixes https://github.com/swaggo/swag/issues/2140