### PR TITLE
fix(swag fmt): use single space after // for gofmt compatibility

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -123,7 +123,7 @@ func formatFuncDoc(fileSet *token.FileSet, commentList []*ast.Comment, edits *ed
 	for commentIndex, comment := range commentList {
 		text := comment.Text
 		if attr, body, found := swagComment(text); found {
-			formatted := "//\t" + attr
+			formatted := "// " + attr
 			if body != "" {
 				formatted += "\t" + splitComment2(attr, body)
 			}

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -65,47 +65,47 @@ func Test_FormatMain(t *testing.T) {
 
 	want := `package main
 
-//	@title			Swagger Example API
-//	@version		1.0
-//	@description	This is a sample server Petstore server.
-//	@termsOfService	http://swagger.io/terms/
+// @title			Swagger Example API
+// @version			1.0
+// @description		This is a sample server Petstore server.
+// @termsOfService	http://swagger.io/terms/
 
-//	@contact.name	API Support
-//	@contact.url	http://www.swagger.io/support
-//	@contact.email	support@swagger.io
+// @contact.name	API Support
+// @contact.url		http://www.swagger.io/support
+// @contact.email	support@swagger.io
 
-//	@license.name	Apache 2.0
-//	@license.url	http://www.apache.org/licenses/LICENSE-2.0.html
+// @license.name	Apache 2.0
+// @license.url		http://www.apache.org/licenses/LICENSE-2.0.html
 
-//	@host		petstore.swagger.io
-//	@BasePath	/v2
+// @host		petstore.swagger.io
+// @BasePath	/v2
 
-//	@securityDefinitions.basic	BasicAuth
+// @securityDefinitions.basic	BasicAuth
 
-//	@securityDefinitions.apikey	ApiKeyAuth
-//	@in							header
-//	@name						Authorization
+// @securityDefinitions.apikey	ApiKeyAuth
+// @in							header
+// @name						Authorization
 
-//	@securitydefinitions.oauth2.application	OAuth2Application
-//	@tokenUrl								https://example.com/oauth/token
-//	@scope.write							Grants write access
-//	@scope.admin							Grants read and write access to administrative information
+// @securitydefinitions.oauth2.application	OAuth2Application
+// @tokenUrl								https://example.com/oauth/token
+// @scope.write								Grants write access
+// @scope.admin								Grants read and write access to administrative information
 
-//	@securitydefinitions.oauth2.implicit	OAuth2Implicit
-//	@authorizationurl						https://example.com/oauth/authorize
-//	@scope.write							Grants write access
-//	@scope.admin							Grants read and write access to administrative information
+// @securitydefinitions.oauth2.implicit	OAuth2Implicit
+// @authorizationurl					https://example.com/oauth/authorize
+// @scope.write							Grants write access
+// @scope.admin							Grants read and write access to administrative information
 
-//	@securitydefinitions.oauth2.password	OAuth2Password
-//	@tokenUrl								https://example.com/oauth/token
-//	@scope.read								Grants read access
-//	@scope.write							Grants write access
-//	@scope.admin							Grants read and write access to administrative information
+// @securitydefinitions.oauth2.password	OAuth2Password
+// @tokenUrl							https://example.com/oauth/token
+// @scope.read							Grants read access
+// @scope.write							Grants write access
+// @scope.admin							Grants read and write access to administrative information
 
 // @securitydefinitions.oauth2.accessCode	OAuth2AccessCode
 // @tokenUrl								https://example.com/oauth/token
 // @authorizationurl						https://example.com/oauth/authorize
-// @scope.admin							Grants read and write access to administrative information
+// @scope.admin								Grants read and write access to administrative information
 func main() {}
 `
 	testFormat(t, "main.go", contents, want)
@@ -166,15 +166,15 @@ import "net/http"
 
 // @Summary		Add a new pet to the store
 // @Description	get string by ID
-// @ID				get-string-by-int
-// @Accept			json
+// @ID			get-string-by-int
+// @Accept		json
 // @Produce		json
-// @Param			some_id	path		int				true	"Some ID"	Format(int64)
-// @Param			some_id	body		web.Pet			true	"Some ID"
+// @Param		some_id	path		int				true	"Some ID"	Format(int64)
+// @Param		some_id	body		web.Pet			true	"Some ID"
 // @Success		200		{string}	string			"ok"
 // @Failure		400		{object}	web.APIError	"We need ID!!"
 // @Failure		404		{object}	web.APIError	"Can not find ID"
-// @Router			/testapi/get-string-by-int/{some_id} [get]
+// @Router		/testapi/get-string-by-int/{some_id} [get]
 func GetStringByInt(w http.ResponseWriter, r *http.Request) {}
 `
 
@@ -191,9 +191,9 @@ func Test_NonSwagComment(t *testing.T) {
 // This is not a @swag comment`
 	want := `package api
 
-//	@Summary		Add a new pet to the store
-//	@Description	get string by ID
-//	@ID				get-string-by-int
+// @Summary		Add a new pet to the store
+// @Description	get string by ID
+// @ID			get-string-by-int
 // @ Accept json
 // This is not a @swag comment
 `
@@ -208,8 +208,8 @@ func Test_EmptyComment(t *testing.T) {
 // @Description  `
 	want := `package empty
 
-//	@Summary	Add a new pet to the store
-//	@Description
+// @Summary	Add a new pet to the store
+// @Description
 `
 
 	testFormat(t, "empty.go", contents, want)
@@ -222,8 +222,8 @@ func Test_AlignAttribute(t *testing.T) {
 //  @Description Description`
 	want := `package align
 
-//	@Summary		Add a new pet to the store
-//	@Description	Description
+// @Summary		Add a new pet to the store
+// @Description	Description
 `
 
 	testFormat(t, "align.go", contents, want)


### PR DESCRIPTION
**Problem**:
`swag fmt `adds a tab after `// (e.g., //\t@Summary)`.
`gofmt` always replaces any tab or multiple spaces after `// with a single space (// @Summary)`.
This creates a formatting conflict on every save, leading to unwanted diffs and forcing developers to disable auto-formatting.

**Fix**:
Change `swag fmt` to output a single space after `// (// @Summary)` instead of a tab.
This matches `gofmt`'s expected format and keeps alignment inside the comment untouched.

**Current `swag fmt` output (with tab after //)**:
<img width="1439" height="411" alt="image" src="https://github.com/user-attachments/assets/80240e2b-42a0-4f8c-a92e-bcf7aeda281a" />

**After running `gofmt` (tab replaced by space)**:
```
❯ diff -u main.go <(gofmt main.go)
--- main.go     2026-04-20 22:52:36.017724139 +0500
+++ /proc/self/fd/12    2026-04-20 22:52:51.265711529 +0500
@@ -5,8 +5,8 @@
 //     @description    This is a sample server Petstore server.
 //     @termsOfService http://swagger.io/terms/
 
-//     @securitydefinitions.oauth2.accessCode  OAuth2AccessCode
-//     @tokenUrl                                                               https://example.com/oauth/token
-//     @authorizationurl                                               https://example.com/oauth/authorize
-//     @scope.admin                                                    Grants read and write access to administrative information
+// @securitydefinitions.oauth2.accessCode      OAuth2AccessCode
+// @tokenUrl                                                           https://example.com/oauth/token
+// @authorizationurl                                           https://example.com/oauth/authorize
+// @scope.admin                                                        Grants read and write access to administrative information
 func main() {}
 ```
 
 **With this fix (space after //)**:
 
<img width="1439" height="411" alt="image" src="https://github.com/user-attachments/assets/b5a878f0-045b-47c6-a83d-84d3ca64d661" />

**After running `gofmt`**:
```
❯ diff -u main.go <(gofmt main.go) || echo "No differences"
No differences
```
