### PR TITLE
V2 Fix swag generating "oneOf" blocks for both form types

### DIFF
--- a/operationv3.go
+++ b/operationv3.go
@@ -173,7 +173,7 @@ func (o *OperationV3) ParseAcceptComment(commentLine string) error {
 		schema := spec.NewSchemaSpec()
 
 		switch value {
-		case "application/json", "multipart/form-data", "text/xml":
+		case "application/json", "multipart/form-data", "text/xml", "application/x-www-form-urlencoded":
 			schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
 		case "image/png",
 			"image/jpeg",
@@ -424,14 +424,24 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 		}
 	case "body", "formData":
 		if objectType == PRIMITIVE {
-			schema := PrimitiveSchemaV3(refType)
+			var schema *spec.RefOrSpec[spec.Schema]
+			if paramType == "formData" && refType == "file" {
+				schema = spec.NewSchemaSpec()
+				schema.Spec.Type = &spec.SingleOrArray[string]{STRING}
+				schema.Spec.Format = "binary"
+			} else {
+				schema = PrimitiveSchemaV3(refType)
+			}
 
 			err := o.parseParamAttributeForBody(commentLine, objectType, refType, schema.Spec)
 			if err != nil {
 				return err
 			}
 
-			o.fillRequestBody(name, schema, required, description, true, paramType == "formData")
+			err = o.fillRequestBody(name, schema, required, description, true, paramType == "formData")
+			if err != nil {
+				return err
+			}
 
 			return nil
 
@@ -446,7 +456,10 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 		if err != nil {
 			return err
 		}
-		o.fillRequestBody(name, schema, required, description, false, paramType == "formData")
+		err = o.fillRequestBody(name, schema, required, description, false, paramType == "formData")
+		if err != nil {
+			return err
+		}
 
 		return nil
 
@@ -468,35 +481,50 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 	return nil
 }
 
-func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.Schema], required bool, description string, primitive, formData bool) {
-	if o.RequestBody == nil {
-		o.RequestBody = spec.NewRequestBodySpec()
-		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
+func isBinarySchema(schema *spec.RefOrSpec[spec.Schema]) bool {
+	if schema == nil || schema.Spec == nil {
+		return false
+	}
+	return schema.Spec.Format == "binary"
+}
 
-		if primitive && !formData {
-			o.RequestBody.Spec.Spec.Content["text/plain"] = spec.NewMediaType()
-		} else if formData {
-			o.RequestBody.Spec.Spec.Content["application/x-www-form-urlencoded"] = spec.NewMediaType()
-		} else {
-			o.RequestBody.Spec.Spec.Content["application/json"] = spec.NewMediaType()
+func (o *OperationV3) formDataContentType(schema *spec.RefOrSpec[spec.Schema]) string {
+	if o.RequestBody != nil && o.RequestBody.Spec != nil && o.RequestBody.Spec.Spec.Content != nil {
+		content := o.RequestBody.Spec.Spec.Content
+
+		if content["multipart/form-data"] != nil {
+			return "multipart/form-data"
+		}
+
+		if content["application/x-www-form-urlencoded"] != nil {
+			return "application/x-www-form-urlencoded"
 		}
 	}
 
-	o.RequestBody.Spec.Spec.Required = required
-
-	// Append description to existing description if this is not the first body
-	if o.RequestBody.Spec.Spec.Description != "" && description != "" {
-		o.RequestBody.Spec.Spec.Description += " | " + description
-	} else if description != "" {
-		o.RequestBody.Spec.Spec.Description = description
+	if isBinarySchema(schema) {
+		return "multipart/form-data"
 	}
 
-	// Handle oneOf merging for request body schemas
+	return "application/x-www-form-urlencoded"
+}
+
+func (o *OperationV3) fillRequestBody(
+	name string,
+	schema *spec.RefOrSpec[spec.Schema],
+	required bool,
+	description string,
+	primitive, formData bool,
+) error {
+	if o.RequestBody == nil {
+		o.RequestBody = spec.NewRequestBodySpec()
+		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
+	}
+
 	contentType := "application/json"
 	if primitive && !formData {
 		contentType = "text/plain"
 	} else if formData {
-		contentType = "application/x-www-form-urlencoded"
+		contentType = o.formDataContentType(schema)
 	}
 
 	mediaType := o.RequestBody.Spec.Spec.Content[contentType]
@@ -504,24 +532,42 @@ func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.S
 		mediaType = spec.NewMediaType()
 		o.RequestBody.Spec.Spec.Content[contentType] = mediaType
 	}
-	if schema.Ref != nil {
-		schema.Ref.Summary = name
-		schema.Ref.Description = description
+
+	o.RequestBody.Spec.Spec.Required = required
+	if description != "" && o.RequestBody.Spec.Spec.Description == "" {
+		o.RequestBody.Spec.Spec.Description = description
 	}
-	if schema.Spec != nil {
-		schema.Spec.Title = name
+
+	if formData {
+		if mediaType.Spec.Schema == nil {
+			mediaType.Spec.Schema = spec.NewSchemaSpec()
+			mediaType.Spec.Schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
+			mediaType.Spec.Schema.Spec.Properties = map[string]*spec.RefOrSpec[spec.Schema]{}
+		}
+
+		if mediaType.Spec.Schema.Ref != nil {
+			return fmt.Errorf("form request body schema cannot be a ref")
+		}
+
+		if mediaType.Spec.Schema.Spec.Properties == nil {
+			mediaType.Spec.Schema.Spec.Properties = map[string]*spec.RefOrSpec[spec.Schema]{}
+		}
+
+		if schema != nil && schema.Spec != nil && schema.Spec.Description == "" && description != "" {
+			schema.Spec.Description = description
+		}
+
+		mediaType.Spec.Schema.Spec.Properties[name] = schema
+		if required && !findInSlice(mediaType.Spec.Schema.Spec.Required, name) {
+			mediaType.Spec.Schema.Spec.Required =
+				append(mediaType.Spec.Schema.Spec.Required, name)
+		}
+
+		return nil
 	}
-	if mediaType.Spec.Schema == nil {
-		mediaType.Spec.Schema = schema
-	} else if mediaType.Spec.Schema.Ref != nil || mediaType.Spec.Schema.Spec.OneOf == nil {
-		// If there's an existing schema that doesn't have oneOf, create a oneOf schema
-		oneOfSchema := spec.NewSchemaSpec()
-		oneOfSchema.Spec.OneOf = []*spec.RefOrSpec[spec.Schema]{mediaType.Spec.Schema, schema}
-		mediaType.Spec.Schema = oneOfSchema
-	} else {
-		// If there's already a oneOf schema, append to it
-		mediaType.Spec.Schema.Spec.OneOf = append(mediaType.Spec.Schema.Spec.OneOf, schema)
-	}
+
+	mediaType.Spec.Schema = schema
+	return nil
 }
 
 func (o *OperationV3) parseParamAttribute(comment, objectType, schemaType string, param *spec.Parameter) error {

--- a/operationv3.go
+++ b/operationv3.go
@@ -19,6 +19,25 @@ type parsedDiscriminator struct {
 	mapping      map[string]string // nil when not specified
 }
 
+// MIME types recognized by ParseAcceptComment and fillRequestBody.
+const (
+	mimeTypeJSON          = "application/json"
+	mimeTypeXML           = "text/xml"
+	mimeTypePlain         = "text/plain"
+	mimeTypeMultipartForm = "multipart/form-data"
+	mimeTypeURLEncoded    = "application/x-www-form-urlencoded"
+	mimeTypePNG           = "image/png"
+	mimeTypeJPEG          = "image/jpeg"
+	mimeTypeGIF           = "image/gif"
+	mimeTypeOctetStream   = "application/octet-stream"
+	mimeTypePDF           = "application/pdf"
+	mimeTypeMSExcel       = "application/msexcel"
+	mimeTypeZip           = "application/zip"
+	mimeTypeDocx          = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	mimeTypeXlsx          = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	mimeTypePptx          = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
 // OperationV3 describes a single API operation on a path.
 // For more information: https://github.com/swaggo/swag#api-operation
 type OperationV3 struct {
@@ -182,18 +201,18 @@ func (o *OperationV3) ParseAcceptComment(commentLine string) error {
 		schema := spec.NewSchemaSpec()
 
 		switch value {
-		case "application/json", "multipart/form-data", "text/xml", "application/x-www-form-urlencoded":
+		case mimeTypeJSON, mimeTypeMultipartForm, mimeTypeXML, mimeTypeURLEncoded:
 			schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
-		case "image/png",
-			"image/jpeg",
-			"image/gif",
-			"application/octet-stream",
-			"application/pdf",
-			"application/msexcel",
-			"application/zip",
-			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-			"application/vnd.openxmlformats-officedocument.presentationml.presentation":
+		case mimeTypePNG,
+			mimeTypeJPEG,
+			mimeTypeGIF,
+			mimeTypeOctetStream,
+			mimeTypePDF,
+			mimeTypeMSExcel,
+			mimeTypeZip,
+			mimeTypeDocx,
+			mimeTypeXlsx,
+			mimeTypePptx:
 			schema.Spec.Type = &spec.SingleOrArray[string]{STRING}
 			schema.Spec.Format = "binary"
 		default:
@@ -501,20 +520,20 @@ func (o *OperationV3) formDataContentType(schema *spec.RefOrSpec[spec.Schema]) s
 	if o.RequestBody != nil && o.RequestBody.Spec != nil && o.RequestBody.Spec.Spec.Content != nil {
 		content := o.RequestBody.Spec.Spec.Content
 
-		if content["multipart/form-data"] != nil {
-			return "multipart/form-data"
+		if content[mimeTypeMultipartForm] != nil {
+			return mimeTypeMultipartForm
 		}
 
-		if content["application/x-www-form-urlencoded"] != nil {
-			return "application/x-www-form-urlencoded"
+		if content[mimeTypeURLEncoded] != nil {
+			return mimeTypeURLEncoded
 		}
 	}
 
 	if isBinarySchema(schema) {
-		return "multipart/form-data"
+		return mimeTypeMultipartForm
 	}
 
-	return "application/x-www-form-urlencoded"
+	return mimeTypeURLEncoded
 }
 
 func (o *OperationV3) fillRequestBody(
@@ -529,9 +548,9 @@ func (o *OperationV3) fillRequestBody(
 		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
 	}
 
-	contentType := "application/json"
+	contentType := mimeTypeJSON
 	if primitive && !formData {
-		contentType = "text/plain"
+		contentType = mimeTypePlain
 	} else if formData {
 		contentType = o.formDataContentType(schema)
 	}

--- a/operationv3.go
+++ b/operationv3.go
@@ -182,7 +182,7 @@ func (o *OperationV3) ParseAcceptComment(commentLine string) error {
 		schema := spec.NewSchemaSpec()
 
 		switch value {
-		case "application/json", "multipart/form-data", "text/xml":
+		case "application/json", "multipart/form-data", "text/xml", "application/x-www-form-urlencoded":
 			schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
 		case "image/png",
 			"image/jpeg",
@@ -433,14 +433,24 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 		}
 	case "body", "formData":
 		if objectType == PRIMITIVE {
-			schema := PrimitiveSchemaV3(refType)
+			var schema *spec.RefOrSpec[spec.Schema]
+			if paramType == "formData" && refType == "file" {
+				schema = spec.NewSchemaSpec()
+				schema.Spec.Type = &spec.SingleOrArray[string]{STRING}
+				schema.Spec.Format = "binary"
+			} else {
+				schema = PrimitiveSchemaV3(refType)
+			}
 
 			err := o.parseParamAttributeForBody(commentLine, objectType, refType, schema.Spec)
 			if err != nil {
 				return err
 			}
 
-			o.fillRequestBody(name, schema, required, description, true, paramType == "formData")
+			err = o.fillRequestBody(name, schema, required, description, true, paramType == "formData")
+			if err != nil {
+				return err
+			}
 
 			return nil
 
@@ -455,7 +465,10 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 		if err != nil {
 			return err
 		}
-		o.fillRequestBody(name, schema, required, description, false, paramType == "formData")
+		err = o.fillRequestBody(name, schema, required, description, false, paramType == "formData")
+		if err != nil {
+			return err
+		}
 
 		return nil
 
@@ -477,21 +490,91 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 	return nil
 }
 
-func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.Schema], required bool, description string, primitive, formData bool) {
-	if o.RequestBody == nil {
-		o.RequestBody = spec.NewRequestBodySpec()
-		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
+func isBinarySchema(schema *spec.RefOrSpec[spec.Schema]) bool {
+	if schema == nil || schema.Spec == nil {
+		return false
+	}
+	return schema.Spec.Format == "binary"
+}
 
-		if primitive && !formData {
-			o.RequestBody.Spec.Spec.Content["text/plain"] = spec.NewMediaType()
-		} else if formData {
-			o.RequestBody.Spec.Spec.Content["application/x-www-form-urlencoded"] = spec.NewMediaType()
-		} else {
-			o.RequestBody.Spec.Spec.Content["application/json"] = spec.NewMediaType()
+func (o *OperationV3) formDataContentType(schema *spec.RefOrSpec[spec.Schema]) string {
+	if o.RequestBody != nil && o.RequestBody.Spec != nil && o.RequestBody.Spec.Spec.Content != nil {
+		content := o.RequestBody.Spec.Spec.Content
+
+		if content["multipart/form-data"] != nil {
+			return "multipart/form-data"
+		}
+
+		if content["application/x-www-form-urlencoded"] != nil {
+			return "application/x-www-form-urlencoded"
 		}
 	}
 
+	if isBinarySchema(schema) {
+		return "multipart/form-data"
+	}
+
+	return "application/x-www-form-urlencoded"
+}
+
+func (o *OperationV3) fillRequestBody(
+	name string,
+	schema *spec.RefOrSpec[spec.Schema],
+	required bool,
+	description string,
+	primitive, formData bool,
+) error {
+	if o.RequestBody == nil {
+		o.RequestBody = spec.NewRequestBodySpec()
+		o.RequestBody.Spec.Spec.Content = make(map[string]*spec.Extendable[spec.MediaType])
+	}
+
+	contentType := "application/json"
+	if primitive && !formData {
+		contentType = "text/plain"
+	} else if formData {
+		contentType = o.formDataContentType(schema)
+	}
+
+	mediaType := o.RequestBody.Spec.Spec.Content[contentType]
+	if mediaType == nil {
+		mediaType = spec.NewMediaType()
+		o.RequestBody.Spec.Spec.Content[contentType] = mediaType
+	}
+
 	o.RequestBody.Spec.Spec.Required = required
+
+	if formData {
+		if description != "" && o.RequestBody.Spec.Spec.Description == "" {
+			o.RequestBody.Spec.Spec.Description = description
+		}
+
+		if mediaType.Spec.Schema == nil {
+			mediaType.Spec.Schema = spec.NewSchemaSpec()
+			mediaType.Spec.Schema.Spec.Type = &spec.SingleOrArray[string]{OBJECT}
+			mediaType.Spec.Schema.Spec.Properties = map[string]*spec.RefOrSpec[spec.Schema]{}
+		}
+
+		if mediaType.Spec.Schema.Ref != nil {
+			return fmt.Errorf("form request body schema cannot be a ref")
+		}
+
+		if mediaType.Spec.Schema.Spec.Properties == nil {
+			mediaType.Spec.Schema.Spec.Properties = map[string]*spec.RefOrSpec[spec.Schema]{}
+		}
+
+		if schema != nil && schema.Spec != nil && schema.Spec.Description == "" && description != "" {
+			schema.Spec.Description = description
+		}
+
+		mediaType.Spec.Schema.Spec.Properties[name] = schema
+		if required && !findInSlice(mediaType.Spec.Schema.Spec.Required, name) {
+			mediaType.Spec.Schema.Spec.Required =
+				append(mediaType.Spec.Schema.Spec.Required, name)
+		}
+
+		return nil
+	}
 
 	// Append description to existing description if this is not the first body
 	if o.RequestBody.Spec.Spec.Description != "" && description != "" {
@@ -500,19 +583,6 @@ func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.S
 		o.RequestBody.Spec.Spec.Description = description
 	}
 
-	// Handle oneOf merging for request body schemas
-	contentType := "application/json"
-	if primitive && !formData {
-		contentType = "text/plain"
-	} else if formData {
-		contentType = "application/x-www-form-urlencoded"
-	}
-
-	mediaType := o.RequestBody.Spec.Spec.Content[contentType]
-	if mediaType == nil {
-		mediaType = spec.NewMediaType()
-		o.RequestBody.Spec.Spec.Content[contentType] = mediaType
-	}
 	if schema.Ref != nil {
 		schema.Ref.Summary = name
 		schema.Ref.Description = description
@@ -531,6 +601,8 @@ func (o *OperationV3) fillRequestBody(name string, schema *spec.RefOrSpec[spec.S
 		// If there's already a oneOf schema, append to it
 		mediaType.Spec.Schema.Spec.OneOf = append(mediaType.Spec.Schema.Spec.OneOf, schema)
 	}
+
+	return nil
 }
 
 func isDefaultAcceptSchema(schema *spec.RefOrSpec[spec.Schema]) bool {

--- a/operationv3.go
+++ b/operationv3.go
@@ -475,6 +475,28 @@ func (o *OperationV3) ParseParamComment(commentLine string, astFile *ast.File) e
 
 		}
 
+		if paramType == "formData" && objectType == ARRAY && refType == "file" {
+			itemSchema := spec.NewSchemaSpec()
+			itemSchema.Spec.Type = &spec.SingleOrArray[string]{STRING}
+			itemSchema.Spec.Format = "binary"
+
+			schema := spec.NewSchemaSpec()
+			schema.Spec.Type = &spec.SingleOrArray[string]{ARRAY}
+			schema.Spec.Items = spec.NewBoolOrSchema(false, itemSchema)
+
+			err := o.parseParamAttributeForBody(commentLine, objectType, refType, schema.Spec)
+			if err != nil {
+				return err
+			}
+
+			err = o.fillRequestBody(name, schema, required, description, false, true)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		}
+
 		schema, err := o.parseAPIObjectSchema(commentLine, objectType, refType, astFile)
 		if err != nil {
 			return err
@@ -513,7 +535,17 @@ func isBinarySchema(schema *spec.RefOrSpec[spec.Schema]) bool {
 	if schema == nil || schema.Spec == nil {
 		return false
 	}
-	return schema.Spec.Format == "binary"
+
+	if schema.Spec.Format == "binary" {
+		return true
+	}
+
+	if schema.Spec.Type != nil && len(*schema.Spec.Type) == 1 && (*schema.Spec.Type)[0] == ARRAY &&
+		schema.Spec.Items != nil && schema.Spec.Items.Schema != nil && schema.Spec.Items.Schema.Spec != nil {
+		return schema.Spec.Items.Schema.Spec.Format == "binary"
+	}
+
+	return false
 }
 
 func (o *OperationV3) formDataContentType(schema *spec.RefOrSpec[spec.Schema]) string {

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1204,11 +1204,33 @@ func TestParseParamCommentByFormDataTypeV3(t *testing.T) {
 	requestBody := operation.RequestBody
 	assert.True(t, requestBody.Spec.Spec.Required)
 	assert.Equal(t, "this is a test file", requestBody.Spec.Spec.Description)
-	assert.NotNil(t, requestBody)
 
 	requestBodySpec := requestBody.Spec.Spec
 	assert.NotNil(t, requestBodySpec)
-	assert.Equal(t, &typeFile, requestBodySpec.Content["application/x-www-form-urlencoded"].Spec.Schema.Spec.Type)
+
+	media := requestBodySpec.Content["multipart/form-data"]
+	if assert.NotNil(t, media) {
+		if assert.NotNil(t, media.Spec.Schema) && assert.NotNil(t, media.Spec.Schema.Spec) {
+			assert.Equal(
+				t,
+				&spec.SingleOrArray[string]{OBJECT},
+				media.Spec.Schema.Spec.Type,
+			)
+
+			prop := media.Spec.Schema.Spec.Properties["file"]
+			if assert.NotNil(t, prop) && assert.NotNil(t, prop.Spec) {
+				assert.Equal(
+					t,
+					&spec.SingleOrArray[string]{STRING},
+					prop.Spec.Type,
+				)
+				assert.Equal(t, "binary", prop.Spec.Format)
+				assert.Equal(t, "this is a test file", prop.Spec.Description)
+			}
+
+			assert.Contains(t, media.Spec.Schema.Spec.Required, "file")
+		}
+	}
 }
 
 func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
@@ -1228,7 +1250,14 @@ func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
 
 	requestBodySpec := requestBody.Spec.Spec.Content["application/x-www-form-urlencoded"].Spec
 	assert.NotNil(t, requestBodySpec)
-	assert.Equal(t, &typeInteger, requestBodySpec.Schema.Spec.Type)
+	assert.Equal(t, &typeObject, requestBodySpec.Schema.Spec.Type)
+
+	prop := requestBodySpec.Schema.Spec.Properties["file"]
+	if assert.NotNil(t, prop) && assert.NotNil(t, prop.Spec) {
+		assert.Equal(t, &typeInteger, prop.Spec.Type)
+	}
+
+	assert.Contains(t, requestBodySpec.Schema.Spec.Required, "file")
 }
 
 func TestParseParamCommentByNotSupportedTypeV3(t *testing.T) {

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1375,6 +1375,102 @@ func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
 	assert.Contains(t, requestBodySpec.Schema.Spec.Required, "file")
 }
 
+func TestParseParamCommentByFormDataMultipleParamsMultipartV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(New())
+
+	comments := []string{
+		`@Accept multipart/form-data`,
+		`@Param zip formData file true "Zip file containing checks.toml, users.toml, and/or settings.toml"`,
+		`@Param destructiveChecks formData boolean false "If true, destructively replace existing checks during checks.toml import"`,
+		`@Param destructiveUsers formData boolean false "If true, destructively replace existing users during users.toml import"`,
+		`@Param destructiveSettings formData boolean false "If true, destructively replace existing settings during settings.toml import"`,
+	}
+
+	for _, comment := range comments {
+		err := operation.ParseComment(comment, nil)
+		require.NoError(t, err)
+	}
+
+	requestBody := operation.RequestBody
+	require.NotNil(t, requestBody)
+
+	media := requestBody.Spec.Spec.Content["multipart/form-data"]
+	require.NotNil(t, media)
+	require.NotNil(t, media.Spec.Schema)
+	require.NotNil(t, media.Spec.Schema.Spec)
+
+	schema := media.Spec.Schema.Spec
+	assert.Equal(t, &typeObject, schema.Type)
+	assert.Nil(t, schema.OneOf, "multiple formData params must not be bundled into oneOf")
+	assert.Len(t, schema.Properties, 4)
+
+	zip := schema.Properties["zip"]
+	if assert.NotNil(t, zip) && assert.NotNil(t, zip.Spec) {
+		assert.Equal(t, &typeString, zip.Spec.Type)
+		assert.Equal(t, "binary", zip.Spec.Format)
+	}
+
+	for _, name := range []string{"destructiveChecks", "destructiveUsers", "destructiveSettings"} {
+		prop := schema.Properties[name]
+		if assert.NotNil(t, prop) && assert.NotNil(t, prop.Spec) {
+			assert.Equal(t, &spec.SingleOrArray[string]{BOOLEAN}, prop.Spec.Type)
+		}
+	}
+
+	assert.ElementsMatch(t, []string{"zip"}, schema.Required)
+}
+
+func TestParseParamCommentByFormDataMultipleParamsURLEncodedV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(New())
+
+	comments := []string{
+		`@Accept application/x-www-form-urlencoded`,
+		`@Param id formData int true "Check ID to update"`,
+		`@Param name formData string false "Update check name"`,
+		`@Param weight formData int false "Update check weight"`,
+		`@Param activated formData boolean false "Update check activation"`,
+	}
+
+	for _, comment := range comments {
+		err := operation.ParseComment(comment, nil)
+		require.NoError(t, err)
+	}
+
+	requestBody := operation.RequestBody
+	require.NotNil(t, requestBody)
+
+	media := requestBody.Spec.Spec.Content["application/x-www-form-urlencoded"]
+	require.NotNil(t, media)
+	require.NotNil(t, media.Spec.Schema)
+	require.NotNil(t, media.Spec.Schema.Spec)
+
+	schema := media.Spec.Schema.Spec
+	assert.Equal(t, &typeObject, schema.Type)
+	assert.Nil(t, schema.OneOf, "multiple formData params must not be bundled into oneOf")
+	assert.Len(t, schema.Properties, 4)
+
+	id := schema.Properties["id"]
+	if assert.NotNil(t, id) && assert.NotNil(t, id.Spec) {
+		assert.Equal(t, &typeInteger, id.Spec.Type)
+	}
+
+	name := schema.Properties["name"]
+	if assert.NotNil(t, name) && assert.NotNil(t, name.Spec) {
+		assert.Equal(t, &typeString, name.Spec.Type)
+	}
+
+	activated := schema.Properties["activated"]
+	if assert.NotNil(t, activated) && assert.NotNil(t, activated.Spec) {
+		assert.Equal(t, &spec.SingleOrArray[string]{BOOLEAN}, activated.Spec.Type)
+	}
+
+	assert.ElementsMatch(t, []string{"id"}, schema.Required)
+}
+
 func TestParseParamCommentByNotSupportedTypeV3(t *testing.T) {
 	t.Parallel()
 

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1375,6 +1375,40 @@ func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
 	assert.Contains(t, requestBodySpec.Schema.Spec.Required, "file")
 }
 
+func TestParseParamCommentByFormDataTypeFileArrayV3(t *testing.T) {
+	t.Parallel()
+
+	comment := `@Param files formData []file true "multiple files"`
+	operation := NewOperationV3(New())
+
+	err := operation.ParseComment(comment, nil)
+	require.NoError(t, err)
+
+	assert.Len(t, operation.Parameters, 0)
+
+	requestBody := operation.RequestBody
+	require.NotNil(t, requestBody)
+	assert.Equal(t, "multiple files", requestBody.Spec.Spec.Description)
+
+	media := requestBody.Spec.Spec.Content["multipart/form-data"]
+	require.NotNil(t, media)
+	require.NotNil(t, media.Spec.Schema)
+	require.NotNil(t, media.Spec.Schema.Spec)
+
+	prop := media.Spec.Schema.Spec.Properties["files"]
+	require.NotNil(t, prop)
+	require.NotNil(t, prop.Spec)
+	assert.Equal(t, &typeArray, prop.Spec.Type)
+
+	require.NotNil(t, prop.Spec.Items)
+	require.NotNil(t, prop.Spec.Items.Schema)
+	require.NotNil(t, prop.Spec.Items.Schema.Spec)
+	assert.Equal(t, &typeString, prop.Spec.Items.Schema.Spec.Type)
+	assert.Equal(t, "binary", prop.Spec.Items.Schema.Spec.Format)
+
+	assert.Contains(t, media.Spec.Schema.Spec.Required, "files")
+}
+
 func TestParseParamCommentByFormDataMultipleParamsMultipartV3(t *testing.T) {
 	t.Parallel()
 

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1319,11 +1319,33 @@ func TestParseParamCommentByFormDataTypeV3(t *testing.T) {
 	requestBody := operation.RequestBody
 	assert.True(t, requestBody.Spec.Spec.Required)
 	assert.Equal(t, "this is a test file", requestBody.Spec.Spec.Description)
-	assert.NotNil(t, requestBody)
 
 	requestBodySpec := requestBody.Spec.Spec
 	assert.NotNil(t, requestBodySpec)
-	assert.Equal(t, &typeFile, requestBodySpec.Content["application/x-www-form-urlencoded"].Spec.Schema.Spec.Type)
+
+	media := requestBodySpec.Content["multipart/form-data"]
+	if assert.NotNil(t, media) {
+		if assert.NotNil(t, media.Spec.Schema) && assert.NotNil(t, media.Spec.Schema.Spec) {
+			assert.Equal(
+				t,
+				&spec.SingleOrArray[string]{OBJECT},
+				media.Spec.Schema.Spec.Type,
+			)
+
+			prop := media.Spec.Schema.Spec.Properties["file"]
+			if assert.NotNil(t, prop) && assert.NotNil(t, prop.Spec) {
+				assert.Equal(
+					t,
+					&spec.SingleOrArray[string]{STRING},
+					prop.Spec.Type,
+				)
+				assert.Equal(t, "binary", prop.Spec.Format)
+				assert.Equal(t, "this is a test file", prop.Spec.Description)
+			}
+
+			assert.Contains(t, media.Spec.Schema.Spec.Required, "file")
+		}
+	}
 }
 
 func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
@@ -1343,7 +1365,14 @@ func TestParseParamCommentByFormDataTypeUint64V3(t *testing.T) {
 
 	requestBodySpec := requestBody.Spec.Spec.Content["application/x-www-form-urlencoded"].Spec
 	assert.NotNil(t, requestBodySpec)
-	assert.Equal(t, &typeInteger, requestBodySpec.Schema.Spec.Type)
+	assert.Equal(t, &typeObject, requestBodySpec.Schema.Spec.Type)
+
+	prop := requestBodySpec.Schema.Spec.Properties["file"]
+	if assert.NotNil(t, prop) && assert.NotNil(t, prop.Spec) {
+		assert.Equal(t, &typeInteger, prop.Spec.Type)
+	}
+
+	assert.Contains(t, requestBodySpec.Schema.Spec.Required, "file")
 }
 
 func TestParseParamCommentByNotSupportedTypeV3(t *testing.T) {

--- a/testdata/v3/formdata/main.go
+++ b/testdata/v3/formdata/main.go
@@ -1,0 +1,39 @@
+package main
+
+import "net/http"
+
+// @title Swagger Example API
+// @version 1.0
+// @description This is a sample server for exercising formData request bodies.
+func main() {
+	http.HandleFunc("/import", ImportSettings)
+	http.HandleFunc("/checks/update", UpdateCheck)
+}
+
+// @Summary Import settings
+// @Accept          multipart/form-data
+// @Produce         plain
+// @Param           zip                   formData file    true  "Zip file containing checks.toml, users.toml, and/or settings.toml"
+// @Param           destructiveChecks     formData boolean false "If true, destructively replace existing checks during checks.toml import"
+// @Param           destructiveUsers      formData boolean false "If true, destructively replace existing users during users.toml import"
+// @Param           destructiveSettings   formData boolean false "If true, destructively replace existing settings during settings.toml import"
+// @Success 200
+// @Router /import [post]
+func ImportSettings(w http.ResponseWriter, r *http.Request) {
+}
+
+// @Summary Update check
+// @Accept          application/x-www-form-urlencoded
+// @Param           id          formData    int     true    "Check ID to update"
+// @Param           name        formData    string  false   "Update check name"
+// @Param           description formData    string  false   "Update check description"
+// @Param           weight      formData    int     false   "Update check weight"
+// @Param           activated   formData    boolean false   "Update check activation"
+// @Param           allow_user_secrets  formData boolean false  "Are teams allowed to change the checks auth parameters?"
+// @Param           type        formData    string  false   "Update check type"
+// @Param           source      formData    string  false   "Update check source"
+// @Param           metadata    formData    string  false   "Update check metadata"
+// @Success 200
+// @Router /checks/update [post]
+func UpdateCheck(w http.ResponseWriter, r *http.Request) {
+}


### PR DESCRIPTION
**Describe the PR**
Currently v2 branch has an issue with the generation of x-www-form-urlencoded and multipart/form-data schemas. For some reason, when generating the yaml and json for the swagger files, it is decided that if you have multiple` //@Param` comments then they all get bundled into a single `oneOf` statement which is not supposed to happen. For both forms they should look something like the following:

```go
// @Accept          multipart/form-data
// @Produce         plain
// @Param           zip                   formData file    true  "Zip file containing checks.toml, users.toml, and/or settings.toml"
// @Param           destructiveChecks     formData boolean false "If true, destructively replace existing checks during checks.toml import"
// @Param           destructiveUsers      formData boolean false "If true, destructively replace existing users during users.toml import"
// @Param           destructiveSettings   formData boolean false "If true, destructively replace existing settings during settings.toml import"
```
Above comments correctly generates the below yaml:
```yaml
requestBody:
        content:
          multipart/form-data:
            schema:
              properties:
                destructiveChecks:
                  description: If true, destructively replace existing checks during
                    checks.toml import
                  type: boolean
                destructiveSettings:
                  description: If true, destructively replace existing settings during
                    settings.toml import
                  type: boolean
                destructiveUsers:
                  description: If true, destructively replace existing users during
                    users.toml import
                  type: boolean
                zip:
                  description: Zip file containing checks.toml, users.toml, and/or
                    settings.toml
                  format: binary
                  type: string
              required:
              - zip
              type: object

```

```go
// @Accept          application/x-www-form-urlencoded
// @Param           id          formData    int     true    "Check ID to update"
// @Param           name        formData    string  false   "Update check name"
// @Param           description formData    string  false   "Update check description"
// @Param           weight      formData    int     false   "Update check weight"
// @Param           activated   formData    boolean false   "Update check activation"
// @Param           allow_user_secrets  formData boolean false  "Are teams allowed to change the checks auth parameters?"
// @Param           type        formData    string  false   "Update check type"
// @Param           source      formData    string  false   "Update check source"
// @Param           metadata    formData    string  false   "Update check metadata"

```
Above x-www-form-urlencoded form correctly produces the following yaml:
```yaml
      requestBody:
        content:
          application/x-www-form-urlencoded:
            schema:
              properties:
                activated:
                  description: Update check activation
                  type: boolean
                allow_user_secrets:
                  description: Are teams allowed to change the checks auth parameters?
                  type: boolean
                description:
                  description: Update check description
                  type: string
                id:
                  description: Check ID to update
                  type: integer
                metadata:
                  description: Update check metadata
                  type: string
                name:
                  description: Update check name
                  type: string
                source:
                  description: Update check source
                  type: string
                type:
                  description: Update check type
                  type: string
                weight:
                  description: Update check weight
                  type: integer
              required:
              - id
              type: object

```

**Relation issue**
[Issue 242](https://github.com/swaggo/swag/issues/2142)
[Issue 2086](https://github.com/swaggo/swag/issues/2086)

Both of the above issues are related to this. I didn't have time to test and see if this also fixed the json body issues that they were having but I know it at least works for the issues I have described.

[PR 2131 ](https://github.com/swaggo/swag/pull/2131)  also seems to fix the `//@Accept` issue so if that gets merged in first then I can remove it from this PR as well

**Additional context**
Go version: 1.25.8
Swag Version: 2.0.0 ([Commit 8c7a6f6](https://github.com/swaggo/swag/commit/8c7a6f694eb43caee7b8b94699f6f08d6fb123f0))

Please let me know if there is anything I should change to help get this merged in soon. Thanks for making this project!