### PR TITLE
Support `example` tag on `map[string]Struct` fields

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -267,7 +267,37 @@ func (ps *tagBaseFieldParser) ComplementSchema(schema *spec.Schema) error {
 		return nil
 	}
 
-	return ps.complementSchema(schema, types)
+	if err := ps.complementSchema(schema, types); err != nil {
+		return err
+	}
+
+	// Synthesise an example for map[string]SomeStruct when the user provides
+	// a plain string as the example tag value. That string is used as the map
+	// key in the generated example, with the value synthesised from the
+	// referenced struct's own field examples.
+	//
+	// Supported forms:
+	//   example:"en"              → {"en": {<synthesised from SomeStruct fields>}}
+	//   example:"{\"en\":{...}}"  → full explicit JSON, already set by complementSchema
+	//   (no tag)                  → no example injected; docs show {}
+	//
+	// Note: this only fires for inline map[string]SomeStruct field declarations.
+	// Named map type aliases (type M map[string]SomeStruct) are resolved to a
+	// $ref before reaching here, so ComplementSchema takes the IsRefSchema path
+	// above and the synthesis block is never reached for those fields.
+	if keyName, ok := schema.Example.(string); ok &&
+		len(schema.Type) > 0 && schema.Type[0] == OBJECT &&
+		schema.AdditionalProperties != nil &&
+		schema.AdditionalProperties.Schema != nil &&
+		IsRefSchema(schema.AdditionalProperties.Schema) {
+		if valueExample := ps.p.buildExampleFromRef(schema.AdditionalProperties.Schema, map[string]bool{}); valueExample != nil {
+			schema.Example = map[string]any{keyName: valueExample}
+		} else {
+			schema.Example = nil
+		}
+	}
+
+	return nil
 }
 
 // complementSchema complement schema with field properties

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -432,6 +432,95 @@ func TestDefaultFieldParser(t *testing.T) {
 		).ComplementSchema(nil)
 		assert.Error(t, err)
 	})
+
+	t.Run("Example tag on map[string]Struct field", func(t *testing.T) {
+		// makeParser returns a parser with a "Child" definition whose fields
+		// carry example values ("url" and "label").
+		makeParser := func() *Parser {
+			p := New()
+			urlProp := spec.Schema{}
+			urlProp.Type = []string{"string"}
+			urlProp.Example = "https://example.com"
+			labelProp := spec.Schema{}
+			labelProp.Type = []string{"string"}
+			labelProp.Example = "English"
+			child := spec.Schema{}
+			child.Type = []string{OBJECT}
+			child.Properties = map[string]spec.Schema{"url": urlProp, "label": labelProp}
+			p.swagger.Definitions["Child"] = child
+			return p
+		}
+
+		t.Run("plain string key-hint synthesises example from struct field examples", func(t *testing.T) {
+			t.Parallel()
+
+			schema := *spec.MapProperty(spec.RefSchema("#/definitions/Child"))
+			err := newTagBaseFieldParser(
+				makeParser(),
+				&ast.Field{Tag: &ast.BasicLit{Value: `json:"langs" example:"en"`}},
+			).ComplementSchema(&schema)
+			assert.NoError(t, err)
+
+			example, ok := schema.Example.(map[string]any)
+			assert.True(t, ok, "Example should be map[string]any")
+			en, ok := example["en"].(map[string]interface{})
+			assert.True(t, ok, "example should be keyed by 'en'")
+			assert.Equal(t, "https://example.com", en["url"])
+			assert.Equal(t, "English", en["label"])
+		})
+
+		t.Run("explicit JSON example is used verbatim", func(t *testing.T) {
+			t.Parallel()
+
+			schema := *spec.MapProperty(spec.RefSchema("#/definitions/Child"))
+			err := newTagBaseFieldParser(
+				makeParser(),
+				&ast.Field{Tag: &ast.BasicLit{Value: `json:"langs" example:"{\"en\":{\"url\":\"https://explicit.com\",\"label\":\"Explicit\"}}"`}},
+			).ComplementSchema(&schema)
+			assert.NoError(t, err)
+
+			example, ok := schema.Example.(map[string]interface{})
+			assert.True(t, ok)
+			en, ok := example["en"].(map[string]interface{})
+			assert.True(t, ok)
+			assert.Equal(t, "https://explicit.com", en["url"])
+			assert.Equal(t, "Explicit", en["label"])
+		})
+
+		t.Run("key-hint with struct having no field examples leaves Example nil", func(t *testing.T) {
+			t.Parallel()
+
+			p := New()
+			urlProp := spec.Schema{}
+			urlProp.Type = []string{"string"}
+			labelProp := spec.Schema{}
+			labelProp.Type = []string{"string"}
+			bare := spec.Schema{}
+			bare.Type = []string{OBJECT}
+			bare.Properties = map[string]spec.Schema{"url": urlProp, "label": labelProp}
+			p.swagger.Definitions["Bare"] = bare
+
+			schema := *spec.MapProperty(spec.RefSchema("#/definitions/Bare"))
+			err := newTagBaseFieldParser(
+				p,
+				&ast.Field{Tag: &ast.BasicLit{Value: `json:"langs" example:"en"`}},
+			).ComplementSchema(&schema)
+			assert.NoError(t, err)
+			assert.Nil(t, schema.Example, "key-hint string must not leak when struct has no field examples")
+		})
+
+		t.Run("no example tag leaves Example nil", func(t *testing.T) {
+			t.Parallel()
+
+			schema := *spec.MapProperty(spec.RefSchema("#/definitions/Child"))
+			err := newTagBaseFieldParser(
+				makeParser(),
+				&ast.Field{Tag: &ast.BasicLit{Value: `json:"langs"`}},
+			).ComplementSchema(&schema)
+			assert.NoError(t, err)
+			assert.Nil(t, schema.Example)
+		})
+	})
 }
 
 func TestValidTags(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -1821,7 +1821,10 @@ func (parser *Parser) GetSchemaTypePath(schema *spec.Schema, depth int) []string
 	return []string{ANY}
 }
 
-// defineTypeOfExample example value define the type (object and array unsupported).
+// defineTypeOfExample example value define the type (object values require
+// either key:primitiveValue pairs for map[string]primitive, or raw JSON for
+// map[string]object; a plain non-JSON string on a map[string]object field is
+// treated as the desired example-key name for auto-synthesis).
 func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{}, error) {
 	switch schemaType {
 	case STRING:
@@ -1865,6 +1868,23 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 			return nil, fmt.Errorf("%s is unsupported type in example value `%s`", schemaType, exampleValue)
 		}
 
+		// When the map value type is itself an object (struct), the key:value
+		// comma syntax can't represent nested structure. Two forms are accepted:
+		//
+		//   example:"{\"en\":{...}}"  — raw JSON, used as the full example value
+		//   example:"en"              — plain string, returned as-is so ComplementSchema
+		//                               can use it as the key name for auto-synthesis
+		//
+		if arrayType == OBJECT {
+			var result interface{}
+			if err := json.Unmarshal([]byte(exampleValue), &result); err == nil {
+				// Valid JSON — use as explicit example.
+				return result, nil
+			}
+			// Not JSON — treat as a key-name hint for auto-synthesis.
+			return exampleValue, nil
+		}
+
 		values := strings.Split(exampleValue, ",")
 
 		result := map[string]any{}
@@ -1890,6 +1910,65 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 	}
 
 	return nil, fmt.Errorf("%s is unsupported type in example value %s", schemaType, exampleValue)
+}
+
+// buildExampleFromRef synthesises an example object from the properties of a
+// $ref definition. For each property it collects:
+//   - scalar/string properties that carry an Example value directly, and
+//   - array properties whose items are either a $ref (recursed) or carry an
+//     Example value — in both cases the result is wrapped in a single-element
+//     slice so the rendered docs show a realistic array shape.
+//
+// visited guards against infinite recursion in mutually-recursive type graphs.
+// Callers should pass an empty map on the initial call.
+// Returns nil when no examples are found or the ref cannot be resolved.
+func (parser *Parser) buildExampleFromRef(refSchema *spec.Schema, visited map[string]bool) map[string]interface{} {
+	// Cycle guard: extract the definition name and skip if already visited.
+	if url := refSchema.Ref.GetURL(); url != nil {
+		name := url.Fragment
+		if pos := strings.LastIndexByte(name, '/'); pos >= 0 {
+			name = name[pos+1:]
+		}
+		if visited[name] {
+			return nil
+		}
+		visited[name] = true
+		defer func() { delete(visited, name) }()
+	}
+
+	underlying := parser.getUnderlyingSchema(refSchema)
+	if underlying == nil {
+		return nil
+	}
+
+	obj := make(map[string]interface{}, len(underlying.Properties))
+	for name, prop := range underlying.Properties {
+		switch {
+		case prop.Example != nil:
+			// Scalar / string / pre-tagged property — use it directly.
+			obj[name] = prop.Example
+
+		case len(prop.Type) > 0 && prop.Type[0] == ARRAY &&
+			prop.Items != nil && prop.Items.Schema != nil:
+			// Array property: synthesise a single-element slice example.
+			items := prop.Items.Schema
+			if IsRefSchema(items) {
+				// []SomeStruct — recurse into the item definition.
+				if itemExample := parser.buildExampleFromRef(items, visited); itemExample != nil {
+					obj[name] = []interface{}{itemExample}
+				}
+			} else if items.Example != nil {
+				// []primitiveType with an example tag on the item schema.
+				obj[name] = []interface{}{items.Example}
+			}
+		}
+	}
+
+	if len(obj) == 0 {
+		return nil
+	}
+
+	return obj
 }
 
 // GetAllGoFileInfo gets all Go source files information for given searchDir.

--- a/parser_test.go
+++ b/parser_test.go
@@ -2717,6 +2717,169 @@ func Test(){
 	assert.Equal(t, expected, string(out))
 }
 
+func TestParser_ParseStructMapMemberWithStructExample(t *testing.T) {
+	t.Parallel()
+
+	// Fix A: explicit JSON example tag on a map[string]Struct field.
+	// Fix B: plain-string example tag used as the key name for auto-synthesis
+	//        from the value struct's field example tags (including []Struct arrays).
+	// No tag: no example injected — no implicit behaviour.
+	src := `
+package api
+
+// Item is an array element with example tags on its fields.
+type Item struct {
+	ID   int    ` + "`" + `json:"id"   example:"1"` + "`" + `
+	Name string ` + "`" + `json:"name" example:"floor-1"` + "`" + `
+}
+
+// Child has example tags on scalar fields and an array-of-$ref field.
+type Child struct {
+	URL   string ` + "`" + `json:"url"   example:"https://example.com/doc.pdf"` + "`" + `
+	Label string ` + "`" + `json:"label" example:"English"` + "`" + `
+	Items []Item ` + "`" + `json:"items"` + "`" + `
+}
+
+type Parent struct {
+	// Fix B: plain key name — auto-synthesise example with "en" as the key.
+	Langs map[string]Child ` + "`" + `json:"langs" example:"en"` + "`" + `
+	// Fix A: full JSON example — used verbatim.
+	LangsExplicit map[string]Child ` + "`" + `json:"langsExplicit" example:"{\"en\":{\"url\":\"https://example.com/explicit.pdf\",\"label\":\"English\"}}"` + "`" + `
+	// No tag — no example should be injected.
+	LangsNoTag map[string]Child ` + "`" + `json:"langsNoTag"` + "`" + `
+}
+
+// @Success 200 {object} Parent
+// @Router /api/{id} [get]
+func Test(){
+}
+`
+	p := New()
+	_ = p.packages.ParseFile("api", "api/api.go", src, ParseAll)
+
+	_, err := p.packages.ParseTypes()
+	assert.NoError(t, err)
+
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
+	assert.NoError(t, err)
+
+	defs := p.swagger.Definitions
+	parent, ok := defs["api.Parent"]
+	assert.True(t, ok, "api.Parent definition should exist")
+
+	// Fix B: plain key name — auto-synthesised example keyed by "en".
+	langsSchema := parent.Properties["langs"]
+	assert.NotNil(t, langsSchema.Example, "langs should have an auto-synthesised example")
+	langsExample, ok := langsSchema.Example.(map[string]interface{})
+	assert.True(t, ok)
+	en, ok := langsExample["en"].(map[string]interface{})
+	assert.True(t, ok, "example should be keyed by 'en'")
+	assert.Equal(t, "https://example.com/doc.pdf", en["url"])
+	assert.Equal(t, "English", en["label"])
+
+	// Array-of-$ref inside the value struct: synthesised as a single-element slice.
+	items, ok := en["items"].([]interface{})
+	assert.True(t, ok, "items should be a synthesised array")
+	assert.Len(t, items, 1)
+	item, ok := items[0].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, 1, item["id"])
+	assert.Equal(t, "floor-1", item["name"])
+
+	// Fix A: full JSON example used verbatim.
+	langsExplicitSchema := parent.Properties["langsExplicit"]
+	assert.NotNil(t, langsExplicitSchema.Example, "langsExplicit should have an example from the tag")
+	explicitExample, ok := langsExplicitSchema.Example.(map[string]interface{})
+	assert.True(t, ok)
+	enExplicit, ok := explicitExample["en"].(map[string]interface{})
+	assert.True(t, ok, "explicit example should be keyed by 'en'")
+	assert.Equal(t, "https://example.com/explicit.pdf", enExplicit["url"])
+	assert.Equal(t, "English", enExplicit["label"])
+
+	// No tag — no example should be injected.
+	langsNoTagSchema := parent.Properties["langsNoTag"]
+	assert.Nil(t, langsNoTagSchema.Example, "map field with no example tag should have no example")
+}
+
+func TestParser_ParseStructMapMemberWithStructExample_NoFieldExamples(t *testing.T) {
+	t.Parallel()
+
+	// When example:"key" is set on a map[string]Struct field but the value
+	// struct has no example tags on any of its fields, no example should be
+	// injected — the key-hint string must not leak into the output.
+	src := `
+package api
+
+type Bare struct {
+	URL   string ` + "`" + `json:"url"` + "`" + `
+	Label string ` + "`" + `json:"label"` + "`" + `
+}
+
+type Owner struct {
+	Langs map[string]Bare ` + "`" + `json:"langs" example:"en"` + "`" + `
+}
+
+// @Success 200 {object} Owner
+// @Router /api/{id} [get]
+func Test(){
+}
+`
+	p := New()
+	_ = p.packages.ParseFile("api", "api/api.go", src, ParseAll)
+
+	_, err := p.packages.ParseTypes()
+	assert.NoError(t, err)
+
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
+	assert.NoError(t, err)
+
+	owner := p.swagger.Definitions["api.Owner"]
+	langsSchema := owner.Properties["langs"]
+	assert.Nil(t, langsSchema.Example, "key-hint string must not leak when value struct has no field examples")
+}
+
+func TestParser_ParseStructMapMemberWithStructExample_CycleDetection(t *testing.T) {
+	t.Parallel()
+
+	// Mutually-recursive types must not cause a stack overflow.
+	src := `
+package api
+
+type A struct {
+	Name     string ` + "`" + `json:"name" example:"a"` + "`" + `
+	Children []B    ` + "`" + `json:"children"` + "`" + `
+}
+
+type B struct {
+	Name    string ` + "`" + `json:"name" example:"b"` + "`" + `
+	Parents []A    ` + "`" + `json:"parents"` + "`" + `
+}
+
+type Root struct {
+	Map map[string]A ` + "`" + `json:"map" example:"key"` + "`" + `
+}
+
+// @Success 200 {object} Root
+// @Router /api/{id} [get]
+func Test(){
+}
+`
+	p := New()
+	_ = p.packages.ParseFile("api", "api/api.go", src, ParseAll)
+
+	_, err := p.packages.ParseTypes()
+	assert.NoError(t, err)
+
+	// Must not panic or stack-overflow.
+	err = p.packages.RangeFiles(p.ParseRouterAPIInfo)
+	assert.NoError(t, err)
+
+	root := p.swagger.Definitions["api.Root"]
+	mapSchema := root.Properties["map"]
+	// Example should be set (cycle is broken, partial synthesis is fine).
+	assert.NotNil(t, mapSchema.Example)
+}
+
 func TestParser_ParseRouterApiInfoErr(t *testing.T) {
 	t.Parallel()
 
@@ -4020,6 +4183,26 @@ func TestDefineTypeOfExample(t *testing.T) {
 		}
 
 		assert.Equal(t, obj, map[string]string{"key_one": "one", "key_two": "two", "key_three": "three"})
+	})
+
+	t.Run("Object type with object values (map[string]Struct) accepts raw JSON", func(t *testing.T) {
+		t.Parallel()
+
+		// Valid JSON object — key maps to a nested struct-like object.
+		example, err := defineTypeOfExample("object", "object", `{"en":{"url":"https://example.com","label":"English"}}`)
+		assert.NoError(t, err)
+		result, ok := example.(map[string]interface{})
+		assert.True(t, ok)
+		en, ok := result["en"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "https://example.com", en["url"])
+		assert.Equal(t, "English", en["label"])
+
+		// Non-JSON plain string is returned as-is (treated as a key-name hint
+		// for auto-synthesis in ComplementSchema — not an error).
+		example, err = defineTypeOfExample("object", "object", "en")
+		assert.NoError(t, err)
+		assert.Equal(t, "en", example)
 	})
 
 	t.Run("Invalid type", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fields typed as `map[string]SomeStruct` have never been able to carry an `example` tag:

- **No tag** — a correct `additionalProperties: $ref` schema is generated, but with no example, so Swagger UI renders an empty `{}` that tells the reader nothing about the value shape.
- **Any tag** — the value reaches the `key:value` comma parser in `defineTypeOfExample` with `arrayType="object"`, which cannot represent nested struct values and errors out (`example value en should format: key:value`, or `... is unsupported type ...` on the recursive value side).

This PR makes the `example` tag work on these fields via two opt-in forms, both surfaced through the existing `example` struct tag. Open since 2019 (#327).

## Changes

**`parser.go`**
- `defineTypeOfExample`: when the map value type is itself an object (`arrayType="object"`), accept either
  - raw JSON — unmarshalled and used as the explicit example, or
  - a plain (non-JSON) string — returned as-is to act as a key-name hint for synthesis.
  
  Previously both paths errored.
- New `buildExampleFromRef`: synthesises an example object from a `$ref` definition's properties — pulling each property's own `Example`, and for array properties wrapping a single-element slice (recursing into `[]SomeStruct` item refs, or using the item example for `[]primitive`). Guards against cycles in mutually-recursive type graphs.

**`field_parser.go`**
- `ComplementSchema`: after the normal schema completion, if the field is an inline `map[string]Struct` (object schema with a `$ref` in `AdditionalProperties`) and the parsed example is a plain string, replace it with `{<key>: <synthesised value>}`. If nothing can be synthesised, the example is cleared rather than left as a dangling string.

## Behaviour

**Form 1 — Explicit JSON** (used verbatim, same as `example` everywhere else):

```go
Translations map[string]Message `json:"translations" example:"{\"en\":{\"text\":\"Hello\",\"locale\":\"en-US\"}}"`
```

**Form 2 — Key name + auto-synthesis** (value built from the struct's own field examples):

```go
type Message struct {
    Text   string `json:"text"   example:"Hello"`
    Locale string `json:"locale" example:"en-US"`
}

Translations map[string]Message `json:"translations" example:"en"`
```

Generates:

```json
"translations": {
  "example": {
    "en": { "text": "Hello", "locale": "en-US" }
  }
}
```

## Backward compatibility

- No implicit behaviour change — synthesis only fires when an `example` tag is present. Existing `map[string]Struct` fields with no tag are untouched (still render `{}`).
- The previous hard parse error on an `example` tag for these fields is replaced by meaningful behaviour; no new errors are introduced.
- `map[string]string` and `swaggertype:"object,string"` paths are unchanged — they never reach the `arrayType="object"` branch.

## Known limitation

Named map type aliases are not supported by key-hint synthesis:

```go
type LangMap map[string]Message            // named alias
Langs LangMap `json:"langs" example:"en"`   // synthesis does not fire
```

A named alias resolves to a `$ref` before `ComplementSchema` reaches the synthesis block (it takes the `IsRefSchema` path), so the inline-map guard never matches. This is a pre-existing architectural constraint affecting all field complementation on named map aliases, not specific to this change. Explicit JSON (Form 1) still works in this case.

## Testing

- `parser_test.go` — `defineTypeOfExample` cases for `map[string]Struct`: raw-JSON acceptance and plain-string key-hint passthrough; `buildExampleFromRef` synthesis including nested arrays.
- `field_parser_test.go` — end-to-end `ComplementSchema` cases covering Form 1, Form 2, and the no-tag (unaffected) path.

## Related issues
- #2180 
- #327 — original report, `map[string]interface{}` example panic.
- #2018 — same `defineTypeOfExample` error via `swaggertype:"object,object" example:"key1:{},key2:{}"`.
- #2111 — open PR with a narrow fix for the empty `{}` value case in #2018; does not address `map[string]Struct` field synthesis.