### PR TITLE
fix: responses could end up nil

### DIFF
--- a/operationv3.go
+++ b/operationv3.go
@@ -53,6 +53,10 @@ type OperationV3 struct {
 func NewOperationV3(parser *Parser, options ...func(*OperationV3)) *OperationV3 {
 	op := *spec.NewOperation().Spec
 	op.Responses = spec.NewResponses()
+	// Keep Response non-nil so an operation with no @Success/@Failure/@Response marshals
+	// responses as {} instead of null (a nil map marshals to JSON null, which fails the
+	// OpenAPI 3.1 meta-schema's requirement that responses be an object).
+	op.Responses.Spec.Response = map[string]*spec.RefOrSpec[spec.Extendable[spec.Response]]{}
 
 	operation := &OperationV3{
 		parser:    parser,

--- a/operationv3_test.go
+++ b/operationv3_test.go
@@ -1,6 +1,7 @@
 package swag
 
 import (
+	"encoding/json"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -767,6 +768,21 @@ func TestParseResponseCommentParamMissingV3(t *testing.T) {
 	paramLenErrComment = `@Success notIntCode "it ok"`
 	paramLenErr = operation.ParseComment(paramLenErrComment, nil)
 	assert.EqualError(t, paramLenErr, `can not parse response comment "notIntCode "it ok""`)
+}
+
+func TestNewOperationV3ResponsesNeverNilV3(t *testing.T) {
+	t.Parallel()
+
+	operation := NewOperationV3(New())
+
+	require.NotNil(t, operation.Responses)
+	require.NotNil(t, operation.Responses.Spec)
+	assert.NotNil(t, operation.Responses.Spec.Response, "Response map must be non-nil so it marshals as {} rather than null")
+	assert.Empty(t, operation.Responses.Spec.Response)
+
+	data, err := json.Marshal(operation.Responses.Spec)
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data), "an operation with no @Success/@Failure/@Response must marshal responses as {}, not null")
 }
 
 func TestOperation_ParseParamCommentV3(t *testing.T) {

--- a/parserv3.go
+++ b/parserv3.go
@@ -569,6 +569,11 @@ func (p *Parser) ParseRouterAPIInfoV3(fileInfo *AstFileInfo) error {
 }
 
 func processRouterOperationV3(p *Parser, o *OperationV3) error {
+	if o.Responses != nil && o.Responses.Spec != nil &&
+		len(o.Responses.Spec.Response) == 0 && o.Responses.Spec.Default == nil {
+		p.debug.Printf("warning: operation has no documented responses (missing @Success/@Failure/@Response)")
+	}
+
 	for _, routeProperties := range o.RouterProperties {
 		var (
 			pathItem *spec.RefOrSpec[spec.Extendable[spec.PathItem]]


### PR DESCRIPTION
**Describe the PR**
Currently on the v2 branch, an operation with no @Success, @Failure, or @Response comment generates "responses": null in the output. This is a type violation against the OpenAPI 3.1 JSON Schema meta-schema, which requires responses to be an object. NewOperationV3 leaves Responses.Spec.Response as a nil map, and a nil map marshals to JSON null instead of {}.
```go
// @Router /ping [get]
func Ping(w http.ResponseWriter, r *http.Request) {}
```
Above comment currently generates:
```yaml
/ping:
  get:
    responses: null
```

Which openapi-spec-validator rejects with:
None is not of type 'object'

Failed validating 'type' in schema[...]['responses']:
    {'$comment': 'https://spec.openapis.org/oas/v3.1.0#responses-object',
     'type': 'object', ...}

On instance['paths']['/ping']['get']['responses']:
    None

and @redocly/cli lint rejects with:
Expected type `Responses` (object) but got `null`
Error was generated by the struct rule.

After this fix, the same operation generates:
```yaml
/ping:
  get:
    responses: {}
```

@redocly/cli lint's struct rule is fully satisfied by this. The penapi-spec-validator still flags it, though.

**Additional context**
Go version: 1.26.5
Swag Version: 2.0.0 (branched from upstream v2 @ e73d748)

**Note: this PR was aided by an LLM.** If this is an issue, let me know, and I won't bother you with more of these PRs (I'll just use my fork). I have confirmed its output to be correct with some new tests. Hoping to get this branch more quickly compliant with the OpenAPI 3.1 spec, since one of the tools I am using for my other projects doesn't really support Swagger 2.0 very well :/

