### PR TITLE
fix: respect parseDepth for operations in the go list dependency walk

### DIFF
--- a/cmd/swag/main.go
+++ b/cmd/swag/main.go
@@ -267,6 +267,7 @@ func initAction(ctx *cli.Context) error {
 		RequiredByDefault:   ctx.Bool(requiredByDefaultFlag),
 		CodeExampleFilesDir: ctx.String(codeExampleFilesFlag),
 		ParseDepth:          ctx.Int(parseDepthFlag),
+		ParseDepthSet:       ctx.IsSet(parseDepthFlag),
 		InstanceName:        ctx.String(instanceNameFlag),
 		OverridesFile:       ctx.String(overridesFileFlag),
 		ParseGoList:         ctx.Bool(parseGoListFlag),

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -102,6 +102,9 @@ type Config struct {
 	// ParseDepth dependency parse depth
 	ParseDepth int
 
+	// ParseDepthSet reports whether ParseDepth was explicitly provided
+	ParseDepthSet bool
+
 	// ParseVendor whether swag should be parse vendor folder
 	ParseVendor bool
 
@@ -227,6 +230,7 @@ func (g *Gen) Build(config *Config) error {
 	p.HostState = config.State
 	p.ParseFuncBody = config.ParseFuncBody
 	p.ParseGoPackages = config.ParseGoPackages
+	p.ParseDepthSet = config.ParseDepthSet
 
 	if err := p.ParseAPIMultiSearchDir(searchDirs, config.MainAPIFile, config.ParseDepth); err != nil {
 		return err

--- a/golist.go
+++ b/golist.go
@@ -77,6 +77,71 @@ func listOnePackages(ctx context.Context, dir string, env []string, args ...stri
 	return pkgs, nil
 }
 
+func operationParsePackages(pkgs []*build.Package, rootDirs []string, parseDepth int) map[string]struct{} {
+	within := make(map[string]struct{}, len(pkgs))
+	if parseDepth <= 0 {
+		for _, pkg := range pkgs {
+			within[pkg.ImportPath] = struct{}{}
+		}
+		return within
+	}
+
+	byImportPath := make(map[string]*build.Package, len(pkgs))
+	for _, pkg := range pkgs {
+		byImportPath[pkg.ImportPath] = pkg
+	}
+
+	rootDirSet := make(map[string]struct{}, len(rootDirs))
+	for _, dir := range rootDirs {
+		if abs, err := filepath.Abs(dir); err == nil {
+			rootDirSet[abs] = struct{}{}
+		}
+	}
+
+	type pkgAtDepth struct {
+		importPath string
+		depth      int
+	}
+
+	var queue []pkgAtDepth
+	for _, pkg := range pkgs {
+		abs, err := filepath.Abs(pkg.Dir)
+		if err != nil {
+			continue
+		}
+		if _, ok := rootDirSet[abs]; ok {
+			if _, seen := within[pkg.ImportPath]; !seen {
+				within[pkg.ImportPath] = struct{}{}
+				queue = append(queue, pkgAtDepth{importPath: pkg.ImportPath, depth: 0})
+			}
+		}
+	}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current.depth >= parseDepth {
+			continue
+		}
+		pkg := byImportPath[current.importPath]
+		if pkg == nil {
+			continue
+		}
+		for _, importPath := range pkg.Imports {
+			if _, ok := byImportPath[importPath]; !ok {
+				continue
+			}
+			if _, seen := within[importPath]; seen {
+				continue
+			}
+			within[importPath] = struct{}{}
+			queue = append(queue, pkgAtDepth{importPath: importPath, depth: current.depth + 1})
+		}
+	}
+
+	return within
+}
+
 func (parser *Parser) getAllGoFileInfoFromDepsByList(pkg *build.Package, parseFlag ParseFlag) error {
 	ignoreInternal := pkg.Goroot && !parser.ParseInternal
 	if ignoreInternal { // ignored internal

--- a/golist_test.go
+++ b/golist_test.go
@@ -114,3 +114,22 @@ func TestGetAllGoFileInfoFromDepsByList(t *testing.T) {
 		})
 	}
 }
+
+func TestOperationParsePackages(t *testing.T) {
+	root := &build.Package{ImportPath: "example.com/app", Dir: "/app", Imports: []string{"example.com/direct"}}
+	direct := &build.Package{ImportPath: "example.com/direct", Dir: "/app/direct", Imports: []string{"example.com/transitive"}}
+	transitive := &build.Package{ImportPath: "example.com/transitive", Dir: "/app/transitive"}
+	pkgs := []*build.Package{root, direct, transitive}
+	rootDirs := []string{"/app"}
+
+	depth1 := operationParsePackages(pkgs, rootDirs, 1)
+	assert.Contains(t, depth1, "example.com/app")
+	assert.Contains(t, depth1, "example.com/direct")
+	assert.NotContains(t, depth1, "example.com/transitive")
+
+	depth2 := operationParsePackages(pkgs, rootDirs, 2)
+	assert.Contains(t, depth2, "example.com/transitive")
+
+	unlimited := operationParsePackages(pkgs, rootDirs, 0)
+	assert.Len(t, unlimited, len(pkgs))
+}

--- a/parser.go
+++ b/parser.go
@@ -174,6 +174,9 @@ type Parser struct {
 	// parseGoList whether swag use go list to parse dependency
 	parseGoList bool
 
+	// ParseDepthSet reports whether parseDepth was explicitly provided.
+	ParseDepthSet bool
+
 	// ParseGoPackages whether swag use golang.org/x/tools/go/packages to parse source.
 	// It ignores go source files which build tags do not match.
 	// It throws error when type check failed.
@@ -440,8 +443,18 @@ func (parser *Parser) ParseAPIMultiSearchDir(searchDirs []string, mainAPIFile st
 			}
 
 			length := len(pkgs)
+			var operationPkgs map[string]struct{}
+			if parser.ParseDepthSet {
+				operationPkgs = operationParsePackages(pkgs, allDir, parseDepth)
+			}
 			for i := 0; i < length; i++ {
-				err := parser.getAllGoFileInfoFromDepsByList(pkgs[i], parser.ParseDependency)
+				parseFlag := parser.ParseDependency
+				if operationPkgs != nil {
+					if _, ok := operationPkgs[pkgs[i].ImportPath]; !ok {
+						parseFlag &^= ParseOperations
+					}
+				}
+				err := parser.getAllGoFileInfoFromDepsByList(pkgs[i], parseFlag)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
**Describe the PR**
When `parseGoList=true` was specified, `parseDepth` was no longer being respected. This PR fixes that in a backwards compatible way

benchmarked for speed & correctness (comparing swagger.json before/after) on a large internal repository

**Related issue**
Fixes https://github.com/swaggo/swag/issues/1269

**Additional Context**

https://github.com/swaggo/swag/pull/2174#issuecomment-4685438255