### PR TITLE
fix(openapi3): filter root tags by selection

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -3113,6 +3113,22 @@ func TestParseTagMarkdownDescription(t *testing.T) {
 	}
 }
 
+func TestApiParseTag_Filtered(t *testing.T) {
+	t.Parallel()
+
+	searchDir := "testdata/tags"
+	p := New(SetMarkdownFileDirectory(searchDir), SetTags("dogs,apes"))
+	p.PropNamingStrategy = PascalCase
+
+	err := p.ParseAPI(searchDir, mainAPIFile, defaultParseDepth)
+	assert.NoError(t, err)
+
+	if assert.Len(t, p.swagger.Tags, 2) {
+		assert.Equal(t, "dogs", p.swagger.Tags[0].TagProps.Name)
+		assert.Equal(t, "apes", p.swagger.Tags[1].TagProps.Name)
+	}
+}
+
 func TestParseApiMarkdownDescription(t *testing.T) {
 	t.Parallel()
 

--- a/parserv3.go
+++ b/parserv3.go
@@ -39,6 +39,7 @@ var (
 
 func (p *Parser) parseGeneralAPIInfoV3(comments []string) error {
 	previousAttribute := ""
+	var tag *spec.Extendable[spec.Tag]
 
 	// parsing classic meta data model
 	for line := 0; line < len(comments); line++ {
@@ -97,36 +98,43 @@ func (p *Parser) parseGeneralAPIInfoV3(comments []string) error {
 		case "@schemes":
 			println("@schemes is deprecated use servers instead")
 		case "@tag.name":
-			tag := &spec.Extendable[spec.Tag]{
-				Spec: &spec.Tag{
-					Name: value,
-				},
-			}
+			if p.matchTag(value) {
+				tag = &spec.Extendable[spec.Tag]{
+					Spec: &spec.Tag{
+						Name: value,
+					},
+				}
 
-			p.openAPI.Tags = append(p.openAPI.Tags, tag)
+				p.openAPI.Tags = append(p.openAPI.Tags, tag)
+			} else {
+				tag = nil
+			}
 		case "@tag.description":
-			tag := p.openAPI.Tags[len(p.openAPI.Tags)-1]
-			tag.Spec.Description = value
+			if tag != nil {
+				tag.Spec.Description = value
+			}
 		case "@tag.description.markdown":
-			tag := p.openAPI.Tags[len(p.openAPI.Tags)-1]
+			if tag != nil {
+				commentInfo, err := getMarkdownForTag(tag.Spec.Name, p.markdownFileDir)
+				if err != nil {
+					return err
+				}
 
-			commentInfo, err := getMarkdownForTag(tag.Spec.Name, p.markdownFileDir)
-			if err != nil {
-				return err
+				tag.Spec.Description = string(commentInfo)
 			}
-
-			tag.Spec.Description = string(commentInfo)
 		case "@tag.docs.url":
-			tag := p.openAPI.Tags[len(p.openAPI.Tags)-1]
-			tag.Spec.ExternalDocs = spec.NewExternalDocs()
-			tag.Spec.ExternalDocs.Spec.URL = value
-		case "@tag.docs.description":
-			tag := p.openAPI.Tags[len(p.openAPI.Tags)-1]
-			if tag.Spec.ExternalDocs == nil {
-				return fmt.Errorf("%s needs to come after a @tags.docs.url", attribute)
+			if tag != nil {
+				tag.Spec.ExternalDocs = spec.NewExternalDocs()
+				tag.Spec.ExternalDocs.Spec.URL = value
 			}
+		case "@tag.docs.description":
+			if tag != nil {
+				if tag.Spec.ExternalDocs == nil {
+					return fmt.Errorf("%s needs to come after a @tags.docs.url", attribute)
+				}
 
-			tag.Spec.ExternalDocs.Spec.Description = value
+				tag.Spec.ExternalDocs.Spec.Description = value
+			}
 		case secBasicAttr, secAPIKeyAttr, secApplicationAttr, secImplicitAttr, secPasswordAttr, secAccessCodeAttr, secBearerAuthAttr:
 			key, scheme, err := parseSecAttributesV3(attribute, comments, &line)
 			if err != nil {

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -254,6 +254,21 @@ func TestParserParseGeneralAPIInfoMarkdownV3(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestParserParseGeneralAPIInfoMarkdownV3FilteredTags(t *testing.T) {
+	t.Parallel()
+
+	p := New(SetMarkdownFileDirectory("testdata"), SetTags("users"), GenerateOpenAPI3Doc(true))
+	mainAPIFile := "testdata/markdown.go"
+
+	err := p.ParseGeneralAPIInfo(mainAPIFile)
+	assert.NoError(t, err)
+
+	if assert.Len(t, p.openAPI.Tags, 1) {
+		assert.Equal(t, "users", p.openAPI.Tags[0].Spec.Name)
+		assert.Equal(t, "Users Tag Markdown Description", p.openAPI.Tags[0].Spec.Description)
+	}
+}
+
 func TestParserParseGeneralApiInfoFailedV3(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Fixes Filtering on Swaggo V2 Openapi V3.1 generator
Current filtering is broken - it includes root tags of not included tags. 
With this fix, we properly filter out the not needed tags.

### Example
`swag init --v3.1 --tags "Tag3,Tag4"`
**Before:**  Output includes all the tags, aka "Tag1, Tag2, Tag3, Tag4"
**After:** Only --tags "Tag3,Tag4" included in the output