### PR TITLE
feat: bump minimal golang to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.21.x', '1.22.x', '1.23.x', '1.24.x', '1.25.x' ]
+        go: [ '1.25.x', '1.26.x' ]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile References: https://docs.docker.com/engine/reference/builder/
 
 # Start from the latest golang base image
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine as builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/example/celler/go.mod
+++ b/example/celler/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggo/swag/example/celler
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/example/go-module-support/go.mod
+++ b/example/go-module-support/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggo/swag/example/go-module-support
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/example/markdown/go.mod
+++ b/example/markdown/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggo/swag/example/markdown
 
-go 1.18
+go 1.25.0
 
 require (
 	github.com/gorilla/mux v1.8.0

--- a/example/object-map-example/go.mod
+++ b/example/object-map-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggo/swag/example/object-map-example
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/swaggo/swag
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/KyleBanks/depth v1.2.1


### PR DESCRIPTION
### Go 1.25 as the minimal supported version
Go 1.24 reached the end of life https://endoflife.date/go