### PR TITLE
Openapi v3 fix duplicates in enums

### DIFF
--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -281,6 +281,44 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		}
 	})
 
+	t.Run("Enums tag on array item ref schema does not mutate component schema", func(t *testing.T) {
+		t.Parallel()
+
+		parser := New()
+		parser.openAPIVersion = true
+
+		componentSchema := spec.NewSchemaSpec()
+		componentSchema.Spec.Type = &spec.SingleOrArray[string]{STRING}
+		componentSchema.Spec.Enum = []interface{}{"image", "video"}
+		parser.openAPI.Components.Spec.Schemas = map[string]*spec.RefOrSpec[spec.Schema]{
+			"PostType": componentSchema,
+		}
+
+		schema := spec.NewSchemaSpec()
+		schema.Spec.Type = &spec.SingleOrArray[string]{ARRAY}
+		schema.Spec.Items = spec.NewBoolOrSchema(false, spec.NewRefOrSpec[spec.Schema](spec.NewRef("#/components/schemas/PostType"), nil))
+
+		err := newTagBaseFieldParserV3(
+			parser,
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{
+				Names: []*ast.Ident{{Name: "Types"}},
+				Tag: &ast.BasicLit{
+					Value: `json:"types" validate:"oneof=video image"`,
+				},
+			},
+		).ComplementSchema(schema)
+		assert.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"image", "video"}, componentSchema.Spec.Enum)
+		if assert.NotNil(t, schema.Spec.Items.Schema.Spec) {
+			assert.Equal(t, []interface{}{"video", "image"}, schema.Spec.Items.Schema.Spec.Enum)
+			if assert.Len(t, schema.Spec.Items.Schema.Spec.AllOf, 1) {
+				assert.Equal(t, "#/components/schemas/PostType", schema.Spec.Items.Schema.Spec.AllOf[0].Ref.Ref)
+			}
+		}
+	})
+
 	t.Run("EnumVarNames tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -274,10 +274,8 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		assert.Equal(t, []string{"PostTypeImage", "PostTypeVideo"}, componentSchema.Spec.Extensions[enumVarNamesExtension])
 		if assert.NotNil(t, schema.Spec) {
 			assert.Equal(t, "video", schema.Spec.Example)
-			if assert.Len(t, schema.Spec.AllOf, 1) {
-				assert.Equal(t, "#/components/schemas/PostType", schema.Spec.AllOf[0].Ref.Ref)
-			}
-			assert.Equal(t, []interface{}{"video", "image"}, schema.Spec.Enum)
+			assert.Equal(t, "#/components/schemas/PostType", schema.Spec.Extensions["$ref"])
+			assert.Empty(t, schema.Spec.Enum)
 		}
 	})
 
@@ -311,12 +309,8 @@ func TestDefaultFieldParserV3(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, []interface{}{"image", "video"}, componentSchema.Spec.Enum)
-		if assert.NotNil(t, schema.Spec.Items.Schema.Spec) {
-			assert.Equal(t, []interface{}{"video", "image"}, schema.Spec.Items.Schema.Spec.Enum)
-			if assert.Len(t, schema.Spec.Items.Schema.Spec.AllOf, 1) {
-				assert.Equal(t, "#/components/schemas/PostType", schema.Spec.Items.Schema.Spec.AllOf[0].Ref.Ref)
-			}
-		}
+		assert.Equal(t, "#/components/schemas/PostType", schema.Spec.Items.Schema.Ref.Ref)
+		assert.Nil(t, schema.Spec.Items.Schema.Spec)
 	})
 
 	t.Run("EnumVarNames tag", func(t *testing.T) {

--- a/field_parser_v3_test.go
+++ b/field_parser_v3_test.go
@@ -240,6 +240,47 @@ func TestDefaultFieldParserV3(t *testing.T) {
 
 	})
 
+	t.Run("Enums tag on ref schema does not mutate component schema", func(t *testing.T) {
+		t.Parallel()
+
+		parser := New()
+		parser.openAPIVersion = true
+
+		componentSchema := spec.NewSchemaSpec()
+		componentSchema.Spec.Type = &spec.SingleOrArray[string]{STRING}
+		componentSchema.Spec.Enum = []interface{}{"image", "video"}
+		componentSchema.Spec.Extensions = map[string]any{
+			enumVarNamesExtension: []string{"PostTypeImage", "PostTypeVideo"},
+		}
+		parser.openAPI.Components.Spec.Schemas = map[string]*spec.RefOrSpec[spec.Schema]{
+			"PostType": componentSchema,
+		}
+
+		schema := spec.NewRefOrSpec[spec.Schema](spec.NewRef("#/components/schemas/PostType"), nil)
+
+		err := newTagBaseFieldParserV3(
+			parser,
+			&ast.File{Name: &ast.Ident{Name: "test"}},
+			&ast.Field{
+				Names: []*ast.Ident{{Name: "Type"}},
+				Tag: &ast.BasicLit{
+					Value: `json:"type" validate:"oneof=video image" example:"video"`,
+				},
+			},
+		).ComplementSchema(schema)
+		assert.NoError(t, err)
+
+		assert.Equal(t, []interface{}{"image", "video"}, componentSchema.Spec.Enum)
+		assert.Equal(t, []string{"PostTypeImage", "PostTypeVideo"}, componentSchema.Spec.Extensions[enumVarNamesExtension])
+		if assert.NotNil(t, schema.Spec) {
+			assert.Equal(t, "video", schema.Spec.Example)
+			if assert.Len(t, schema.Spec.AllOf, 1) {
+				assert.Equal(t, "#/components/schemas/PostType", schema.Spec.AllOf[0].Ref.Ref)
+			}
+			assert.Equal(t, []interface{}{"video", "image"}, schema.Spec.Enum)
+		}
+	})
+
 	t.Run("EnumVarNames tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -124,22 +124,25 @@ func (ps *tagBaseFieldParserV3) ComplementSchema(schema *spec.RefOrSpec[spec.Sch
 
 	if schema.Ref != nil { //IsRefSchema(schema)
 		var newSchema = spec.Schema{}
-		err := ps.complementSchema(&newSchema, types)
+		err := ps.complementSchema(&newSchema, types, ps.p.getSchemaByRef(schema.Ref))
 		if err != nil {
 			return err
 		}
 		if !reflect.ValueOf(newSchema).IsZero() {
-			newSchema.AllOf = []*spec.RefOrSpec[spec.Schema]{{Ref: schema.Ref}}
+			if newSchema.Extensions == nil {
+				newSchema.Extensions = make(map[string]any)
+			}
+			newSchema.Extensions["$ref"] = schema.Ref.Ref
 			*schema = spec.RefOrSpec[spec.Schema]{Spec: &newSchema}
 		}
 		return nil
 	}
 
-	return ps.complementSchema(schema.Spec, types)
+	return ps.complementSchema(schema.Spec, types, nil)
 }
 
 // complementSchema complement schema with field properties
-func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []string) error {
+func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []string, refSchema *spec.Schema) error {
 	if ps.field.Tag == nil {
 		if ps.field.Doc != nil {
 			schema.Description = strings.TrimSpace(ps.field.Doc.Text())
@@ -348,6 +351,7 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 	}
 
 	elemSchema := schema
+	elemRefSchema := refSchema
 	var itemRef *spec.Ref
 
 	if field.schemaType == ARRAY {
@@ -359,8 +363,10 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 		if schema.Items.Schema.Ref != nil {
 			itemRef = schema.Items.Schema.Ref
 			elemSchema = &spec.Schema{}
+			elemRefSchema = ps.p.getSchemaByRef(itemRef)
 		} else {
 			elemSchema = schema.Items.Schema.Spec
+			elemRefSchema = nil
 		}
 
 		elemSchema.Format = field.formatType
@@ -371,16 +377,55 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 	elemSchema.MultipleOf = field.multipleOf
 	elemSchema.MaxLength = field.maxLength
 	elemSchema.MinLength = field.minLength
-	elemSchema.Enum = append(elemSchema.Enum, field.enums...)
+	if shouldApplyFieldEnumConstraint(field.enums, elemRefSchema) {
+		elemSchema.Enum = append(elemSchema.Enum, field.enums...)
+	}
 	elemSchema.Pattern = field.pattern
 	elemSchema.OneOf = oneOfSchemas
 
 	if itemRef != nil && !reflect.ValueOf(*elemSchema).IsZero() {
-		elemSchema.AllOf = []*spec.RefOrSpec[spec.Schema]{{Ref: itemRef}}
+		if elemSchema.Extensions == nil {
+			elemSchema.Extensions = make(map[string]any)
+		}
+		elemSchema.Extensions["$ref"] = itemRef.Ref
 		schema.Items.Schema = spec.NewRefOrSpec[spec.Schema](nil, elemSchema)
 	}
 
 	return nil
+}
+
+func shouldApplyFieldEnumConstraint(fieldEnums []interface{}, refSchema *spec.Schema) bool {
+	if len(fieldEnums) == 0 {
+		return false
+	}
+
+	if refSchema == nil || len(refSchema.Enum) == 0 {
+		return true
+	}
+
+	if len(fieldEnums) != len(refSchema.Enum) {
+		return true
+	}
+
+	used := make([]bool, len(refSchema.Enum))
+	for _, fieldEnum := range fieldEnums {
+		matched := false
+		for i, refEnum := range refSchema.Enum {
+			if used[i] {
+				continue
+			}
+			if reflect.DeepEqual(fieldEnum, refEnum) {
+				used[i] = true
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return true
+		}
+	}
+
+	return false
 }
 
 func getIntTagV3(structTag reflect.StructTag, tagName string) (*int, error) {

--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -117,28 +117,19 @@ func (ps *tagBaseFieldParserV3) CustomSchema() (*spec.RefOrSpec[spec.Schema], er
 
 // ComplementSchema complement schema with field properties
 func (ps *tagBaseFieldParserV3) ComplementSchema(schema *spec.RefOrSpec[spec.Schema]) error {
-	if schema.Spec == nil {
-		componentSchema := ps.p.openAPI.Components.Spec.Schemas[strings.ReplaceAll(schema.Ref.Ref, "#/components/schemas/", "")]
-		if componentSchema == nil {
-			return fmt.Errorf("could not resolve schema for ref %s", schema.Ref.Ref)
-		}
-		schema = componentSchema
-	}
-
 	types := ps.p.GetSchemaTypePathV3(schema, 2)
 	if len(types) == 0 {
 		return fmt.Errorf("invalid type for field: %s", ps.field.Names[0])
 	}
 
 	if schema.Ref != nil { //IsRefSchema(schema)
-		// TODO fetch existing schema from components
 		var newSchema = spec.Schema{}
 		err := ps.complementSchema(&newSchema, types)
 		if err != nil {
 			return err
 		}
 		if !reflect.ValueOf(newSchema).IsZero() {
-			newSchema.AllOf = []*spec.RefOrSpec[spec.Schema]{{Spec: schema.Spec}}
+			newSchema.AllOf = []*spec.RefOrSpec[spec.Schema]{{Ref: schema.Ref}}
 			*schema = spec.RefOrSpec[spec.Schema]{Spec: &newSchema}
 		}
 		return nil

--- a/field_parserv3.go
+++ b/field_parserv3.go
@@ -348,6 +348,7 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 	}
 
 	elemSchema := schema
+	var itemRef *spec.Ref
 
 	if field.schemaType == ARRAY {
 		// For Array only
@@ -355,9 +356,11 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 		schema.MinItems = field.minItems
 		schema.UniqueItems = &field.unique
 
-		elemSchema = schema.Items.Schema.Spec
-		if elemSchema == nil {
-			elemSchema = ps.p.getSchemaByRef(schema.Items.Schema.Ref)
+		if schema.Items.Schema.Ref != nil {
+			itemRef = schema.Items.Schema.Ref
+			elemSchema = &spec.Schema{}
+		} else {
+			elemSchema = schema.Items.Schema.Spec
 		}
 
 		elemSchema.Format = field.formatType
@@ -371,6 +374,11 @@ func (ps *tagBaseFieldParserV3) complementSchema(schema *spec.Schema, types []st
 	elemSchema.Enum = append(elemSchema.Enum, field.enums...)
 	elemSchema.Pattern = field.pattern
 	elemSchema.OneOf = oneOfSchemas
+
+	if itemRef != nil && !reflect.ValueOf(*elemSchema).IsZero() {
+		elemSchema.AllOf = []*spec.RefOrSpec[spec.Schema]{{Ref: itemRef}}
+		schema.Items.Schema = spec.NewRefOrSpec[spec.Schema](nil, elemSchema)
+	}
 
 	return nil
 }


### PR DESCRIPTION
**Fixes duplicates in Enum fields, using Swaggo V2 Openapi V3.1 Generator**
Current generator generates Enum fields twice:
```yaml
    PostType:
      enum:
      - image
      - video
      - video
      - image
```
PR includes the fix to avoid this. 

Additionally, this PR contains proper OpenAPI V3.1 specs for loading enum objects as References 
