### PR TITLE
fix: swag fmt skips files when the formatted result is not longer

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -98,10 +98,16 @@ func (edits edits) apply(contents []byte) []byte {
 		return edits[i].begin > edits[j].begin
 	})
 
+	// Build a new slice for every edit rather than writing into contents in
+	// place. When the replacement is no longer than the range it replaces,
+	// append reuses the backing array and rewrites the caller's buffer, which
+	// leaves callers unable to tell whether the content actually changed.
 	for _, edit := range edits {
-		prefix := contents[:edit.begin]
-		suffix := contents[edit.end:]
-		contents = append(prefix, append(edit.replacement, suffix...)...)
+		result := make([]byte, 0, len(contents)-(edit.end-edit.begin)+len(edit.replacement))
+		result = append(result, contents[:edit.begin]...)
+		result = append(result, edit.replacement...)
+		result = append(result, contents[edit.end:]...)
+		contents = result
 	}
 
 	return contents

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -348,3 +348,15 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 `
 	testFormat(t, "db.sql.go", contents, want)
 }
+
+func Test_FormatDoesNotModifyInput(t *testing.T) {
+	contents := []byte(`package main
+
+// @title Foo
+func main() {}`)
+	original := string(contents)
+
+	_, err := NewFormatter().Format("main.go", contents)
+	assert.NoError(t, err)
+	assert.Equal(t, original, string(contents), "Format must not modify the caller's buffer")
+}


### PR DESCRIPTION
**Describe the PR**

`Formatter.Format` rewrites the caller's buffer in place, which makes `swag fmt` silently skip files.

`edits.apply` builds each result with `append(prefix, ...)`, where `prefix` is a sub-slice of the `contents` argument. When a replacement is no longer than the range it replaces, `append` reuses the backing array, so the caller's input buffer ends up holding the formatted output too.

`format.Build` decides whether to write a file by comparing its input with the returned value:

```go
formatted, err := f.formatter.Format(path, contents)
...
if bytes.Equal(contents, formatted) {
    // Skip write if no change
    return nil
}
```

Since `contents` was rewritten in place, the comparison finds no difference and the file is never written.

A single annotation line is enough to trigger it, because replacing the space with a tab keeps the byte length identical:

```go
package main

// @title Foo
func main() {}
```

`swag fmt` leaves that file untouched, and `TestFormat_WriteError` (which expects an error when the target directory is read-only) only passes today because nothing is written.

This PR makes `edits.apply` build a fresh slice for every edit, so the input buffer is left alone.

**Relation issue**

None.

**Additional context**

Added `Test_FormatDoesNotModifyInput`, which fails on master and passes with the fix. `go test ./...` is green.