### PR TITLE
fix: keep quoted commas inside example slice and map values

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1822,6 +1822,30 @@ func (parser *Parser) GetSchemaTypePath(schema *spec.Schema, depth int) []string
 }
 
 // defineTypeOfExample example value define the type (object and array unsupported).
+// splitExampleValues splits a comma separated example value, treating commas
+// inside double quotes as part of the value rather than as separators.
+func splitExampleValues(value string) []string {
+	var (
+		values  []string
+		current strings.Builder
+		inQuote bool
+	)
+
+	for i := 0; i < len(value); i++ {
+		switch c := value[i]; {
+		case c == '"':
+			inQuote = !inQuote
+		case c == ',' && !inQuote:
+			values = append(values, current.String())
+			current.Reset()
+		default:
+			current.WriteByte(c)
+		}
+	}
+
+	return append(values, current.String())
+}
+
 func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{}, error) {
 	switch schemaType {
 	case STRING:
@@ -1848,7 +1872,7 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 
 		return v, nil
 	case ARRAY:
-		values := strings.Split(exampleValue, ",")
+		values := splitExampleValues(exampleValue)
 		result := make([]any, 0)
 		for _, value := range values {
 			v, err := defineTypeOfExample(arrayType, "", value)
@@ -1865,7 +1889,7 @@ func defineTypeOfExample(schemaType, arrayType, exampleValue string) (interface{
 			return nil, fmt.Errorf("%s is unsupported type in example value `%s`", schemaType, exampleValue)
 		}
 
-		values := strings.Split(exampleValue, ",")
+		values := splitExampleValues(exampleValue)
 
 		result := map[string]any{}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -4022,6 +4022,36 @@ func TestDefineTypeOfExample(t *testing.T) {
 		assert.Equal(t, obj, map[string]string{"key_one": "one", "key_two": "two", "key_three": "three"})
 	})
 
+	t.Run("Array type with quoted commas", func(t *testing.T) {
+		t.Parallel()
+
+		example, err := defineTypeOfExample("array", "string", `"a,b,c","d,e,f"`)
+		assert.NoError(t, err)
+
+		var arr []string
+
+		for _, v := range example.([]interface{}) {
+			arr = append(arr, v.(string))
+		}
+
+		assert.Equal(t, arr, []string{"a,b,c", "d,e,f"})
+	})
+
+	t.Run("Object type with quoted commas", func(t *testing.T) {
+		t.Parallel()
+
+		example, err := defineTypeOfExample("object", "string", `key_one:"a,b",key_two:two`)
+		assert.NoError(t, err)
+
+		obj := map[string]string{}
+
+		for k, v := range example.(map[string]interface{}) {
+			obj[k] = v.(string)
+		}
+
+		assert.Equal(t, obj, map[string]string{"key_one": "a,b", "key_two": "two"})
+	})
+
 	t.Run("Invalid type", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
Fixes #899

A string slice example with quoted elements that contain commas was split on every comma, so `example:"\"a,b,c\",\"a,b,c\""` produced `["a", "b", "c", "a", "b", "c"]` instead of `["a,b,c", "a,b,c"]`.

`defineTypeOfExample` now splits on commas that are outside double quotes, for both the array and object branches. Unquoted values behave exactly as before.

Added tests covering quoted commas in array and object examples.
