### PR TITLE
fixed binary attachments generation from comments. resolves #1933

### DIFF
--- a/operationv3.go
+++ b/operationv3.go
@@ -423,30 +423,30 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 			return nil
 		}
 	case "body", "formData":
-		if objectType == PRIMITIVE {
-			schema := PrimitiveSchemaV3(refType)
+		var finalSchema *spec.RefOrSpec[spec.Schema]
+		isPrimitive := false
 
-			err := o.parseParamAttributeForBody(commentLine, objectType, refType, schema.Spec)
+		if paramType == "formData" && refType == "file" {
+			finalSchema = spec.NewSchemaSpec()
+			finalSchema.Spec.Type = &spec.SingleOrArray[string]{"file"}
+			finalSchema.Spec.Format = "binary"
+			isPrimitive = true // Treat as primitive for fillRequestBody
+		} else if objectType == PRIMITIVE {
+			finalSchema = PrimitiveSchemaV3(refType)
+			isPrimitive = true
+		} else { // objectType == OBJECT or ARRAY
+			var err error
+			finalSchema, err = o.parseAPIObjectSchema(commentLine, objectType, refType, astFile)
 			if err != nil {
 				return err
 			}
-
-			o.fillRequestBody(name, schema, required, description, true, paramType == "formData")
-
-			return nil
-
 		}
 
-		schema, err := o.parseAPIObjectSchema(commentLine, objectType, refType, astFile)
+		err := o.parseParamAttributeForBody(commentLine, objectType, refType, finalSchema.Spec)
 		if err != nil {
 			return err
 		}
-
-		err = o.parseParamAttributeForBody(commentLine, objectType, refType, schema.Spec)
-		if err != nil {
-			return err
-		}
-		o.fillRequestBody(name, schema, required, description, false, paramType == "formData")
+		o.fillRequestBody(name, finalSchema, required, description, isPrimitive, paramType == "formData")
 
 		return nil
 
@@ -472,55 +472,72 @@ func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.S
 	if o.RequestBody == nil {
 		o.RequestBody = spec.NewRequestBodySpec()
 		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
-
-		if primitive && !formData {
-			o.RequestBody.Spec.Spec.Content["text/plain"] = spec.NewMediaType()
-		} else if formData {
-			o.RequestBody.Spec.Spec.Content["application/x-www-form-urlencoded"] = spec.NewMediaType()
-		} else {
-			o.RequestBody.Spec.Spec.Content["application/json"] = spec.NewMediaType()
-		}
 	}
 
 	o.RequestBody.Spec.Spec.Required = required
-
-	// Append description to existing description if this is not the first body
 	if o.RequestBody.Spec.Spec.Description != "" && description != "" {
 		o.RequestBody.Spec.Spec.Description += " | " + description
 	} else if description != "" {
 		o.RequestBody.Spec.Spec.Description = description
 	}
 
-	// Handle oneOf merging for request body schemas
-	contentType := "application/json"
-	if primitive && !formData {
-		contentType = "text/plain"
-	} else if formData {
-		contentType = "application/x-www-form-urlencoded"
+	// Determine content types to process
+	contentTypesToProcess := []string{}
+	if len(o.RequestBody.Spec.Spec.Content) == 0 { // No @Accept specified
+		if formData {
+			contentTypesToProcess = append(contentTypesToProcess, "multipart/form-data", "application/x-www-form-urlencoded")
+		} else if primitive {
+			contentTypesToProcess = append(contentTypesToProcess, "text/plain")
+		} else {
+			contentTypesToProcess = append(contentTypesToProcess, "application/json")
+		}
+	} else { // @Accept specified, use those
+		for ct := range o.RequestBody.Spec.Spec.Content {
+			contentTypesToProcess = append(contentTypesToProcess, ct)
+		}
 	}
 
-	mediaType := o.RequestBody.Spec.Spec.Content[contentType]
-	if mediaType == nil {
-		mediaType = spec.NewMediaType()
-		o.RequestBody.Spec.Spec.Content[contentType] = mediaType
-	}
-	if schema.Ref != nil {
-		schema.Ref.Summary = name
-		schema.Ref.Description = description
-	}
-	if schema.Spec != nil {
-		schema.Spec.Title = name
-	}
-	if mediaType.Spec.Schema == nil {
-		mediaType.Spec.Schema = schema
-	} else if mediaType.Spec.Schema.Ref != nil || mediaType.Spec.Schema.Spec.OneOf == nil {
-		// If there's an existing schema that doesn't have oneOf, create a oneOf schema
-		oneOfSchema := spec.NewSchemaSpec()
-		oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{mediaType.Spec.Schema, schema}
-		mediaType.Spec.Schema = oneOfSchema
-	} else {
-		// If there's already a oneOf schema, append to it
-		mediaType.Spec.Schema.Spec.OneOf = append(mediaType.Spec.Schema.Spec.OneOf, schema)
+	for _, contentType := range contentTypesToProcess {
+		mediaType := o.RequestBody.Spec.Spec.Content[contentType]
+		if mediaType == nil {
+			mediaType = spec.NewMediaType()
+			if o.RequestBody.Spec.Spec.Content == nil {
+				o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
+			}
+			o.RequestBody.Spec.Spec.Content[contentType] = mediaType
+		}
+
+		// Special handling for formData file in multipart/form-data
+		if formData && contentType == "multipart/form-data" && schema.Spec != nil && schema.Spec.Format == "binary" {
+			if mediaType.Spec.Schema == nil {
+				mediaType.Spec.Schema = spec.NewSchemaSpec()
+				mediaType.Spec.Schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
+				mediaType.Spec.Schema.Spec.Properties = make(map[string]*spec.RefOrSpec[spec.Schema])
+			} else if mediaType.Spec.Schema.Spec.Properties == nil {
+				mediaType.Spec.Schema.Spec.Properties = make(map[string]*spec.RefOrSpec[spec.Schema])
+			}
+			mediaType.Spec.Schema.Spec.Properties[name] = schema // Add the file schema as a property
+		} else {
+			// For other content types (e.g., application/x-www-form-urlencoded for file)
+			// or non-file schemas, use the schema directly or merge with oneOf.
+			// The `schema` passed here is already `type: string, format: binary` for files.
+			if schema.Ref != nil {
+				schema.Ref.Summary = name
+				schema.Ref.Description = description
+			}
+			if schema.Spec != nil {
+				schema.Spec.Title = name
+			}
+			if mediaType.Spec.Schema == nil {
+				mediaType.Spec.Schema = schema
+			} else if mediaType.Spec.Schema.Ref != nil || mediaType.Spec.Schema.Spec.OneOf == nil {
+				oneOfSchema := spec.NewSchemaSpec()
+				oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{mediaType.Spec.Schema, schema}
+				mediaType.Spec.Schema = oneOfSchema
+			} else {
+				mediaType.Spec.Schema.Spec.OneOf = append(mediaType.Spec.Schema.Spec.OneOf, schema)
+			}
+		}
 	}
 }
 

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -653,3 +653,23 @@ func TestGetSchemaByRef(t *testing.T) {
 		assert.Equal(t, &spec.Schema{}, result)
 	})
 }
+
+func TestFormDataBinary(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/v3/form-data-binary"
+	p := New(GenerateOpenAPI3Doc(true))
+	p.PropNamingStrategy = PascalCase
+	p.openAPI.OpenAPI = "3.1.0"
+
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	assert.NoError(t, err)
+
+	expected, err := os.ReadFile(filepath.Join(searchDir, "expected.json"))
+	require.NoError(t, err)
+
+	result, err := json.Marshal(p.openAPI)
+	require.NoError(t, err)
+
+	assert.JSONEq(t, string(expected), string(result))
+}

--- a/testdata/v3/form-data-binary/api/api.go
+++ b/testdata/v3/form-data-binary/api/api.go
@@ -1,0 +1,19 @@
+package api
+
+import "net/http"
+
+// Upload godoc
+// @Summary      Upload
+// @Description  Upload a file.
+// @Tags         Some section
+// @Accept	     multipart/form-data
+// @Produce      text/plain
+// @Param        data formData file true "attachment file"
+// @Success      201  {string}  "OK"
+// @Failure      400  {string}  "Bad Request"
+// @Failure      422  {string}  "Validation Error"
+// @Failure      500  {string}  "Internal Server Error"
+// @Router       /upload [post]
+func Upload(w http.ResponseWriter, r *http.Request) {
+	//write your code
+}

--- a/testdata/v3/form-data-binary/expected.json
+++ b/testdata/v3/form-data-binary/expected.json
@@ -1,0 +1,98 @@
+{
+  "components": {},
+  "info": {
+    "contact": {
+      "email": "support@swagger.io",
+      "name": "API Support",
+      "url": "http://www.swagger.io/support"
+    },
+    "description": "This is a sample server Petstore server.",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "termsOfService": "http://swagger.io/terms/",
+    "title": "Swagger Example API",
+    "version": "1.0"
+  },
+  "externalDocs": {
+    "description": "",
+    "url": ""
+  },
+  "paths": {
+    "/upload": {
+      "post": {
+        "description": "Upload a file.",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "file",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          },
+          "description": "attachment file",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Upload",
+        "tags": [
+          "Some section"
+        ]
+      }
+    }
+  },
+  "openapi": "3.1.0",
+  "servers": [
+    {
+      "url": "petstore.swagger.io/v2"
+    }
+  ]
+}

--- a/testdata/v3/form-data-binary/main.go
+++ b/testdata/v3/form-data-binary/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/swaggo/swag/v2/testdata/v3/form-data-binary/api"
+)
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server Petstore server.
+// @termsOfService http://swagger.io/terms/
+
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+
+// @license.name Apache 2.0
+// @license.url http://www.apache.org/licenses/LICENSE-2.0.html
+
+// @host petstore.swagger.io
+// @BasePath /v2
+func main() {
+	http.HandleFunc("/testapi/upload", api.Upload)
+
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
**Describe the PR**
problems is well described in #1933

now --v3.1 will generate from comments like
```
// @Accept	 multipart/form-data
// @Param        data formData file true "Module package .zip file"
```
following swagger:
```
    post:
      description: Upload a module package ZIP file.
      requestBody:
        content:
          multipart/form-data:
            schema:
              properties:
                data:
                  format: binary
                  type: file
              type: object
        description: Module package .zip file
        required: true
```

**Relation issue**
[Issue #1933](https://github.com/swaggo/swag/issues/1933)
