### PR TITLE
Add support for discriminator in OpenAPI v3

### DIFF
--- a/operationv3.go
+++ b/operationv3.go
@@ -13,6 +13,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type parsedDiscriminator struct {
+	propertyName string
+	mapping      map[string]string // nil when not specified
+}
+
 // OperationV3 describes a single API operation on a path.
 // For more information: https://github.com/swaggo/swag#api-operation
 type OperationV3 struct {
@@ -21,6 +26,7 @@ type OperationV3 struct {
 	spec.Operation
 	RouterProperties  []RouteProperties
 	responseMimeTypes []string
+	discriminatorInfo *parsedDiscriminator
 }
 
 // NewOperationV3 returns a new instance of OperationV3.
@@ -99,6 +105,8 @@ func (o *OperationV3) ParseComment(comment string, astFile *ast.File) error {
 		return o.ParseServerURLComment(lineRemainder)
 	case "@servers.description":
 		return o.ParseServerDescriptionComment(lineRemainder)
+	case discriminatorAttr:
+		return o.ParseDiscriminatorComment(lineRemainder)
 	default:
 		return o.ParseMetadata(attribute, lowerAttribute, lineRemainder)
 	}
@@ -1270,4 +1278,88 @@ func (o *OperationV3) ParseCodeSample(attribute, _, lineRemainder string) error 
 
 	// Fallback into existing logic
 	return o.ParseMetadata(attribute, strings.ToLower(attribute), lineRemainder)
+}
+
+// ParseDiscriminatorComment parses the @Discriminator annotation.
+// Syntax: @Discriminator propertyName [key=ref,key=ref,...]
+func (o *OperationV3) ParseDiscriminatorComment(commentLine string) error {
+	if commentLine == "" {
+		return fmt.Errorf("@discriminator requires at least a propertyName")
+	}
+	parts := FieldsByAnySpace(commentLine, 2)
+	propertyName := parts[0]
+	var mapping map[string]string
+	if len(parts) == 2 {
+		parsed, err := parseDiscriminatorMapping(parts[1])
+		if err != nil {
+			return fmt.Errorf("@discriminator mapping: %w", err)
+		}
+		mapping = parsed
+	}
+	if o.discriminatorInfo != nil {
+		return fmt.Errorf("@discriminator already defined for this operation")
+	}
+	o.discriminatorInfo = &parsedDiscriminator{propertyName: propertyName, mapping: mapping}
+	return nil
+}
+
+func parseDiscriminatorMapping(raw string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, entry := range strings.Split(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		kv := strings.SplitN(entry, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid mapping entry %q: expected key=ref", entry)
+		}
+		key, ref := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
+		if key == "" || ref == "" {
+			return nil, fmt.Errorf("invalid mapping entry %q: key and ref must not be empty", entry)
+		}
+		result[key] = ref
+	}
+	return result, nil
+}
+
+// ProcessDiscriminatorComment applies the parsed discriminator to any oneOf schemas in the operation's responses and request body.
+func (o *OperationV3) ProcessDiscriminatorComment() error {
+	if o.discriminatorInfo == nil {
+		return nil
+	}
+	d := buildDiscriminator(o.discriminatorInfo)
+	if o.Responses != nil {
+		for _, response := range o.Responses.Spec.Response {
+			applyDiscriminatorToContent(response.Spec.Spec.Content, d)
+		}
+		if o.Responses.Spec.Default != nil {
+			applyDiscriminatorToContent(o.Responses.Spec.Default.Spec.Spec.Content, d)
+		}
+	}
+	if o.RequestBody != nil {
+		applyDiscriminatorToContent(o.RequestBody.Spec.Spec.Content, d)
+	}
+	return nil
+}
+
+func buildDiscriminator(info *parsedDiscriminator) *spec.Discriminator {
+	d := spec.NewDiscriminator()
+	d.PropertyName = info.propertyName
+	if len(info.mapping) > 0 {
+		d.Mapping = info.mapping
+	}
+	return d
+}
+
+func applyDiscriminatorToContent(content map[string]*spec.Extendable[spec.MediaType], d *spec.Discriminator) {
+	for _, mediaType := range content {
+		if mediaType == nil || mediaType.Spec.Schema == nil {
+			continue
+		}
+		s := mediaType.Spec.Schema
+		if s.Spec != nil && len(s.Spec.OneOf) > 0 {
+			s.Spec.Discriminator = d
+		}
+	}
 }

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -2199,3 +2199,189 @@ func TestResponseSchemaWithCustomMimeTypeV3(t *testing.T) {
 		require.Equal(t, "#/components/schemas/model.OrderRow", apiJsonContent.Spec.Schema.Ref.Ref)
 	})
 }
+
+func TestParseDiscriminatorCommentPropertyNameOnlyV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type", nil)
+	require.NoError(t, err)
+	require.NotNil(t, operation.discriminatorInfo)
+	assert.Equal(t, "pet_type", operation.discriminatorInfo.propertyName)
+	assert.Nil(t, operation.discriminatorInfo.mapping)
+}
+
+func TestParseDiscriminatorCommentWithMappingV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type cat=#/components/schemas/web.Cat,dog=#/components/schemas/web.Dog", nil)
+	require.NoError(t, err)
+	require.NotNil(t, operation.discriminatorInfo)
+	assert.Equal(t, "pet_type", operation.discriminatorInfo.propertyName)
+	require.NotNil(t, operation.discriminatorInfo.mapping)
+	assert.Equal(t, "#/components/schemas/web.Cat", operation.discriminatorInfo.mapping["cat"])
+	assert.Equal(t, "#/components/schemas/web.Dog", operation.discriminatorInfo.mapping["dog"])
+}
+
+func TestParseDiscriminatorCommentEmptyV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseDiscriminatorComment("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "propertyName")
+}
+
+func TestParseDiscriminatorCommentDuplicateV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type", nil)
+	require.NoError(t, err)
+	err = operation.ParseComment("/@Discriminator other_type", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+}
+
+func TestParseDiscriminatorCommentMalformedMappingV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type cat-no-equals", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mapping")
+}
+
+func TestProcessDiscriminatorCommentNoOpWhenNilV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ProcessDiscriminatorComment()
+	require.NoError(t, err)
+	// Responses still intact, nothing changed
+	require.NotNil(t, operation.Responses)
+}
+
+func TestProcessDiscriminatorCommentAppliedToOneOfV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type", nil)
+	require.NoError(t, err)
+
+	// Simulate two @Success that produce a oneOf
+	schema1 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Cat"))
+	schema2 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Dog"))
+	oneOfSchema := spec.NewSchemaSpec()
+	oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{schema1, schema2}
+
+	response := spec.NewResponseSpec()
+	response.Spec.Spec.Description = "OK"
+	response.Spec.Spec.Content = map[string]*spec.Extendable[spec.MediaType]{
+		"application/json": {
+			Spec: &spec.MediaType{Schema: oneOfSchema},
+		},
+	}
+	operation.Responses.Spec.Response = map[string]*spec.RefOrSpec[spec.Extendable[spec.Response]]{
+		"200": response,
+	}
+
+	err = operation.ProcessDiscriminatorComment()
+	require.NoError(t, err)
+
+	schema := operation.Responses.Spec.Response["200"].Spec.Spec.Content["application/json"].Spec.Schema
+	require.NotNil(t, schema.Spec.Discriminator)
+	assert.Equal(t, "pet_type", schema.Spec.Discriminator.PropertyName)
+	assert.Nil(t, schema.Spec.Discriminator.Mapping)
+}
+
+func TestProcessDiscriminatorCommentWithMappingV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type cat=#/components/schemas/web.Cat,dog=#/components/schemas/web.Dog", nil)
+	require.NoError(t, err)
+
+	schema1 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Cat"))
+	schema2 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Dog"))
+	oneOfSchema := spec.NewSchemaSpec()
+	oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{schema1, schema2}
+
+	response := spec.NewResponseSpec()
+	response.Spec.Spec.Description = "OK"
+	response.Spec.Spec.Content = map[string]*spec.Extendable[spec.MediaType]{
+		"application/json": {
+			Spec: &spec.MediaType{Schema: oneOfSchema},
+		},
+	}
+	operation.Responses.Spec.Response = map[string]*spec.RefOrSpec[spec.Extendable[spec.Response]]{
+		"200": response,
+	}
+
+	err = operation.ProcessDiscriminatorComment()
+	require.NoError(t, err)
+
+	d := operation.Responses.Spec.Response["200"].Spec.Spec.Content["application/json"].Spec.Schema.Spec.Discriminator
+	require.NotNil(t, d)
+	assert.Equal(t, "pet_type", d.PropertyName)
+	require.NotNil(t, d.Mapping)
+	assert.Equal(t, "#/components/schemas/web.Cat", d.Mapping["cat"])
+	assert.Equal(t, "#/components/schemas/web.Dog", d.Mapping["dog"])
+}
+
+func TestProcessDiscriminatorCommentSkipsNonOneOfV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator pet_type", nil)
+	require.NoError(t, err)
+
+	// Single schema (no oneOf)
+	singleSchema := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Cat"))
+
+	response := spec.NewResponseSpec()
+	response.Spec.Spec.Description = "OK"
+	response.Spec.Spec.Content = map[string]*spec.Extendable[spec.MediaType]{
+		"application/json": {
+			Spec: &spec.MediaType{Schema: singleSchema},
+		},
+	}
+	operation.Responses.Spec.Response = map[string]*spec.RefOrSpec[spec.Extendable[spec.Response]]{
+		"200": response,
+	}
+
+	err = operation.ProcessDiscriminatorComment()
+	require.NoError(t, err)
+
+	// Discriminator must NOT be set on a non-oneOf schema
+	schema := operation.Responses.Spec.Response["200"].Spec.Spec.Content["application/json"].Spec.Schema
+	assert.Nil(t, schema.Spec)
+}
+
+func TestProcessDiscriminatorCommentAppliedToRequestBodyV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(nil)
+	err := operation.ParseComment("/@Discriminator body_type", nil)
+	require.NoError(t, err)
+
+	schema1 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Cat"))
+	schema2 := spec.NewSchemaRef(spec.NewRef("#/components/schemas/web.Dog"))
+	oneOfSchema := spec.NewSchemaSpec()
+	oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{schema1, schema2}
+
+	operation.RequestBody = spec.NewRequestBodySpec()
+	operation.RequestBody.Spec.Spec.Content = map[string]*spec.Extendable[spec.MediaType]{
+		"application/json": {
+			Spec: &spec.MediaType{Schema: oneOfSchema},
+		},
+	}
+
+	err = operation.ProcessDiscriminatorComment()
+	require.NoError(t, err)
+
+	schema := operation.RequestBody.Spec.Spec.Content["application/json"].Spec.Schema
+	require.NotNil(t, schema.Spec.Discriminator)
+	assert.Equal(t, "body_type", schema.Spec.Discriminator.PropertyName)
+}

--- a/parser.go
+++ b/parser.go
@@ -72,6 +72,7 @@ const (
 	xCodeSamplesAttrOriginal = "@x-codeSamples"
 	scopeAttrPrefix          = "@scope."
 	stateAttr                = "@state"
+	discriminatorAttr        = "@discriminator"
 )
 
 // ParseFlag determine what to parse

--- a/parserv3.go
+++ b/parserv3.go
@@ -553,6 +553,11 @@ func (p *Parser) ParseRouterAPIInfoV3(fileInfo *AstFileInfo) error {
 				return err
 			}
 
+			err = operation.ProcessDiscriminatorComment()
+			if err != nil {
+				return err
+			}
+
 			err = processRouterOperationV3(p, operation)
 			if err != nil {
 				return err

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -484,6 +484,40 @@ func TestParseSimpleApiV3(t *testing.T) {
 		}, rootSchema.OneOf)
 
 	})
+
+	t.Run("Test parse discriminator with mapping", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Contains(t, paths, "/pets/{id}/discriminated")
+		path := paths["/pets/{id}/discriminated"]
+		require.NotNil(t, path.Spec.Spec.Get)
+		assert.Contains(t, path.Spec.Spec.Get.Spec.Responses.Spec.Response, "200")
+		response := path.Spec.Spec.Get.Spec.Responses.Spec.Response["200"]
+		mediaType := response.Spec.Spec.Content["application/json"]
+		require.NotNil(t, mediaType)
+		rootSchema := mediaType.Spec.Schema.Spec
+		require.NotNil(t, rootSchema.Discriminator, "discriminator should be set")
+		assert.Equal(t, "pet_type", rootSchema.Discriminator.PropertyName)
+		require.NotNil(t, rootSchema.Discriminator.Mapping)
+		assert.Equal(t, "#/components/schemas/web.Cat", rootSchema.Discriminator.Mapping["cat"])
+		assert.Equal(t, "#/components/schemas/web.Dog", rootSchema.Discriminator.Mapping["dog"])
+	})
+
+	t.Run("Test parse discriminator without mapping", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Contains(t, paths, "/pets/{id}/no-mapping")
+		path := paths["/pets/{id}/no-mapping"]
+		require.NotNil(t, path.Spec.Spec.Get)
+		assert.Contains(t, path.Spec.Spec.Get.Spec.Responses.Spec.Response, "200")
+		response := path.Spec.Spec.Get.Spec.Responses.Spec.Response["200"]
+		mediaType := response.Spec.Spec.Content["application/json"]
+		require.NotNil(t, mediaType)
+		rootSchema := mediaType.Spec.Schema.Spec
+		require.NotNil(t, rootSchema.Discriminator, "discriminator should be set")
+		assert.Equal(t, "pet_type", rootSchema.Discriminator.PropertyName)
+		assert.Nil(t, rootSchema.Discriminator.Mapping)
+	})
 }
 
 func TestParserParseServers(t *testing.T) {

--- a/testdata/v3/simple/api/api.go
+++ b/testdata/v3/simple/api/api.go
@@ -171,3 +171,19 @@ func GetPetByID() {
 func AddPet() {
 
 }
+
+// @Summary Get pet by ID with discriminator
+// @Param id path string true "ID"
+// @Discriminator pet_type cat=#/components/schemas/web.Cat,dog=#/components/schemas/web.Dog
+// @Success 200 {object} web.Cat
+// @Success 200 {object} web.Dog
+// @Router /pets/{id}/discriminated [get]
+func GetPetByIDDiscriminated() {}
+
+// @Summary Get pet by ID with discriminator (no mapping)
+// @Param id path string true "ID"
+// @Discriminator pet_type
+// @Success 200 {object} web.Cat
+// @Success 200 {object} web.Dog
+// @Router /pets/{id}/no-mapping [get]
+func GetPetByIDNoMapping() {}


### PR DESCRIPTION
**Describe the PR**
Adds a new `@Discriminator` route-handler annotation for OpenAPI v3. When a response (or request body) uses `oneOf` polymorphism (multiple `@Success` annotations with the same status code), a discriminator object can now be declared to tell clients which concrete type to use at runtime.

**Relation issue**
#2150 #829 

**Additional context**
Builds on the existing `oneOf` support introduced in #1870 and extended in #2059. The discriminator should only be applied to schemas that already contain a `oneOf` composition, as per the OpenAPI 3.0 spec.

**Implementation notes**
- Follows the same deferred-processing pattern as `@Produce`
- `discriminatorInfo *parsedDiscriminator` is stored on `OperationV3` to bridge the two phases. Open to feedback on whether there's a better place for this — it felt slightly out of place on the struct but couldn't find a cleaner alternative given the parse ordering constraints.
- Declaring `@Discriminator` twice on the same operation returns an error rather than silently overwriting.
- Applied to both responses and request body content.