### PR TITLE
feat: add --requiredByDefaultMode=pointer to mark non-pointer fields as required

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -15,37 +15,37 @@ import (
 )
 
 const (
-	searchDirFlag            = "dir"
-	excludeFlag              = "exclude"
-	generalInfoFlag          = "generalInfo"
-	pipeFlag                 = "pipe"
-	propertyStrategyFlag     = "propertyStrategy"
-	outputFlag               = "output"
-	outputTypesFlag          = "outputTypes"
-	parseVendorFlag          = "parseVendor"
-	parseDependencyFlag      = "parseDependency"
-	useStructNameFlag        = "useStructName"
-	parseDependencyLevelFlag = "parseDependencyLevel"
-	markdownFilesFlag        = "markdownFiles"
-	codeExampleFilesFlag     = "codeExampleFiles"
-	parseInternalFlag        = "parseInternal"
-	generatedTimeFlag        = "generatedTime"
-	requiredByDefaultFlag        = "requiredByDefault"
-	requiredByDefaultModeFlag    = "requiredByDefaultMode"
-	parseDepthFlag           = "parseDepth"
-	instanceNameFlag         = "instanceName"
-	overridesFileFlag        = "overridesFile"
-	parseGoListFlag          = "parseGoList"
-	quietFlag                = "quiet"
-	tagsFlag                 = "tags"
-	parseExtensionFlag       = "parseExtension"
-	templateDelimsFlag       = "templateDelims"
-	packageName              = "packageName"
-	collectionFormatFlag     = "collectionFormat"
-	packagePrefixFlag        = "packagePrefix"
-	stateFlag                = "state"
-	parseFuncBodyFlag        = "parseFuncBody"
-	parseGoPackagesFlag      = "parseGoPackages"
+	searchDirFlag             = "dir"
+	excludeFlag               = "exclude"
+	generalInfoFlag           = "generalInfo"
+	pipeFlag                  = "pipe"
+	propertyStrategyFlag      = "propertyStrategy"
+	outputFlag                = "output"
+	outputTypesFlag           = "outputTypes"
+	parseVendorFlag           = "parseVendor"
+	parseDependencyFlag       = "parseDependency"
+	useStructNameFlag         = "useStructName"
+	parseDependencyLevelFlag  = "parseDependencyLevel"
+	markdownFilesFlag         = "markdownFiles"
+	codeExampleFilesFlag      = "codeExampleFiles"
+	parseInternalFlag         = "parseInternal"
+	generatedTimeFlag         = "generatedTime"
+	requiredByDefaultFlag     = "requiredByDefault"
+	requiredByDefaultModeFlag = "requiredByDefaultMode"
+	parseDepthFlag            = "parseDepth"
+	instanceNameFlag          = "instanceName"
+	overridesFileFlag         = "overridesFile"
+	parseGoListFlag           = "parseGoList"
+	quietFlag                 = "quiet"
+	tagsFlag                  = "tags"
+	parseExtensionFlag        = "parseExtension"
+	templateDelimsFlag        = "templateDelims"
+	packageName               = "packageName"
+	collectionFormatFlag      = "collectionFormat"
+	packagePrefixFlag         = "packagePrefix"
+	stateFlag                 = "state"
+	parseFuncBodyFlag         = "parseFuncBody"
+	parseGoPackagesFlag       = "parseGoPackages"
 )
 
 var initFlags = []cli.Flag{
@@ -256,36 +256,36 @@ func initAction(ctx *cli.Context) error {
 		}
 	}
 	return gen.New().Build(&gen.Config{
-		SearchDir:           ctx.String(searchDirFlag),
-		Excludes:            ctx.String(excludeFlag),
-		ParseExtension:      ctx.String(parseExtensionFlag),
-		MainAPIFile:         ctx.String(generalInfoFlag),
-		PropNamingStrategy:  strategy,
-		OutputDir:           ctx.String(outputFlag),
-		OutputTypes:         outputTypes,
-		ParseVendor:         ctx.Bool(parseVendorFlag),
-		ParseDependency:     pdv,
-		MarkdownFilesDir:    ctx.String(markdownFilesFlag),
-		ParseInternal:       ctx.Bool(parseInternalFlag),
-		UseStructNames:      ctx.Bool(useStructNameFlag),
-		GeneratedTime:       ctx.Bool(generatedTimeFlag),
+		SearchDir:             ctx.String(searchDirFlag),
+		Excludes:              ctx.String(excludeFlag),
+		ParseExtension:        ctx.String(parseExtensionFlag),
+		MainAPIFile:           ctx.String(generalInfoFlag),
+		PropNamingStrategy:    strategy,
+		OutputDir:             ctx.String(outputFlag),
+		OutputTypes:           outputTypes,
+		ParseVendor:           ctx.Bool(parseVendorFlag),
+		ParseDependency:       pdv,
+		MarkdownFilesDir:      ctx.String(markdownFilesFlag),
+		ParseInternal:         ctx.Bool(parseInternalFlag),
+		UseStructNames:        ctx.Bool(useStructNameFlag),
+		GeneratedTime:         ctx.Bool(generatedTimeFlag),
 		RequiredByDefault:     ctx.Bool(requiredByDefaultFlag),
 		RequiredByDefaultMode: ctx.String(requiredByDefaultModeFlag),
-		CodeExampleFilesDir: ctx.String(codeExampleFilesFlag),
-		ParseDepth:          ctx.Int(parseDepthFlag),
-		InstanceName:        ctx.String(instanceNameFlag),
-		OverridesFile:       ctx.String(overridesFileFlag),
-		ParseGoList:         ctx.Bool(parseGoListFlag),
-		Tags:                ctx.String(tagsFlag),
-		LeftTemplateDelim:   leftDelim,
-		RightTemplateDelim:  rightDelim,
-		PackageName:         ctx.String(packageName),
-		Debugger:            logger,
-		CollectionFormat:    collectionFormat,
-		PackagePrefix:       ctx.String(packagePrefixFlag),
-		State:               ctx.String(stateFlag),
-		ParseFuncBody:       ctx.Bool(parseFuncBodyFlag),
-		ParseGoPackages:     ctx.Bool(parseGoPackagesFlag),
+		CodeExampleFilesDir:   ctx.String(codeExampleFilesFlag),
+		ParseDepth:            ctx.Int(parseDepthFlag),
+		InstanceName:          ctx.String(instanceNameFlag),
+		OverridesFile:         ctx.String(overridesFileFlag),
+		ParseGoList:           ctx.Bool(parseGoListFlag),
+		Tags:                  ctx.String(tagsFlag),
+		LeftTemplateDelim:     leftDelim,
+		RightTemplateDelim:    rightDelim,
+		PackageName:           ctx.String(packageName),
+		Debugger:              logger,
+		CollectionFormat:      collectionFormat,
+		PackagePrefix:         ctx.String(packagePrefixFlag),
+		State:                 ctx.String(stateFlag),
+		ParseFuncBody:         ctx.Bool(parseFuncBodyFlag),
+		ParseGoPackages:       ctx.Bool(parseGoPackagesFlag),
 	})
 }
 

--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -30,7 +30,8 @@ const (
 	codeExampleFilesFlag     = "codeExampleFiles"
 	parseInternalFlag        = "parseInternal"
 	generatedTimeFlag        = "generatedTime"
-	requiredByDefaultFlag    = "requiredByDefault"
+	requiredByDefaultFlag        = "requiredByDefault"
+	requiredByDefaultModeFlag    = "requiredByDefaultMode"
 	parseDepthFlag           = "parseDepth"
 	instanceNameFlag         = "instanceName"
 	overridesFileFlag        = "overridesFile"
@@ -134,6 +135,10 @@ var initFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  requiredByDefaultFlag,
 		Usage: "Set validation required for all fields by default",
+	},
+	&cli.StringFlag{
+		Name:  requiredByDefaultModeFlag,
+		Usage: `Set the mode for --requiredByDefault. "all" (default) requires all fields, "pointer" requires only non-pointer fields`,
 	},
 	&cli.StringFlag{
 		Name:  instanceNameFlag,
@@ -264,7 +269,8 @@ func initAction(ctx *cli.Context) error {
 		ParseInternal:       ctx.Bool(parseInternalFlag),
 		UseStructNames:      ctx.Bool(useStructNameFlag),
 		GeneratedTime:       ctx.Bool(generatedTimeFlag),
-		RequiredByDefault:   ctx.Bool(requiredByDefaultFlag),
+		RequiredByDefault:     ctx.Bool(requiredByDefaultFlag),
+		RequiredByDefaultMode: ctx.String(requiredByDefaultModeFlag),
 		CodeExampleFilesDir: ctx.String(codeExampleFilesFlag),
 		ParseDepth:          ctx.Int(parseDepthFlag),
 		InstanceName:        ctx.String(instanceNameFlag),

--- a/field_parser.go
+++ b/field_parser.go
@@ -554,6 +554,11 @@ func (ps *tagBaseFieldParser) IsRequired() (bool, error) {
 		}
 	}
 
+	if ps.p.RequiredByDefaultMode == "pointer" {
+		_, isPointer := ps.field.Type.(*ast.StarExpr)
+		return !isPointer, nil
+	}
+
 	return ps.p.RequiredByDefault, nil
 }
 

--- a/field_parser.go
+++ b/field_parser.go
@@ -554,7 +554,10 @@ func (ps *tagBaseFieldParser) IsRequired() (bool, error) {
 		}
 	}
 
-	if ps.p.RequiredByDefaultMode == "pointer" {
+	switch ps.p.RequiredByDefaultMode {
+	case "all":
+		return true, nil
+	case "pointer":
 		_, isPointer := ps.field.Type.(*ast.StarExpr)
 		return !isPointer, nil
 	}

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -149,6 +149,22 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.False(t, got)
 	})
 
+	t.Run("RequiredByDefaultMode all - field is required", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefaultMode: "all",
+			},
+			&ast.Field{
+				Tag:  &ast.BasicLit{Value: `json:"test"`},
+				Type: &ast.StarExpr{X: &ast.Ident{Name: "string"}},
+			},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.True(t, got)
+	})
+
 	t.Run("RequiredByDefaultMode pointer - non-pointer field is required", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -149,6 +149,70 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.False(t, got)
 	})
 
+	t.Run("RequiredByDefaultMode pointer - non-pointer field is required", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefaultMode: "pointer",
+			},
+			&ast.Field{
+				Tag:  &ast.BasicLit{Value: `json:"test"`},
+				Type: &ast.Ident{Name: "string"},
+			},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("RequiredByDefaultMode pointer - pointer field is not required", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefaultMode: "pointer",
+			},
+			&ast.Field{
+				Tag:  &ast.BasicLit{Value: `json:"test"`},
+				Type: &ast.StarExpr{X: &ast.Ident{Name: "string"}},
+			},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("RequiredByDefaultMode pointer - omitempty overrides non-pointer", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefaultMode: "pointer",
+			},
+			&ast.Field{
+				Tag:  &ast.BasicLit{Value: `json:"test,omitempty"`},
+				Type: &ast.Ident{Name: "string"},
+			},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("RequiredByDefaultMode pointer - optional tag overrides non-pointer", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := newTagBaseFieldParser(
+			&Parser{
+				RequiredByDefaultMode: "pointer",
+			},
+			&ast.Field{
+				Tag:  &ast.BasicLit{Value: `json:"test" binding:"optional"`},
+				Type: &ast.Ident{Name: "string"},
+			},
+		).IsRequired()
+		assert.NoError(t, err)
+		assert.False(t, got)
+	})
+
 	t.Run("Extensions tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -123,6 +123,10 @@ type Config struct {
 	// RequiredByDefault set validation required for all fields by default
 	RequiredByDefault bool
 
+	// RequiredByDefaultMode controls which fields are required when RequiredByDefault is not set.
+	// "pointer" marks only non-pointer fields as required.
+	RequiredByDefaultMode string
+
 	// OverridesFile defines global type overrides.
 	OverridesFile string
 
@@ -224,6 +228,7 @@ func (g *Gen) Build(config *Config) error {
 	p.ParseVendor = config.ParseVendor
 	p.ParseInternal = config.ParseInternal
 	p.RequiredByDefault = config.RequiredByDefault
+	p.RequiredByDefaultMode = config.RequiredByDefaultMode
 	p.HostState = config.State
 	p.ParseFuncBody = config.ParseFuncBody
 	p.ParseGoPackages = config.ParseGoPackages

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -124,7 +124,7 @@ type Config struct {
 	RequiredByDefault bool
 
 	// RequiredByDefaultMode controls which fields are required when RequiredByDefault is not set.
-	// "pointer" marks only non-pointer fields as required.
+	// "all" marks all fields as required; "pointer" marks only non-pointer fields as required.
 	RequiredByDefaultMode string
 
 	// OverridesFile defines global type overrides.

--- a/parser.go
+++ b/parser.go
@@ -140,6 +140,10 @@ type Parser struct {
 	// RequiredByDefault set validation required for all fields by default
 	RequiredByDefault bool
 
+	// RequiredByDefaultMode controls which fields are required when RequiredByDefault is not set.
+	// "pointer" marks only non-pointer fields as required.
+	RequiredByDefaultMode string
+
 	// structStack stores full names of the structures that were already parsed or are being parsed now
 	structStack []*TypeSpecDef
 

--- a/parser.go
+++ b/parser.go
@@ -141,7 +141,7 @@ type Parser struct {
 	RequiredByDefault bool
 
 	// RequiredByDefaultMode controls which fields are required when RequiredByDefault is not set.
-	// "pointer" marks only non-pointer fields as required.
+	// "all" marks all fields as required; "pointer" marks only non-pointer fields as required.
 	RequiredByDefaultMode string
 
 	// structStack stores full names of the structures that were already parsed or are being parsed now


### PR DESCRIPTION
Adds a new --requiredByDefaultMode flag to control which fields are marked as required by default. Supported values are "all" (all fields required) and "pointer" (only non-pointer fields required), reflecting Go semantics where non-pointer fields always have a value and cannot be nil.

Explicit tags (binding/validate:"optional", json:",omitempty") still take precedence. The existing --requiredByDefault flag is unchanged for full backward compatibility.

fix #901 